### PR TITLE
Mount /tmp as an empty dir to store policies

### DIFF
--- a/internal/pkg/admission/policy-server-deployment.go
+++ b/internal/pkg/admission/policy-server-deployment.go
@@ -193,6 +193,9 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *policiesv
 		dockerConfigJSONPolicyServerPath = "/home/kubewarden/.docker"
 	)
 
+	policyStoreVolume := "policy-store"
+	policyStoreVolumePath := "/tmp"
+
 	admissionContainer := corev1.Container{
 		Name:  policyServer.NameWithPrefix(),
 		Image: policyServer.Spec.Image,
@@ -206,6 +209,10 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *policiesv
 				Name:      policiesVolumeName,
 				ReadOnly:  true,
 				MountPath: policiesConfigContainerPath,
+			},
+			{
+				Name:      policyStoreVolume,
+				MountPath: policyStoreVolumePath,
 			},
 		},
 		Env: append([]corev1.EnvVar{
@@ -223,7 +230,7 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *policiesv
 			},
 			{
 				Name:  "KUBEWARDEN_POLICIES_DOWNLOAD_DIR",
-				Value: "/tmp/",
+				Value: policyStoreVolumePath,
 			},
 			{
 				Name:  "KUBEWARDEN_POLICIES",
@@ -322,6 +329,12 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *policiesv
 					Containers:         []corev1.Container{admissionContainer},
 					ServiceAccountName: policyServer.Spec.ServiceAccountName,
 					Volumes: []corev1.Volume{
+						{
+							Name: policyStoreVolume,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
 						{
 							Name: certsVolumeName,
 							VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
Since https://github.com/kubewarden/policy-server/pull/138, the layout of the policy-server container image has been simplified.

Its current layout looks like:

- /etc/group
- /etc/passwd
- /policy-server

Given we don't have a LSB-based layout, make /tmp be mounted by the Kubewarden controller as an empty dir.