### PR TITLE
Change git-chglog and CHANGELOG.md workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,9 @@
 - Extract sources path into constants pkg
 
 ### Features
-- Add PolicyServer.spec.sourceAuthorities to CR
+- Add spec.sourceAuthorities to PolicyServer CR
 - Add spec.insecureSources to PolicyServer CR
-- Add spec.imagePullSecrets to PolicyServer
+- Add spec.imagePullSecrets to PolicyServer CR
 
 ### Pull Requests
 - Merge pull request [#117](https://github.com/kubewarden/kubewarden-controller/issues/117) from viccuad/docs-crds
@@ -40,9 +40,24 @@
 
 
 <a name="v0.4.0"></a>
-## [v0.4.0] - 2021-10-05
-### Reverts
-- Set PolicyStatus "unscheduled" as default in CRD
+## [v0.4.0] - 2021-10-01
+### Features
+- Introduce a PolicyServer CRD that allow users to describe a Policy Server
+  Deployment. The configuration of PolicyServer is now done through this
+  resource, instead of using the `policy-server` ConfigMap.
+- ClusterAdmissionPolicy has the following changes:
+  - A new PolicyStatus field which can be: `unscheduled`, `unschedulable`, `pending` or `active`
+  - A new condition called PolicyActive.
+  - A `policyServer` attribute. This is used to specify which instance of
+    PolicyServer is going to host the policy. If nothing is specified, the
+    policy will be scheduled on the PolicyServer named `default`. This one is
+    created by the helm chart at installation time.
+- Introduce cert-manager dependency
+- PolicyServer and ClusterAdmissionPolicies are now validated and mutated by
+  dedicated admission controllers. The kubewarden-controller is acting as
+  validation endpoint for both of them.
+- All the resources created by the operator are now using
+  [`Finalizers`](https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/).
 
 ### Pull Requests
 - Merge pull request [#98](https://github.com/kubewarden/kubewarden-controller/issues/98) from kubewarden/viccuad-update-readme

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,17 +132,20 @@ $ go get -u github.com/git-chglog/git-chglog/cmd/git-chglog@v0.14.2
 For creating a new release, first create a new tag:
 
 ```console
-$ TAG=vX.Y.Z make tag
+git-chglog --next-tag vX.Y.Z -o CHANGELOG.md
 ```
 
-This will also update the `CHANGELOG.md` file on a separate
-commit.
+This will update the `CHANGELOG.md` file without yet commiting it. You should
+only stage changes to the new version, and format them as needed.
+
 
 ### Push new tag to the upstream repository
 
 Assuming your official kubewarden remote is called `upstream`:
 
 ```console
+$ git commit -m 'Update CHANGELOG.md' # on main branch
+$ git tag -a vX.Y.Z  -m "vX.Y.Z" -s
 $ git push upstream main vX.Y.Z
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -101,12 +101,6 @@ kustomize: ## Download kustomize locally if necessary.
 
 ##@ Release
 
-tag:
-	@git tag "${TAG}" || (echo "Tag ${TAG} already exists. If you want to retag, delete it manually and re-run this command" && exit 1)
-	@git-chglog --output CHANGELOG.md
-	@git commit -m 'Update CHANGELOG.md' -- CHANGELOG.md
-	@git tag -f "${TAG}"
-
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool


### PR DESCRIPTION
Drop `make tag`, use `git-chglog --next`, and reinstate old changelog entries.


Fixes https://github.com/kubewarden/kubewarden-controller/issues/119