### PR TITLE
Default mutating webhook prevent resource to be deleted.

### DIFF
--- a/apis/policies/v1alpha2/clusteradmissionpolicy_webhook.go
+++ b/apis/policies/v1alpha2/clusteradmissionpolicy_webhook.go
@@ -44,7 +44,7 @@ func (r *ClusterAdmissionPolicy) SetupWebhookWithManager(mgr ctrl.Manager) error
 	return nil
 }
 
-//+kubebuilder:webhook:path=/mutate-policies-kubewarden-io-v1alpha2-clusteradmissionpolicy,mutating=true,failurePolicy=fail,sideEffects=None,groups=policies.kubewarden.io,resources=clusteradmissionpolicies,verbs=create,versions=v1alpha2,name=mclusteradmissionpolicy.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-policies-kubewarden-io-v1alpha2-clusteradmissionpolicy,mutating=true,failurePolicy=fail,sideEffects=None,groups=policies.kubewarden.io,resources=clusteradmissionpolicies,verbs=create;update,versions=v1alpha2,name=mclusteradmissionpolicy.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &ClusterAdmissionPolicy{}
 

--- a/apis/policies/v1alpha2/policyserver_webhook.go
+++ b/apis/policies/v1alpha2/policyserver_webhook.go
@@ -39,7 +39,7 @@ func (ps *PolicyServer) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return nil
 }
 
-//+kubebuilder:webhook:path=/mutate-policies-kubewarden-io-v1alpha2-policyserver,mutating=true,failurePolicy=fail,sideEffects=None,groups=policies.kubewarden.io,resources=policyservers,verbs=create,versions=v1alpha2,name=mpolicyserver.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-policies-kubewarden-io-v1alpha2-policyserver,mutating=true,failurePolicy=fail,sideEffects=None,groups=policies.kubewarden.io,resources=policyservers,verbs=create;update,versions=v1alpha2,name=mpolicyserver.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &PolicyServer{}
 

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -23,6 +23,7 @@ webhooks:
     - v1alpha2
     operations:
     - CREATE
+    - UPDATE
     resources:
     - clusteradmissionpolicies
   sideEffects: None
@@ -43,6 +44,7 @@ webhooks:
     - v1alpha2
     operations:
     - CREATE
+    - UPDATE
     resources:
     - policyservers
   sideEffects: None


### PR DESCRIPTION
When deleting a policy server the policies are deleted. In this process the webhook register to mutate the `clusteradmissionpolicies ` receive a request. The function used to handle this request is the default one which adds a `kubewarden` finalizer in the resource preventing the policy to be removed and consequently the policy server is not deleted as well. To work around this the default webhook code checks if the resource has a deletion timestamp which indicates that the resource should be deleted and does not add the default finalizer.

Closes #100 