### PR TITLE
docs: Add missing `any_of.signatures` to RFC 3

### DIFF
--- a/rfc/0003-policy-signing.md
+++ b/rfc/0003-policy-signing.md
@@ -459,6 +459,7 @@ apiVersion: v1
 
 anyOf:
   minimumMatches: 2
+  signatures:
   - kind: githubAction
     owner: kubewarden
     annotations:
@@ -496,6 +497,7 @@ allOf:
       env: prod
 anyOf:
   minimumMatches: 2
+  signatures:
   - kind: pubKey
     owner: bob
     key: ....


### PR DESCRIPTION
## Description

RFC 3 for policy signing is missing some fields on the examples.

Related to: https://github.com/kubewarden/policy-server/issues/142