### PR TITLE
Allow to configure policy-server service account

### DIFF
--- a/controllers/cluster_admissionpolicy_controller.go
+++ b/controllers/cluster_admissionpolicy_controller.go
@@ -38,9 +38,10 @@ import (
 // ClusterAdmissionPolicy object
 type ClusterAdmissionPolicyReconciler struct {
 	client.Client
-	Log                  logr.Logger
-	Scheme               *runtime.Scheme
-	DeploymentsNamespace string
+	Log                           logr.Logger
+	Scheme                        *runtime.Scheme
+	DeploymentsNamespace          string
+	DeploymentsServiceAccountName string
 }
 
 // nolint:lll

--- a/internal/pkg/admission/policy-server-deployment.go
+++ b/internal/pkg/admission/policy-server-deployment.go
@@ -253,7 +253,8 @@ func (r *Reconciler) deployment(ctx context.Context, configMapVersion string) *a
 					Annotations: templateAnnotations,
 				},
 				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{admissionContainer},
+					Containers:         []corev1.Container{admissionContainer},
+					ServiceAccountName: r.DeploymentsServiceAccountName,
 					Volumes: []corev1.Volume{
 						{
 							Name: certsVolumeName,

--- a/internal/pkg/admission/reconciler.go
+++ b/internal/pkg/admission/reconciler.go
@@ -15,9 +15,10 @@ import (
 )
 
 type Reconciler struct {
-	Client               client.Client
-	DeploymentsNamespace string
-	Log                  logr.Logger
+	Client                        client.Client
+	DeploymentsNamespace          string
+	DeploymentsServiceAccountName string
+	Log                           logr.Logger
 }
 
 type errorList []error

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
-	var deploymentsNamespace string
+	var deploymentsNamespace, deploymentsServiceAccountName string
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
@@ -55,6 +55,10 @@ func main() {
 		"deployments-namespace",
 		"",
 		"The namespace where the kubewarden resources will be created.")
+	flag.StringVar(&deploymentsServiceAccountName,
+		"deployments-service-account-name",
+		"default",
+		"The service account name that kubewarden policy-server deployment will use.")
 	flag.Parse()
 
 	if deploymentsNamespace == "" {
@@ -76,10 +80,11 @@ func main() {
 	}
 
 	if err = (&controllers.ClusterAdmissionPolicyReconciler{
-		Client:               mgr.GetClient(),
-		Log:                  ctrl.Log.WithName("controllers").WithName("ClusterAdmissionPolicy"),
-		Scheme:               mgr.GetScheme(),
-		DeploymentsNamespace: deploymentsNamespace,
+		Client:                        mgr.GetClient(),
+		Log:                           ctrl.Log.WithName("controllers").WithName("ClusterAdmissionPolicy"),
+		Scheme:                        mgr.GetScheme(),
+		DeploymentsNamespace:          deploymentsNamespace,
+		DeploymentsServiceAccountName: deploymentsServiceAccountName,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterAdmissionPolicy")
 		os.Exit(1)


### PR DESCRIPTION
The policy-server can use the provided service account, so it can be
granted permissions to list certain resources that will be exposed to
context-aware policies.

Related: https://github.com/kubewarden/helm-charts/issues/4

A helm chart PR will follow that depends on this PR.