### PR TITLE
Update changelog for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 ## [Unreleased]
 
 
-<a name="0.4.0"></a>
-## [0.4.0] - 2021-10-01
+<a name="v0.4.0"></a>
+## [v0.4.0] - 2021-10-01
 ### Features
 - Introduce a PolicyServer CRD that allow users to describe a Policy Server
   Deployment. The configuration of PolicyServer is now done through this
@@ -122,8 +122,8 @@
 <a name="v0.0.1"></a>
 ## v0.0.1 - 2021-01-18
 
-[Unreleased]: https://github.com/kubewarden/kubewarden-controller/compare/0.4.0...HEAD
-[0.4.0]: https://github.com/kubewarden/kubewarden-controller/compare/v0.3.2...0.4.0
+[Unreleased]: https://github.com/kubewarden/kubewarden-controller/compare/v0.4.0...HEAD
+[v0.4.0]: https://github.com/kubewarden/kubewarden-controller/compare/v0.3.2...v0.4.0
 [v0.3.2]: https://github.com/kubewarden/kubewarden-controller/compare/v0.3.1...v0.3.2
 [v0.3.1]: https://github.com/kubewarden/kubewarden-controller/compare/v0.3.0...v0.3.1
 [v0.3.0]: https://github.com/kubewarden/kubewarden-controller/compare/v0.2.3...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 ## [Unreleased]
 
 
+<a name="v0.4.1"></a>
+## [v0.4.1] - 2021-11-02
+### Code Refactoring
+- Extract sources path into constants pkg
+
+### Features
+- Add spec.sourceAuthorities to PolicyServer CR
+- Add spec.insecureSources to PolicyServer CR
+- Add spec.imagePullSecrets to PolicyServer to CR
+
+### Pull Requests
+- Merge pull request [#117](https://github.com/kubewarden/kubewarden-controller/issues/117) from viccuad/docs-crds
+- Merge pull request [#114](https://github.com/kubewarden/kubewarden-controller/issues/114) from viccuad/custom-cas
+- Merge pull request [#108](https://github.com/kubewarden/kubewarden-controller/issues/108) from viccuad/insecureregs
+- Merge pull request [#106](https://github.com/kubewarden/kubewarden-controller/issues/106) from jvanz/can-update-env
+- Merge pull request [#92](https://github.com/kubewarden/kubewarden-controller/issues/92) from ereslibre/development-webhook-wrapper
+- Merge pull request [#99](https://github.com/kubewarden/kubewarden-controller/issues/99) from viccuad/main
+
+
 <a name="v0.4.0"></a>
 ## [v0.4.0] - 2021-10-01
 ### Features
@@ -122,7 +141,8 @@
 <a name="v0.0.1"></a>
 ## v0.0.1 - 2021-01-18
 
-[Unreleased]: https://github.com/kubewarden/kubewarden-controller/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/kubewarden/kubewarden-controller/compare/v0.4.1...HEAD
+[v0.4.1]: https://github.com/kubewarden/kubewarden-controller/compare/v0.4.0...v0.4.1
 [v0.4.0]: https://github.com/kubewarden/kubewarden-controller/compare/v0.3.2...v0.4.0
 [v0.3.2]: https://github.com/kubewarden/kubewarden-controller/compare/v0.3.1...v0.3.2
 [v0.3.1]: https://github.com/kubewarden/kubewarden-controller/compare/v0.3.0...v0.3.1


### PR DESCRIPTION
Updated manually for now, as git-chglog removes manually added changelog content for v0.4.0.
An option would be to craft the template to contain those old entries: https://github.com/git-chglog/git-chglog/issues/55