### PR TITLE
PolicyServer control loop: create certificates for Policy Server deployment

### DIFF
--- a/internal/pkg/admission/mutating-webhook.go
+++ b/internal/pkg/admission/mutating-webhook.go
@@ -34,7 +34,7 @@ func (r *Reconciler) mutatingWebhookConfiguration(
 
 	service := admissionregistrationv1.ServiceReference{
 		Namespace: r.DeploymentsNamespace,
-		Name:      constants.PolicyServerServiceName,
+		Name:      constants.PolicyServerServiceNamePrefix,
 		Path:      &admissionPath,
 		Port:      &admissionPort,
 	}

--- a/internal/pkg/admission/policy-server-deployment.go
+++ b/internal/pkg/admission/policy-server-deployment.go
@@ -260,7 +260,7 @@ func (r *Reconciler) deployment(ctx context.Context, configMapVersion string) *a
 							Name: certsVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: constants.PolicyServerSecretName,
+									SecretName: constants.PolicyServerSecretNamePrefix,
 								},
 							},
 						},

--- a/internal/pkg/admission/policy-server-secret.go
+++ b/internal/pkg/admission/policy-server-secret.go
@@ -2,6 +2,8 @@ package admission
 
 import (
 	"context"
+	"crypto/rsa"
+	"crypto/x509"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -13,6 +15,10 @@ import (
 	"github.com/kubewarden/kubewarden-controller/internal/pkg/constants"
 )
 
+type generateCAFunc = func() (*admissionregistration.CA, error)
+type pemEncodeCertificateFunc = func(certificate []byte) ([]byte, error)
+type generateCertFunc = func(ca []byte, commonName string, extraSANs []string, CAPrivateKey *rsa.PrivateKey) ([]byte, []byte, error)
+
 func (r *Reconciler) reconcileSecret(ctx context.Context, secret *corev1.Secret) error {
 	err := r.Client.Create(ctx, secret)
 	if err == nil || apierrors.IsAlreadyExists(err) {
@@ -22,8 +28,66 @@ func (r *Reconciler) reconcileSecret(ctx context.Context, secret *corev1.Secret)
 	return fmt.Errorf("error reconciling policy-server Secret: %w", err)
 }
 
-type generateCAFunc = func() ([]byte, *admissionregistration.KeyPair, error)
-type pemEncodeCertificateFunc = func(certificate []byte) ([]byte, error)
+func (r *Reconciler) fetchOrInitializePolicyServerSecret(ctx context.Context, policyServerName string, caSecret *corev1.Secret, generateCert generateCertFunc) (*corev1.Secret, error) {
+	policyServerSecret := corev1.Secret{}
+	err := r.Client.Get(
+		ctx,
+		client.ObjectKey{
+			Namespace: r.DeploymentsNamespace,
+			Name:      constants.PolicyServerSecretNamePrefix + policyServerName},
+		&policyServerSecret)
+	if err != nil && apierrors.IsNotFound(err) {
+		return r.buildPolicyServerSecret(policyServerName, caSecret, generateCert)
+	}
+	policyServerSecret.ResourceVersion = ""
+	if err != nil {
+		return &corev1.Secret{},
+			fmt.Errorf("cannot fetch or initialize Policy Server secret: %w", err)
+	}
+
+	return &policyServerSecret, nil
+}
+
+func (r *Reconciler) buildPolicyServerSecret(policyServerName string, caSecret *corev1.Secret, generateCert generateCertFunc) (*corev1.Secret, error) {
+	ca, err := extractCaFromSecret(caSecret)
+	servingCert, servingKey, err := generateCert(
+		ca.CaCert,
+		fmt.Sprintf("%s.%s.svc", constants.PolicyServerServiceNamePrefix+policyServerName, r.DeploymentsNamespace),
+		[]string{fmt.Sprintf("%s.%s.svc", constants.PolicyServerServiceNamePrefix+policyServerName, r.DeploymentsNamespace)},
+		ca.CaPrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("cannot generate policy-server %s certificate: %w", policyServerName, err)
+	}
+	secretContents := map[string]string{
+		constants.PolicyServerTLSCert: string(servingCert),
+		constants.PolicyServerTLSKey:  string(servingKey),
+	}
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.PolicyServerSecretNamePrefix + policyServerName,
+			Namespace: r.DeploymentsNamespace,
+		},
+		StringData: secretContents,
+		Type:       corev1.SecretTypeOpaque,
+	}, nil
+}
+
+func extractCaFromSecret(caSecret *corev1.Secret) (*admissionregistration.CA, error) {
+	caCert, ok := caSecret.Data[constants.PolicyServerCARootCACert]
+	if !ok {
+		return nil, fmt.Errorf("")
+	}
+	caPrivateKeyBytes, ok := caSecret.Data[constants.PolicyServerCARootPrivateKeyCertName]
+	if !ok {
+		return nil, fmt.Errorf("")
+	}
+
+	caPrivateKey, err := x509.ParsePKCS1PrivateKey(caPrivateKeyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("")
+	}
+	return &admissionregistration.CA{CaCert: caCert, CaPrivateKey: caPrivateKey}, nil
+}
 
 func (r *Reconciler) fetchOrInitializePolicyServerCARootSecret(ctx context.Context, generateCA generateCAFunc, pemEncodeCertificate pemEncodeCertificateFunc) (*corev1.Secret, error) {
 	policyServerSecret := corev1.Secret{}
@@ -46,24 +110,26 @@ func (r *Reconciler) fetchOrInitializePolicyServerCARootSecret(ctx context.Conte
 }
 
 func (r *Reconciler) buildPolicyServerCARootSecret(generateCA generateCAFunc, pemEncodeCertificate pemEncodeCertificateFunc) (*corev1.Secret, error) {
-	ca, caPrivateKey, err := generateCA()
+	ca, err := generateCA()
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate policy-server secret CA: %w", err)
 	}
-	caPEMEncoded, err := pemEncodeCertificate(ca)
+	caPEMEncoded, err := pemEncodeCertificate(ca.CaCert)
 	if err != nil {
 		return nil, fmt.Errorf("cannot encode policy-server secret CA: %w", err)
 	}
-	secretContents := map[string]string{
-		constants.PolicyServerCARootPemName:            string(caPEMEncoded),
-		constants.PolicyServerCARootPrivateKeyCertName: caPrivateKey.PrivateKey,
+	caPrivateKeyBytes := x509.MarshalPKCS1PrivateKey(ca.CaPrivateKey)
+	secretContents := map[string][]byte{
+		constants.PolicyServerCARootCACert:             ca.CaCert,
+		constants.PolicyServerCARootPemName:            caPEMEncoded,
+		constants.PolicyServerCARootPrivateKeyCertName: caPrivateKeyBytes,
 	}
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      constants.PolicyServerCARootSecretName,
 			Namespace: r.DeploymentsNamespace,
 		},
-		StringData: secretContents,
-		Type:       corev1.SecretTypeOpaque,
+		Data: secretContents,
+		Type: corev1.SecretTypeOpaque,
 	}, nil
 }

