### PR TITLE
Rename condition from `active` to `PolicyActive`

### DIFF
--- a/apis/policies/v1alpha2/clusteradmissionpolicy_types.go
+++ b/apis/policies/v1alpha2/clusteradmissionpolicy_types.go
@@ -160,7 +160,7 @@ const (
 	PolicyServerConfigMapReconciled PolicyConditionType = "PolicyServerConfigMapReconciled"
 	// ClusterAdmissionPolicyActive represents the condition of the Policy
 	// admission webhook being registered
-	ClusterAdmissionPolicyActive PolicyConditionType = "active"
+	ClusterAdmissionPolicyActive PolicyConditionType = "PolicyActive"
 )
 
 // +kubebuilder:validation:Enum=unscheduled;unschedulable;pending;active


### PR DESCRIPTION
This name is more in line to how other conditions are named in other core API resources.