### PR TITLE
cluster admission policy: default to `default` policyServer explicitly

### DIFF
--- a/apis/policies/v1alpha2/clusteradmissionpolicy_webhook.go
+++ b/apis/policies/v1alpha2/clusteradmissionpolicy_webhook.go
@@ -51,6 +51,9 @@ var _ webhook.Defaulter = &ClusterAdmissionPolicy{}
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *ClusterAdmissionPolicy) Default() {
 	clusteradmissionpolicylog.Info("default", "name", r.Name)
+	if r.Spec.PolicyServer == "" {
+		r.Spec.PolicyServer = "default" //nolint:goconst
+	}
 	controllerutil.AddFinalizer(r, constants.KubewardenFinalizer)
 }
 


### PR DESCRIPTION
When no `policyServer` is provided in a cluster admission policy,
default it to the `default` one that will have been created when
installing Kubewarden.

This, along with
https://github.com/kubewarden/kubewarden-controller/pull/94, makes it
explicit to see to what policy server every policy is bound just by
listing them.