### PR TITLE
Add Github release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+on:
+  push:
+    tags:
+    - 'v*'
+
+name: publish release
+
+jobs:
+  build:
+    name: Create new Github release
+    runs-on: ubuntu-20.04
+    steps:
+      -
+        name: Checkout code
+        uses: actions/checkout@v2
+      -
+        name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
This action will create a Github release whenever a tag `v<version>`
is pushed to the repository.

Image building and publishing into the image repository is still
handled by the `container-image` workflow.

Fixes https://github.com/kubewarden/kubewarden-controller/issues/22