### PR TITLE
Update the CRDs docs

### DIFF
--- a/apis/policies/v1alpha2/clusteradmissionpolicy_types.go
+++ b/apis/policies/v1alpha2/clusteradmissionpolicy_types.go
@@ -200,7 +200,6 @@ type ClusterAdmissionPolicyStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-//nolint:lll
 // ClusterAdmissionPolicy is the Schema for the clusteradmissionpolicies API
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
@@ -208,6 +207,7 @@ type ClusterAdmissionPolicyStatus struct {
 //+kubebuilder:storageversion
 //+kubebuilder:printcolumn:name="Mutating",type=boolean,JSONPath=`.spec.mutating`,description="Whether the policy is mutating"
 //+kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.policyStatus`,description="Status of the policy"
+//nolint:lll
 type ClusterAdmissionPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/docs/crds/README.asciidoc
+++ b/docs/crds/README.asciidoc
@@ -16,6 +16,8 @@ Package v1alpha2 contains API Schema definitions for the policies v1alpha2 API g
 .Resource Types
 - xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-clusteradmissionpolicy[$$ClusterAdmissionPolicy$$]
 - xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-clusteradmissionpolicylist[$$ClusterAdmissionPolicyList$$]
+- xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-policyserver[$$PolicyServer$$]
+- xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-policyserverlist[$$PolicyServerList$$]
 
 
 
@@ -71,6 +73,7 @@ ClusterAdmissionPolicySpec defines the desired state of ClusterAdmissionPolicy
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
+| *`policyServer`* __string__ | PolicyServer identifies an existing PolicyServer resource.
 | *`module`* __string__ | Module is the location of the WASM module to be loaded. Can be a local file (file://), a remote file served by an HTTP server (http://, https://), or an artifact served by an OCI-compatible registry (registry://).
 | *`settings`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | Settings is a free-form object that contains the policy configuration values. x-kubernetes-embedded-resource: false
 | *`rules`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#rulewithoperations-v1-admissionregistration[$$RuleWithOperations$$] array__ | Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule.
@@ -88,6 +91,68 @@ ClusterAdmissionPolicySpec defines the desired state of ClusterAdmissionPolicy
 | *`objectSelector`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#labelselector-v1-meta[$$LabelSelector$$]__ | ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
 | *`sideEffects`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#sideeffectclass-v1-admissionregistration[$$SideEffectClass$$]__ | SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
 | *`timeoutSeconds`* __integer__ | TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
+|===
+
+
+
+
+[id="{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-policyserver"]
+==== PolicyServer 
+
+PolicyServer is the Schema for the policyservers API
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-policyserverlist[$$PolicyServerList$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `policies.kubewarden.io/v1alpha2`
+| *`kind`* __string__ | `PolicyServer`
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-policyserverspec[$$PolicyServerSpec$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-policyserverlist"]
+==== PolicyServerList 
+
+PolicyServerList contains a list of PolicyServer
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `policies.kubewarden.io/v1alpha2`
+| *`kind`* __string__ | `PolicyServerList`
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`items`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-policyserver[$$PolicyServer$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-policyserverspec"]
+==== PolicyServerSpec 
+
+PolicyServerSpec defines the desired state of PolicyServer
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-policyserver[$$PolicyServer$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`image`* __string__ | Docker image name.
+| *`replicas`* __integer__ | Replicas is the number of desired replicas.
+| *`annotations`* __object (keys:string, values:string)__ | Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations
+| *`env`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#envvar-v1-core[$$EnvVar$$] array__ | List of environment variables to set in the container. Cannot be updated.
+| *`serviceAccountName`* __string__ | Name of the service account associated with the policy server. Namespace service account will be used if not specified.
 |===
 
 


### PR DESCRIPTION
Generate the file that holds the description of our CRD.

That was generated by using the `make generate` target inside of the `docs/crds` directory