--- a/internal/pkg/admission/policy-server-secret.go
+++ b/internal/pkg/admission/policy-server-secret.go
@@ -39,11 +39,12 @@ func (r *Reconciler) fetchOrInitializePolicyServerSecret(ctx context.Context, po
 	if err != nil && apierrors.IsNotFound(err) {
 		return r.buildPolicyServerSecret(policyServerName, caSecret, generateCert)
 	}
-	policyServerSecret.ResourceVersion = ""
 	if err != nil {
 		return &corev1.Secret{},
 			fmt.Errorf("cannot fetch or initialize Policy Server secret: %w", err)
 	}
+
+	policyServerSecret.ResourceVersion = ""
 
 	return &policyServerSecret, nil
 }

--- a/internal/pkg/admission/policy-server-secret_test.go
+++ b/internal/pkg/admission/policy-server-secret_test.go
@@ -3,6 +3,8 @@ package admission
 import (
 	"bytes"
 	"context"
+	"crypto/rsa"
+	"crypto/x509"
 	"fmt"
 	"github.com/google/go-cmp/cmp"
 	"github.com/kubewarden/kubewarden-controller/internal/pkg/admissionregistration"
@@ -13,43 +15,44 @@ import (
 	"testing"
 )
 
-func TestFetchOrInitializePolicyServerSecret(t *testing.T) {
-	caBytes := []byte{}
-	b, ca, err := admissionregistration.GenerateCA()
+func TestFetchOrInitializePolicyServerCARootSecret(t *testing.T) {
+	caPemBytes := []byte{}
+	ca, err := admissionregistration.GenerateCA()
 	generateCACalled := false
 
-	generateCAFunc := func() ([]byte, *admissionregistration.KeyPair, error) {
+	generateCAFunc := func() (*admissionregistration.CA, error) {
 		generateCACalled = true
-		return b, ca, err
+		return ca, err
 	}
 
 	pemEncodeCertificateFunc := func(certificate []byte) ([]byte, error) {
-		if bytes.Compare(certificate, b) != 0 {
+		if bytes.Compare(certificate, ca.CaCert) != 0 {
 			return nil, fmt.Errorf("certificate received should be the one returned by generateCA")
 		}
-		return caBytes, nil
+		return caPemBytes, nil
 	}
 
-	caSecretContents := map[string]string{
-		constants.PolicyServerCARootPemName:            string(caBytes),
-		constants.PolicyServerCARootPrivateKeyCertName: ca.PrivateKey,
+	caSecretContents := map[string][]byte{
+		constants.PolicyServerCARootCACert:             ca.CaCert,
+		constants.PolicyServerCARootPemName:            caPemBytes,
+		constants.PolicyServerCARootPrivateKeyCertName: x509.MarshalPKCS1PrivateKey(ca.CaPrivateKey),
 	}
 
 	var tests = []struct {
 		name             string
 		r                Reconciler
 		err              error
-		secretContents   map[string]string
+		secretContents   map[string][]byte
 		generateCACalled bool
 	}{
 		{"Existing CA", createReconcilerWithExistingCA(), nil, mockSecretContents, false},
-		{"CA does not exist", createReconcilerWithOutCA(), nil, caSecretContents, true},
+		{"CA does not exist", createReconcilerWithEmptyClient(), nil, caSecretContents, true},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			secret, err := test.r.fetchOrInitializePolicyServerCARootSecret(context.Background(), generateCAFunc, pemEncodeCertificateFunc)
-			if diff := cmp.Diff(secret.StringData, test.secretContents); diff != "" {
+			if diff := cmp.Diff(secret.Data, test.secretContents); diff != "" {
 				t.Errorf("got an unexpected secret, diff %s", diff)
 			}
 
@@ -66,9 +69,57 @@ func TestFetchOrInitializePolicyServerSecret(t *testing.T) {
 
 }
 
+func TestFetchOrInitializePolicyServerSecret(t *testing.T) {
+	generateCertCalled := false
+	servingCert := []byte{1}
+	servingKey := []byte{2}
+	ca, _ := admissionregistration.GenerateCA()
+	caSecret := &corev1.Secret{Data: map[string][]byte{constants.PolicyServerCARootCACert: ca.CaCert, constants.PolicyServerCARootPrivateKeyCertName: x509.MarshalPKCS1PrivateKey(ca.CaPrivateKey)}}
+
+	generateCertFunc := func(ca []byte, commonName string, extraSANs []string, CAPrivateKey *rsa.PrivateKey) ([]byte, []byte, error) {
+		generateCertCalled = true
+		return servingCert, servingKey, nil
+	}
+
+	caSecretContents := map[string]string{
+		constants.PolicyServerTLSCert: string(servingCert),
+		constants.PolicyServerTLSKey:  string(servingKey),
+	}
+
+	var tests = []struct {
+		name               string
+		r                  Reconciler
+		err                error
+		secretContents     map[string]string
+		generateCertCalled bool
+	}{
+		{"Existing cert", createReconcilerWithExistingCert(), nil, mockSecretCert, false},
+		{"cert does not exist", createReconcilerWithEmptyClient(), nil, caSecretContents, true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			secret, err := test.r.fetchOrInitializePolicyServerSecret(context.Background(), "policyServer", caSecret, generateCertFunc)
+			if diff := cmp.Diff(secret.StringData, test.secretContents); diff != "" {
+				t.Errorf("got an unexpected secret, diff %s", diff)
+			}
+
+			if err != test.err {
+				t.Errorf("got %s, want %s", err, test.err)
+			}
+
+			if generateCertCalled != test.generateCertCalled {
+				t.Errorf("got %t, want %t", generateCertCalled, test.generateCertCalled)
+			}
+			generateCertCalled = false
+		})
+	}
+
+}
+
 const namespace = "namespace"
 
-var mockSecretContents = map[string]string{"ca": "secretContents"}
+var mockSecretContents = map[string][]byte{"ca": []byte("secretContents")}
 
 func createReconcilerWithExistingCA() Reconciler {
 	mockSecret := &corev1.Secret{
@@ -76,7 +127,28 @@ func createReconcilerWithExistingCA() Reconciler {
 			Name:      constants.PolicyServerCARootSecretName,
 			Namespace: namespace,
 		},
-		StringData: mockSecretContents,
+		Data: mockSecretContents,
+		Type: corev1.SecretTypeOpaque,
+	}
+
+	// Create a fake client to mock API calls. It will return the mock secret
+	cl := fake.NewClientBuilder().WithObjects(mockSecret).Build()
+	return Reconciler{
+		Client:                        cl,
+		DeploymentsNamespace:          namespace,
+		DeploymentsServiceAccountName: "",
+	}
+}
+
+var mockSecretCert = map[string]string{"cert": "certString"}
+
+func createReconcilerWithExistingCert() Reconciler {
+	mockSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.PolicyServerSecretNamePrefix + "policyServer",
+			Namespace: namespace,
+		},
+		StringData: mockSecretCert,
 		Type:       corev1.SecretTypeOpaque,
 	}
 
@@ -89,7 +161,7 @@ func createReconcilerWithExistingCA() Reconciler {
 	}
 }
 
-func createReconcilerWithOutCA() Reconciler {
+func createReconcilerWithEmptyClient() Reconciler {
 	// Create a fake client to mock API calls.
 	cl := fake.NewClientBuilder().WithObjects().Build()
 	return Reconciler{

--- a/internal/pkg/admission/policy-server-service.go
+++ b/internal/pkg/admission/policy-server-service.go
@@ -22,7 +22,7 @@ func (r *Reconciler) reconcilePolicyServerService(ctx context.Context) error {
 func (r *Reconciler) service() *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      constants.PolicyServerServiceName,
+			Name:      constants.PolicyServerServiceNamePrefix,
 			Namespace: r.DeploymentsNamespace,
 			Labels:    constants.PolicyServerLabels,
 		},

--- a/internal/pkg/admission/policy-server_integration_test.go
+++ b/internal/pkg/admission/policy-server_integration_test.go
@@ -1,0 +1,72 @@
+package admission
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"github.com/kubewarden/kubewarden-controller/internal/pkg/admissionregistration"
+	"github.com/kubewarden/kubewarden-controller/internal/pkg/constants"
+	"net/http"
+	"sync"
+	"testing"
+)
+
+func TestCAAndCertificateCreationInAHttpsServer(t *testing.T) {
+	const domain = "localhost"
+	r := createReconcilerWithEmptyClient()
+	// create CA
+	caSecret, err := r.buildPolicyServerCARootSecret(admissionregistration.GenerateCA, admissionregistration.PemEncodeCertificate)
+	if err != nil {
+		t.Errorf("CA secret could not be created: %s", err.Error())
+	}
+	ca, err := extractCaFromSecret(caSecret)
+	if err != nil {
+		t.Errorf("CA could not be extracted from secret: %s", err.Error())
+	}
+	// create cert using CA previously created
+	servingCert, servingKey, err := admissionregistration.GenerateCert(
+		ca.CaCert,
+		domain,
+		[]string{domain},
+		ca.CaPrivateKey)
+
+	var server http.Server
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// create https server with the certificates created
+	go func() {
+		cert, err := tls.X509KeyPair(servingCert, servingKey)
+		if err != nil {
+			t.Errorf("could not load cert: %s", err.Error())
+		}
+		tlsConfig := &tls.Config{
+			Certificates: []tls.Certificate{cert},
+		}
+		server = http.Server{
+			Addr:      ":8080",
+			TLSConfig: tlsConfig,
+		}
+		wg.Done()
+		server.ListenAndServeTLS("", "")
+	}()
+
+	//wait for https server to be ready to avoid race conditions
+	wg.Wait()
+	rootCAs := x509.NewCertPool()
+	rootCAs.AppendCertsFromPEM(caSecret.Data[constants.PolicyServerCARootPemName])
+	//test ssl handshake using the ca pem
+	conn, err := tls.Dial("tcp", domain+":8080", &tls.Config{RootCAs: rootCAs})
+	if err != nil {
+		t.Errorf("error when connecting to the https server : %s", err.Error())
+	}
+	err = conn.Close()
+	if err != nil {
+		t.Errorf("error when closing connection : %s", err.Error())
+	}
+	err = server.Shutdown(context.Background())
+	if err != nil {
+		t.Errorf("error when shutting down https server : %s", err.Error())
+	}
+
+}

--- a/internal/pkg/admission/reconciler.go
+++ b/internal/pkg/admission/reconciler.go
@@ -135,6 +135,25 @@ func (r *Reconciler) Reconcile(
 		policiesv1alpha2.PolicyServerSecretReconciled,
 	)
 
+	policyServerSecret, err := r.fetchOrInitializePolicyServerSecret(ctx, "psp-policies", policyServerCARootSecret, admissionregistration.GenerateCert)
+	if err != nil {
+		setFalseConditionType(
+			&clusterAdmissionPolicy.Status.Conditions,
+			policiesv1alpha2.PolicyServerSecretReconciled,
+			fmt.Sprintf("error reconciling secret: %v", err),
+		)
+		return err
+	}
+
+	if err := r.reconcileSecret(ctx, policyServerSecret); err != nil {
+		setFalseConditionType(
+			&clusterAdmissionPolicy.Status.Conditions,
+			policiesv1alpha2.PolicyServerSecretReconciled,
+			fmt.Sprintf("error reconciling secret: %v", err),
+		)
+		return err
+	}
+
 	if err := r.reconcilePolicyServerConfigMap(ctx, clusterAdmissionPolicy, AddPolicy); err != nil {
 		setFalseConditionType(
 			&clusterAdmissionPolicy.Status.Conditions,

--- a/internal/pkg/admission/validating-webhook.go
+++ b/internal/pkg/admission/validating-webhook.go
@@ -34,7 +34,7 @@ func (r *Reconciler) validatingWebhookConfiguration(
 
 	service := admissionregistrationv1.ServiceReference{
 		Namespace: r.DeploymentsNamespace,
-		Name:      constants.PolicyServerServiceName,
+		Name:      constants.PolicyServerServiceNamePrefix,
 		Path:      &admissionPath,
 		Port:      &admissionPort,
 	}

--- a/internal/pkg/constants/constants.go
+++ b/internal/pkg/constants/constants.go
@@ -7,6 +7,7 @@ const (
 	PolicyServerTLSKey                   = "policy-server-key"
 	PolicyServerCARootSecretName         = "policy-server-root-ca"
 	PolicyServerCARootPemName            = "policy-server-root-ca-pem"
+	PolicyServerCARootCACert             = "policy-server-root-ca-cert"
 	PolicyServerCARootPrivateKeyCertName = "policy-server-root-ca-privatekey-cert"
 
 	// PolicyServer Deployment
@@ -18,10 +19,10 @@ const (
 	PolicyServerReadinessProbe             = "/readiness"
 	PolicyServerReplicaSize                = 1
 	PolicyServerReplicaSizeKey             = "replicas"
-	PolicyServerSecretName                 = "policy-server-certs"
+	PolicyServerSecretNamePrefix           = "policy-server-"
 
 	// PolicyServer Service
-	PolicyServerServiceName = "policy-server"
+	PolicyServerServiceNamePrefix = "policy-server-"
 
 	// PolicyServer ConfigMap
 	PolicyServerConfigMapName       = "policy-server"


### PR DESCRIPTION
Fixes kubewarden/kubewarden-controller#56

I added an integration test that creates ca and policy server certs and validates them in a go https server. Right now it will also be executed with the unit tests when running go test ./... We can add a flag for the integration tests to run them separately as they take longer than the unit tests (this int test takes a bit more than 1 second in my machine). Maybe we don't need it now, but just keep it in mind for the future. What do you think?