### PR TITLE
Fix controller panic when policy server does not have any annotation

### DIFF
--- a/internal/pkg/admission/policy-server-deployment.go
+++ b/internal/pkg/admission/policy-server-deployment.go
@@ -199,6 +199,9 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *policiesv
 	}
 
 	templateAnnotations := policyServer.Spec.Annotations
+	if templateAnnotations == nil {
+		templateAnnotations = make(map[string]string)
+	}
 	templateAnnotations[constants.PolicyServerDeploymentConfigAnnotation] = configMapVersion
 
 	return &appsv1.Deployment{


### PR DESCRIPTION
Fixes kubewarden/kubewarden-controller#71