### PR TITLE
feat: set KUBEWARDEN_SIGSTORE_CACHE_DIR on deployment

### DIFF
--- a/internal/pkg/admission/policy-server-deployment.go
+++ b/internal/pkg/admission/policy-server-deployment.go
@@ -191,10 +191,10 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *policiesv
 		secretsContainerPath             = "/pki"
 		imagePullSecretVolumeName        = "imagepullsecret"
 		dockerConfigJSONPolicyServerPath = "/home/kubewarden/.docker"
+		policyStoreVolume                = "policy-store"
+		policyStoreVolumePath            = "/tmp"
+		sigstoreCacheDirPath             = "/tmp/sigstore-data"
 	)
-
-	policyStoreVolume := "policy-store"
-	policyStoreVolumePath := "/tmp"
 
 	admissionContainer := corev1.Container{
 		Name:  policyServer.NameWithPrefix(),
@@ -235,6 +235,10 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *policiesv
 			{
 				Name:  "KUBEWARDEN_POLICIES",
 				Value: filepath.Join(policiesConfigContainerPath, policiesFilename),
+			},
+			{
+				Name:  "KUBEWARDEN_SIGSTORE_CACHE_DIR",
+				Value: sigstoreCacheDirPath,
 			},
 		}, policyServer.Spec.Env...),
 		ReadinessProbe: &corev1.Probe{


### PR DESCRIPTION
## Description

Needed so policy-server can download the up-to-date Fulcio and Rekor
certs to a non read-only path.

Needed by https://github.com/kubewarden/helm-charts/pull/72.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

Tested manually as part of https://github.com/kubewarden/helm-charts/pull/72.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
