### PR TITLE
feat: add OpenTelemetry integration

### DIFF
--- a/internal/pkg/admission/policy-server-service.go
+++ b/internal/pkg/admission/policy-server-service.go
@@ -3,15 +3,37 @@ package admission
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 
 	policiesv1alpha2 "github.com/kubewarden/kubewarden-controller/apis/policies/v1alpha2"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/kubewarden/kubewarden-controller/internal/pkg/constants"
 )
+
+var (
+	// This is the port where the Policy Server service will be exposing metrics. Can be overridden
+	// by an environment variable KUBEWARDEN_POLICY_SERVER_SERVICES_METRICS_PORT
+	metricsPort = constants.PolicyServerMetricsPort
+)
+
+func init() {
+	envMetricsPort := os.Getenv(constants.PolicyServerMetricsPortEnvVar)
+	if envMetricsPort != "" {
+		var err error
+		metricsPortInt32, err := strconv.ParseInt(envMetricsPort, 10, 32)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "port %s provided in %s envvar cannot be parsed as integer: %v. Aborting.\n", envMetricsPort, constants.PolicyServerMetricsPortEnvVar, err)
+			os.Exit(1)
+		}
+		metricsPort = int(metricsPortInt32)
+	}
+}
 
 func (r *Reconciler) reconcilePolicyServerService(ctx context.Context, policyServer *policiesv1alpha2.PolicyServer) error {
 	err := r.Client.Create(ctx, r.service(policyServer))
@@ -22,7 +44,7 @@ func (r *Reconciler) reconcilePolicyServerService(ctx context.Context, policySer
 }
 
 func (r *Reconciler) service(policyServer *policiesv1alpha2.PolicyServer) *corev1.Service {
-	return &corev1.Service{
+	svc := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      policyServer.NameWithPrefix(),
 			Namespace: r.DeploymentsNamespace,
@@ -33,8 +55,10 @@ func (r *Reconciler) service(policyServer *policiesv1alpha2.PolicyServer) *corev
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
-					Port:     constants.PolicyServerPort,
-					Protocol: corev1.ProtocolTCP,
+					Name:       "policy-server",
+					Port:       constants.PolicyServerPort,
+					TargetPort: intstr.FromInt(constants.PolicyServerPort),
+					Protocol:   corev1.ProtocolTCP,
 				},
 			},
 			Selector: map[string]string{
@@ -42,4 +66,26 @@ func (r *Reconciler) service(policyServer *policiesv1alpha2.PolicyServer) *corev
 			},
 		},
 	}
+	if metricsEnabled(policyServer) {
+		svc.Spec.Ports = append(
+			svc.Spec.Ports,
+			corev1.ServicePort{
+				Name:     "metrics",
+				Port:     int32(metricsPort),
+				Protocol: corev1.ProtocolTCP,
+			},
+		)
+	}
+	return &svc
+}
+
+// If an environment variable `KUBEWARDEN_ENABLE_METRICS` is exported -- regardless of its value --,
+// metrics are considered enabled.
+func metricsEnabled(policyServer *policiesv1alpha2.PolicyServer) bool {
+	for _, envVar := range policyServer.Spec.Env {
+		if envVar.Name == constants.PolicyServerEnableMetricsEnvVar {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/pkg/admission/policy-server-service_test.go
+++ b/internal/pkg/admission/policy-server-service_test.go
@@ -1,0 +1,76 @@
+package admission
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	policiesv1alpha2 "github.com/kubewarden/kubewarden-controller/apis/policies/v1alpha2"
+	"github.com/kubewarden/kubewarden-controller/internal/pkg/constants"
+)
+
+func TestMetricsEnabled(t *testing.T) {
+	cases := []struct {
+		policyServer           policiesv1alpha2.PolicyServer
+		expectedMetricsEnabled bool
+	}{
+		{
+			policyServer: policyServerWithEnvVar(
+				"SOME_VAR", "SOME_VALUE",
+			),
+			expectedMetricsEnabled: false,
+		},
+		{
+			policyServer: policyServerWithEnvVar(
+				constants.PolicyServerEnableMetricsEnvVar, "1",
+			),
+			expectedMetricsEnabled: true,
+		},
+		{
+			policyServer: policyServerWithEnvVar(
+				constants.PolicyServerEnableMetricsEnvVar, "true",
+			),
+			expectedMetricsEnabled: true,
+		},
+		// If the environment variable is exported -- regardless of its value --, metrics are
+		// considered enabled
+		{
+			policyServer: policyServerWithEnvVar(
+				constants.PolicyServerEnableMetricsEnvVar, "",
+			),
+			expectedMetricsEnabled: true,
+		},
+		{
+			policyServer: policyServerWithEnvVar(
+				constants.PolicyServerEnableMetricsEnvVar, "0",
+			),
+			expectedMetricsEnabled: true,
+		},
+		{
+			policyServer: policyServerWithEnvVar(
+				constants.PolicyServerEnableMetricsEnvVar, "false",
+			),
+			expectedMetricsEnabled: true,
+		},
+	}
+
+	for _, testCase := range cases {
+		expected, actual := testCase.expectedMetricsEnabled, metricsEnabled(&testCase.policyServer)
+		if actual != expected {
+			t.Errorf("metrics enabled value (%v) does not match expected value: %v", actual, expected)
+		}
+	}
+}
+
+func policyServerWithEnvVar(name, value string) policiesv1alpha2.PolicyServer {
+	return policiesv1alpha2.PolicyServer{
+		Spec: policiesv1alpha2.PolicyServerSpec{
+			Env: []corev1.EnvVar{
+				{
+					Name:  name,
+					Value: value,
+				},
+			},
+		},
+	}
+}

--- a/internal/pkg/constants/constants.go
+++ b/internal/pkg/constants/constants.go
@@ -10,8 +10,11 @@ const (
 	PolicyServerCARootPrivateKeyCertName = "policy-server-root-ca-privatekey-cert"
 
 	// PolicyServer Deployment
+	PolicyServerEnableMetricsEnvVar        = "KUBEWARDEN_ENABLE_METRICS"
 	PolicyServerDeploymentConfigAnnotation = "config/version"
 	PolicyServerPort                       = 8443
+	PolicyServerMetricsPortEnvVar          = "KUBEWARDEN_POLICY_SERVER_SERVICES_METRICS_PORT"
+	PolicyServerMetricsPort                = 8080
 	PolicyServerReadinessProbe             = "/readiness"
 
 	// PolicyServer ConfigMap


### PR DESCRIPTION
Related: https://github.com/kubewarden/policy-server/issues/106

- Add sample `otel-collector.yaml.example` file containing a basic
OpenTelemetry collector resource that can be deployed using the
OpenTelemetry operator.

- If metrics are enabled, expose metrics port on the policy-server
service, so a prometheus instance running on the cluster can be
instructed to scrape this endpoint.