### PR TITLE
feat: policy server name label in the deployment.

### DIFF
--- a/internal/pkg/admission/policy-server-deployment.go
+++ b/internal/pkg/admission/policy-server-deployment.go
@@ -280,7 +280,8 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *policiesv
 			Name:      policyServer.NameWithPrefix(),
 			Namespace: r.DeploymentsNamespace,
 			Labels: map[string]string{
-				constants.AppLabelKey: policyServer.AppLabel(),
+				constants.AppLabelKey:              policyServer.AppLabel(),
+				constants.PolicyServerNameLabelKey: policyServer.Name,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{

--- a/internal/pkg/constants/constants.go
+++ b/internal/pkg/constants/constants.go
@@ -24,7 +24,8 @@ const (
 	PolicyServerSourcesConfigContainerPath  = "/sources"
 
 	// Label
-	AppLabelKey = "app"
+	AppLabelKey              = "app"
+	PolicyServerNameLabelKey = "policy-server-name"
 
 	// Index
 	PolicyServerIndexKey  = "policyServer"


### PR DESCRIPTION
Adds a new label in the policy servers deployment. The new label stores the name of the policy server which originates the deployment.