### PR TITLE
fix(policy-server): Run the policy server with readonly root

### DIFF
--- a/internal/pkg/admission/policy-server-deployment.go
+++ b/internal/pkg/admission/policy-server-deployment.go
@@ -292,6 +292,11 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *policiesv
 			},
 		)
 	}
+	enableReadOnlyFilesystem := true
+	admissionContainerSecurityContext := corev1.SecurityContext{
+		ReadOnlyRootFilesystem: &enableReadOnlyFilesystem,
+	}
+	admissionContainer.SecurityContext = &admissionContainerSecurityContext
 
 	templateAnnotations := policyServer.Spec.Annotations
 	if templateAnnotations == nil {


### PR DESCRIPTION
Ensure the Policy Server container runs with a readonly root filesystem.
This improves the security of the project.

This partially addresses https://github.com/kubewarden/helm-charts/issues/51
