### PR TITLE
refactor: Fix golangci-lint 1.43 issues

### DIFF
--- a/internal/pkg/admission/policy-server-configmap.go
+++ b/internal/pkg/admission/policy-server-configmap.go
@@ -194,19 +194,19 @@ func (r *Reconciler) createSourcesMap(policyServer *policiesv1alpha2.PolicyServe
 func (r *Reconciler) policyServerConfigMapVersion(ctx context.Context, policyServer *policiesv1alpha2.PolicyServer) (string, error) {
 	// By using Unstructured data we force the client to fetch fresh, uncached
 	// data from the API server
-	u := &unstructured.Unstructured{}
-	u.SetGroupVersionKind(schema.GroupVersionKind{
+	unstructuredObj := &unstructured.Unstructured{}
+	unstructuredObj.SetGroupVersionKind(schema.GroupVersionKind{
 		Kind:    "ConfigMap",
 		Version: "v1",
 	})
 	err := r.Client.Get(ctx, client.ObjectKey{
 		Namespace: r.DeploymentsNamespace,
 		Name:      policyServer.NameWithPrefix(),
-	}, u)
+	}, unstructuredObj)
 
 	if err != nil {
 		return "", fmt.Errorf("cannot retrieve existing policies ConfigMap: %w", err)
 	}
 
-	return u.GetResourceVersion(), nil
+	return unstructuredObj.GetResourceVersion(), nil
 }

--- a/internal/pkg/admission/policy-server-configmap_test.go
+++ b/internal/pkg/admission/policy-server-configmap_test.go
@@ -41,18 +41,18 @@ func TestArePoliciesEqual(t *testing.T) {
 			true},
 	}
 	for _, test := range tests {
-		tt := test // ensure tt is correctly scoped when used in function literal
-		t.Run(tt.name, func(t *testing.T) {
+		ttest := test // ensure tt is correctly scoped when used in function literal
+		t.Run(ttest.name, func(t *testing.T) {
 			var currentPoliciesMap map[string]policyServerConfigEntry
-			if err := json.Unmarshal([]byte(tt.newPoliciesYML), &currentPoliciesMap); err != nil {
+			if err := json.Unmarshal([]byte(ttest.newPoliciesYML), &currentPoliciesMap); err != nil {
 				t.Errorf("unexpected error %s", err.Error())
 			}
-			got, err := shouldUpdatePolicyMap(tt.currentPoliciesYML, currentPoliciesMap)
+			got, err := shouldUpdatePolicyMap(ttest.currentPoliciesYML, currentPoliciesMap)
 			if err != nil {
 				t.Errorf("unexpected error %s", err.Error())
 			}
-			if got != tt.expect {
-				t.Errorf("got %t, want %t", got, tt.expect)
+			if got != ttest.expect {
+				t.Errorf("got %t, want %t", got, ttest.expect)
 			}
 		})
 	}
@@ -128,14 +128,14 @@ func TestShouldUpdateSourcesList(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		tt := test // ensure tt is correctly scoped when used in function literal
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := shouldUpdateSourcesList(tt.currentSourcesYML, tt.newSourcesList)
+		ttest := test // ensure ttest is correctly scoped when used in function literal
+		t.Run(ttest.name, func(t *testing.T) {
+			got, err := shouldUpdateSourcesList(ttest.currentSourcesYML, ttest.newSourcesList)
 			if err != nil {
 				t.Errorf("unexpected error %s", err.Error())
 			}
-			if got != tt.expect {
-				t.Errorf("got %t, want %t", got, tt.expect)
+			if got != ttest.expect {
+				t.Errorf("got %t, want %t", got, ttest.expect)
 			}
 		})
 	}

--- a/internal/pkg/admission/policy-server-deployment.go
+++ b/internal/pkg/admission/policy-server-deployment.go
@@ -106,22 +106,22 @@ func getProgressingDeploymentCondition(status appsv1.DeploymentStatus) *appsv1.D
 func (r *Reconciler) policyServerImagePullSecretPresent(ctx context.Context, policyServer *policiesv1alpha2.PolicyServer) error {
 	// By using Unstructured data we force the client to fetch fresh, uncached
 	// data from the API server
-	u := &unstructured.Unstructured{}
-	u.SetGroupVersionKind(schema.GroupVersionKind{
+	unstructuredObj := &unstructured.Unstructured{}
+	unstructuredObj.SetGroupVersionKind(schema.GroupVersionKind{
 		Kind:    "Secret",
 		Version: "v1",
 	})
 	err := r.Client.Get(ctx, client.ObjectKey{
 		Namespace: r.DeploymentsNamespace,
 		Name:      policyServer.Spec.ImagePullSecret,
-	}, u)
+	}, unstructuredObj)
 	if err != nil {
 		return fmt.Errorf("cannot get spec.ImagePullSecret: %w", err)
 	}
 
 	var secret corev1.Secret
 	err = runtime.DefaultUnstructuredConverter.
-		FromUnstructured(u.UnstructuredContent(), &secret)
+		FromUnstructured(unstructuredObj.UnstructuredContent(), &secret)
 	if err != nil {
 		return fmt.Errorf("spec.ImagePullSecret is not of Kind Secret: %w", err)
 	}

--- a/internal/pkg/admission/policy-server-secret_test.go
+++ b/internal/pkg/admission/policy-server-secret_test.go
@@ -19,26 +19,26 @@ import (
 
 func TestFetchOrInitializePolicyServerCARootSecret(t *testing.T) {
 	caPemBytes := []byte{}
-	ca, err := admissionregistration.GenerateCA()
+	admissionregCA, err := admissionregistration.GenerateCA()
 	generateCACalled := false
 
 	// nolint: wrapcheck
 	generateCAFunc := func() (*admissionregistration.CA, error) {
 		generateCACalled = true
-		return ca, err
+		return admissionregCA, err
 	}
 
 	pemEncodeCertificateFunc := func(certificate []byte) ([]byte, error) {
-		if !bytes.Equal(certificate, ca.CaCert) {
+		if !bytes.Equal(certificate, admissionregCA.CaCert) {
 			return nil, fmt.Errorf("certificate received should be the one returned by generateCA")
 		}
 		return caPemBytes, nil
 	}
 
 	caSecretContents := map[string][]byte{
-		constants.PolicyServerCARootCACert:             ca.CaCert,
+		constants.PolicyServerCARootCACert:             admissionregCA.CaCert,
 		constants.PolicyServerCARootPemName:            caPemBytes,
-		constants.PolicyServerCARootPrivateKeyCertName: x509.MarshalPKCS1PrivateKey(ca.CaPrivateKey),
+		constants.PolicyServerCARootPrivateKeyCertName: x509.MarshalPKCS1PrivateKey(admissionregCA.CaPrivateKey),
 	}
 
 	var tests = []struct {
@@ -53,19 +53,19 @@ func TestFetchOrInitializePolicyServerCARootSecret(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		tt := test // ensure tt is correctly scoped when used in function literal
-		t.Run(tt.name, func(t *testing.T) {
-			secret, err := tt.r.fetchOrInitializePolicyServerCARootSecret(context.Background(), generateCAFunc, pemEncodeCertificateFunc)
-			if diff := cmp.Diff(secret.Data, tt.secretContents); diff != "" {
+		ttest := test // ensure tt is correctly scoped when used in function literal
+		t.Run(ttest.name, func(t *testing.T) {
+			secret, err := ttest.r.fetchOrInitializePolicyServerCARootSecret(context.Background(), generateCAFunc, pemEncodeCertificateFunc)
+			if diff := cmp.Diff(secret.Data, ttest.secretContents); diff != "" {
 				t.Errorf("got an unexpected secret, diff %s", diff)
 			}
 
-			if !errors.Is(err, tt.err) {
-				t.Errorf("got %s, want %s", err, tt.err)
+			if !errors.Is(err, ttest.err) {
+				t.Errorf("got %s, want %s", err, ttest.err)
 			}
 
-			if generateCACalled != tt.generateCACalled {
-				t.Errorf("got %t, want %t", generateCACalled, tt.generateCACalled)
+			if generateCACalled != ttest.generateCACalled {
+				t.Errorf("got %t, want %t", generateCACalled, ttest.generateCACalled)
 			}
 			generateCACalled = false
 		})
@@ -76,8 +76,8 @@ func TestFetchOrInitializePolicyServerSecret(t *testing.T) {
 	generateCertCalled := false
 	servingCert := []byte{1}
 	servingKey := []byte{2}
-	ca, _ := admissionregistration.GenerateCA()
-	caSecret := &corev1.Secret{Data: map[string][]byte{constants.PolicyServerCARootCACert: ca.CaCert, constants.PolicyServerCARootPrivateKeyCertName: x509.MarshalPKCS1PrivateKey(ca.CaPrivateKey)}}
+	admissionregCA, _ := admissionregistration.GenerateCA()
+	caSecret := &corev1.Secret{Data: map[string][]byte{constants.PolicyServerCARootCACert: admissionregCA.CaCert, constants.PolicyServerCARootPrivateKeyCertName: x509.MarshalPKCS1PrivateKey(admissionregCA.CaPrivateKey)}}
 
 	// nolint:unparam
 	generateCertFunc := func(ca []byte, commonName string, extraSANs []string, CAPrivateKey *rsa.PrivateKey) ([]byte, []byte, error) {
@@ -102,19 +102,19 @@ func TestFetchOrInitializePolicyServerSecret(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		tt := test // ensure tt is correctly scoped when used in function literal
-		t.Run(tt.name, func(t *testing.T) {
-			secret, err := tt.r.fetchOrInitializePolicyServerSecret(context.Background(), "policyServer", caSecret, generateCertFunc)
-			if diff := cmp.Diff(secret.StringData, tt.secretContents); diff != "" {
+		ttest := test // ensure tt is correctly scoped when used in function literal
+		t.Run(ttest.name, func(t *testing.T) {
+			secret, err := ttest.r.fetchOrInitializePolicyServerSecret(context.Background(), "policyServer", caSecret, generateCertFunc)
+			if diff := cmp.Diff(secret.StringData, ttest.secretContents); diff != "" {
 				t.Errorf("got an unexpected secret, diff %s", diff)
 			}
 
-			if !errors.Is(err, tt.err) {
-				t.Errorf("got %s, want %s", err, tt.err)
+			if !errors.Is(err, ttest.err) {
+				t.Errorf("got %s, want %s", err, ttest.err)
 			}
 
-			if generateCertCalled != tt.generateCertCalled {
-				t.Errorf("got %t, want %t", generateCertCalled, tt.generateCertCalled)
+			if generateCertCalled != ttest.generateCertCalled {
+				t.Errorf("got %t, want %t", generateCertCalled, ttest.generateCertCalled)
 			}
 			generateCertCalled = false
 		})

--- a/internal/pkg/admission/policy-server_integration_test.go
+++ b/internal/pkg/admission/policy-server_integration_test.go
@@ -24,16 +24,16 @@ func TestCAAndCertificateCreationInAHttpsServer(t *testing.T) {
 	if err != nil {
 		t.Errorf("CA secret could not be created: %s", err.Error())
 	}
-	ca, err := extractCaFromSecret(caSecret)
+	admissionregCA, err := extractCaFromSecret(caSecret)
 	if err != nil {
 		t.Errorf("CA could not be extracted from secret: %s", err.Error())
 	}
 	// create cert using CA previously created
 	servingCert, servingKey, err := admissionregistration.GenerateCert(
-		ca.CaCert,
+		admissionregCA.CaCert,
 		domain,
 		[]string{domain},
-		ca.CaPrivateKey)
+		admissionregCA.CaPrivateKey)
 	if err != nil {
 		t.Errorf("failed generating cert: %s", err.Error())
 	}

--- a/internal/pkg/admission/reconciler.go
+++ b/internal/pkg/admission/reconciler.go
@@ -262,7 +262,7 @@ func (r *Reconciler) DeleteAllClusterAdmissionPolicies(ctx context.Context, poli
 	for _, policy := range clusterAdmissionPolicies.Items {
 		policy := policy // safely use pointer inside for
 		// will not delete it because it has a finalizer. It will add a DeletionTimestamp
-		err := r.Client.Delete(context.Background(), &policy)
+		err := r.Client.Delete(ctx, &policy)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed deleting pending ClusterAdmissionPolicy %s: %w",
 				policy.Name, err)
@@ -344,7 +344,7 @@ func (r *Reconciler) deletePendingClusterAdmissionPolicies(ctx context.Context, 
 						Name: policy.Name,
 					},
 				}
-				err := r.Client.Delete(context.Background(), mutatingWebhook)
+				err := r.Client.Delete(ctx, mutatingWebhook)
 				if err != nil && !apierrors.IsNotFound(err) {
 					return fmt.Errorf("failed deleting pending ClusterAdmissionPolicy %s: %w",
 						policy.Name, err)
@@ -355,7 +355,7 @@ func (r *Reconciler) deletePendingClusterAdmissionPolicies(ctx context.Context, 
 						Name: policy.Name,
 					},
 				}
-				err := r.Client.Delete(context.Background(), validatingWebhook)
+				err := r.Client.Delete(ctx, validatingWebhook)
 				if err != nil && !apierrors.IsNotFound(err) {
 					return fmt.Errorf("failed deleting pending ClusterAdmissionPolicy %s: %w",
 						policy.Name, err)


### PR DESCRIPTION
The GH Action for golangci-lint now uses golangci-lint v1.43.
This PR makes golangci-lint happy.