### PR TITLE
Update GitHub release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,22 @@
+name: kubewarden-controller release
 on:
   push:
     tags:
     - 'v*'
-
-name: publish release
-
 jobs:
-  build:
-    name: Create new Github release
-    runs-on: ubuntu-20.04
+  ci:
+    uses: kubewarden/kubewarden-controller/.github/workflows/ci.yml@main
+  release:
+    name: Create release
+    needs:
+      - ci
     steps:
-      -
-        name: Checkout code
-        uses: actions/checkout@v2
-      -
-        name: Create Release
-        id: create_release
+      - name: Create release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          release_name: Release kubewarden-controller ${{ github.ref }}
           draft: false
-          prerelease: false
+          prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}


### PR DESCRIPTION
If the tag contains '-alpha', '-beta' or '-rc' a release with the flag
pre-release will be created.

Fixes: https://github.com/kubewarden/kubewarden-controller/issues/143