### PR TITLE
 Mutating field in the policy configmap

### DIFF
--- a/internal/pkg/admission/common_test.go
+++ b/internal/pkg/admission/common_test.go
@@ -1,0 +1,43 @@
+package admission
+
+import (
+	"time"
+
+	policiesv1alpha2 "github.com/kubewarden/kubewarden-controller/apis/policies/v1alpha2"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func createReconciler() (Reconciler, policiesv1alpha2.ClusterAdmissionPolicy, policiesv1alpha2.ClusterAdmissionPolicy) {
+	admissionPolicyName := "admissionPolicy"
+	validatingWebhook := &admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: admissionPolicyName,
+		},
+	}
+	validationPolicy := policiesv1alpha2.ClusterAdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &metav1.Time{Time: time.Now()}, Name: admissionPolicyName, Finalizers: []string{"kubewarden"}},
+		Spec:       policiesv1alpha2.ClusterAdmissionPolicySpec{Mutating: false, Module: "registry://blabla/validation-policy:latest"},
+	}
+	mutatingPolicyName := "mutatingPolicy"
+	mutatingWebhook := &admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mutatingPolicyName,
+		},
+	}
+	mutatingPolicy := policiesv1alpha2.ClusterAdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &metav1.Time{Time: time.Now()}, Name: mutatingPolicyName, Finalizers: []string{"kubewarden"}},
+		Spec:       policiesv1alpha2.ClusterAdmissionPolicySpec{Mutating: true, Module: "registry://blabla/mutation-policy:latest"},
+	}
+	customScheme := scheme.Scheme
+	customScheme.AddKnownTypes(schema.GroupVersion{Group: "policies.kubewarden.io", Version: "v1alpha2"}, &validationPolicy)
+	cl := fake.NewClientBuilder().WithScheme(customScheme).WithObjects(validatingWebhook, mutatingWebhook, &validationPolicy, &mutatingPolicy).Build()
+	reconciler := Reconciler{
+		Client:               cl,
+		DeploymentsNamespace: namespace,
+	}
+	return reconciler, validationPolicy, mutatingPolicy
+}

--- a/internal/pkg/admission/policy-server-configmap.go
+++ b/internal/pkg/admission/policy-server-configmap.go
@@ -19,8 +19,9 @@ import (
 )
 
 type policyServerConfigEntry struct {
-	URL      string               `json:"url"`
-	Settings runtime.RawExtension `json:"settings,omitempty"`
+	URL             string               `json:"url"`
+	AllowedToMutate bool                 `json:"allowedToMutate"`
+	Settings        runtime.RawExtension `json:"settings,omitempty"`
 }
 
 type sourceAuthorityType string
@@ -163,8 +164,9 @@ func (r *Reconciler) createPoliciesMap(clusterAdmissionPolicies *policiesv1alpha
 
 	for _, clusterAdmissionPolicy := range clusterAdmissionPolicies.Items {
 		policies[clusterAdmissionPolicy.Name] = policyServerConfigEntry{
-			URL:      clusterAdmissionPolicy.Spec.Module,
-			Settings: clusterAdmissionPolicy.Spec.Settings,
+			URL:             clusterAdmissionPolicy.Spec.Module,
+			AllowedToMutate: clusterAdmissionPolicy.Spec.Mutating,
+			Settings:        clusterAdmissionPolicy.Spec.Settings,
 		}
 	}
 	return policies

--- a/internal/pkg/admission/policy-server-configmap_test.go
+++ b/internal/pkg/admission/policy-server-configmap_test.go
@@ -78,15 +78,15 @@ func TestCreatePoliciesMap(t *testing.T) {
 		t.Error("Policy map must has 2 entries")
 	}
 	expectedPolicies := make(map[string]policyServerConfigEntry)
-	expectedPolicies[admissionPolicyName] = policyServerConfigEntry{
-		URL:      "registry://blabla/validation-policy:latest",
-		Mutating: false,
-		Settings: runtime.RawExtension{},
+	expectedPolicies[validationPolicy.Name] = policyServerConfigEntry{
+		URL:             "registry://blabla/validation-policy:latest",
+		AllowedToMutate: false,
+		Settings:        runtime.RawExtension{},
 	}
-	expectedPolicies[mutatingPolicyName] = policyServerConfigEntry{
-		URL:      "registry://blabla/mutation-policy:latest",
-		Mutating: true,
-		Settings: runtime.RawExtension{},
+	expectedPolicies[mutatingPolicy.Name] = policyServerConfigEntry{
+		URL:             "registry://blabla/mutation-policy:latest",
+		AllowedToMutate: true,
+		Settings:        runtime.RawExtension{},
 	}
 	if len(policies) != len(expectedPolicies) {
 		t.Errorf("Policies maps must be length %d", len(expectedPolicies))


### PR DESCRIPTION
Adds a new field in the configmap where the policies info are store. The new "Mutating" field tells Policy Server that the policy can mutate requests or not.