### PR TITLE
Sigstore release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,28 @@
 ## [Unreleased]
 
 
+<a name="v0.5.1"></a>
+## [v0.5.1] - 2022-03-24
+### Features
+- set KUBEWARDEN_SIGSTORE_CACHE_DIR on deployment
+
+### Pull Requests
+- Merge pull request [#193](https://github.com/kubewarden/kubewarden-controller/issues/193) from viccuad/0.5.0-sigstore-cache-dir
+- Merge pull request [#191](https://github.com/kubewarden/kubewarden-controller/issues/191) from kubewarden/renovate/actions-upload-artifact-3.x
+- Merge pull request [#187](https://github.com/kubewarden/kubewarden-controller/issues/187) from kubewarden/renovate/actions-checkout-3.x
+- Merge pull request [#188](https://github.com/kubewarden/kubewarden-controller/issues/188) from kubewarden/renovate/actions-setup-go-3.x
+- Merge pull request [#176](https://github.com/kubewarden/kubewarden-controller/issues/176) from ereslibre/policy-reports
+- Merge pull request [#183](https://github.com/kubewarden/kubewarden-controller/issues/183) from raulcabello/main
+
+
 <a name="v0.5.0"></a>
-## [v0.5.0] - 2022-03-02
+## [v0.5.0] - 2022-03-03
 ### Reverts
 - Group kubernetes dependencies
 - Run e2e test in a self-hosted action runner.
 
 ### Pull Requests
+- Merge pull request [#181](https://github.com/kubewarden/kubewarden-controller/issues/181) from raulcabello/main
 - Merge pull request [#177](https://github.com/kubewarden/kubewarden-controller/issues/177) from raulcabello/main
 - Merge pull request [#174](https://github.com/kubewarden/kubewarden-controller/issues/174) from flavio/main
 - Merge pull request [#172](https://github.com/kubewarden/kubewarden-controller/issues/172) from ereslibre/monitor-mode
@@ -210,7 +225,8 @@
 <a name="v0.0.1"></a>
 ## v0.0.1 - 2021-01-18
 
-[Unreleased]: https://github.com/kubewarden/kubewarden-controller/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/kubewarden/kubewarden-controller/compare/v0.5.1...HEAD
+[v0.5.1]: https://github.com/kubewarden/kubewarden-controller/compare/v0.5.0...v0.5.1
 [v0.5.0]: https://github.com/kubewarden/kubewarden-controller/compare/v0.4.5...v0.5.0
 [v0.4.5]: https://github.com/kubewarden/kubewarden-controller/compare/v0.4.5-rc1...v0.4.5
 [v0.4.5-rc1]: https://github.com/kubewarden/kubewarden-controller/compare/v0.4.4...v0.4.5-rc1

--- a/docs/crds/README.asciidoc
+++ b/docs/crds/README.asciidoc
@@ -14,13 +14,82 @@
 Package v1alpha2 contains API Schema definitions for the policies v1alpha2 API group
 
 .Resource Types
-- xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-clusteradmissionpolicy[$$ClusterAdmissionPolicy$$]
-- xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-clusteradmissionpolicylist[$$ClusterAdmissionPolicyList$$]
 - xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-admissionpolicy[$$AdmissionPolicy$$]
 - xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-admissionpolicylist[$$AdmissionPolicyList$$]
+- xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-clusteradmissionpolicy[$$ClusterAdmissionPolicy$$]
+- xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-clusteradmissionpolicylist[$$ClusterAdmissionPolicyList$$]
 - xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-policyserver[$$PolicyServer$$]
 - xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-policyserverlist[$$PolicyServerList$$]
 
+
+
+[id="{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-admissionpolicy"]
+==== AdmissionPolicy 
+
+AdmissionPolicy is the Schema for the admissionpolicies API
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-admissionpolicylist[$$AdmissionPolicyList$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `policies.kubewarden.io/v1alpha2`
+| *`kind`* __string__ | `AdmissionPolicy`
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-admissionpolicyspec[$$AdmissionPolicySpec$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-admissionpolicylist"]
+==== AdmissionPolicyList 
+
+AdmissionPolicyList contains a list of AdmissionPolicy
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `policies.kubewarden.io/v1alpha2`
+| *`kind`* __string__ | `AdmissionPolicyList`
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`items`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-admissionpolicy[$$AdmissionPolicy$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-admissionpolicyspec"]
+==== AdmissionPolicySpec 
+
+AdmissionPolicySpec defines the desired state of AdmissionPolicy
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-admissionpolicy[$$AdmissionPolicy$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`policyServer`* __string__ | PolicyServer identifies an existing PolicyServer resource.
+| *`module`* __string__ | Module is the location of the WASM module to be loaded. Can be a local file (file://), a remote file served by an HTTP server (http://, https://), or an artifact served by an OCI-compatible registry (registry://).
+| *`mode`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-policymode[$$PolicyMode$$]__ | Mode defines the execution mode of this policy. Can be set to either "protect" or "monitor". If it's empty, it is defaulted to "protect". Transitioning this setting from "monitor" to "protect" is allowed, but is disallowed to transition from "protect" to "monitor". To perform this transition, the policy should be recreated in "monitor" mode instead.
+| *`settings`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | Settings is a free-form object that contains the policy configuration values. x-kubernetes-embedded-resource: false
+| *`rules`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#rulewithoperations-v1-admissionregistration[$$RuleWithOperations$$] array__ | Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule.
+| *`failurePolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#failurepolicytype-v1-admissionregistration[$$FailurePolicyType$$]__ | FailurePolicy defines how unrecognized errors and timeout errors from the policy are handled. Allowed values are "Ignore" or "Fail". * "Ignore" means that an error calling the webhook is ignored and the API   request is allowed to continue. * "Fail" means that an error calling the webhook causes the admission to   fail and the API request to be rejected. The default behaviour is "Fail"
+| *`mutating`* __boolean__ | Mutating indicates whether a policy has the ability to mutate incoming requests or not.
+| *`matchPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#matchpolicytype-v1-admissionregistration[$$MatchPolicyType$$]__ | matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent". 
+ - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook. 
+ - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook. 
+ Defaults to "Equivalent"
+| *`objectSelector`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#labelselector-v1-meta[$$LabelSelector$$]__ | ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
+| *`sideEffects`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#sideeffectclass-v1-admissionregistration[$$SideEffectClass$$]__ | SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
+| *`timeoutSeconds`* __integer__ | TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
+|===
 
 
 [id="{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-clusteradmissionpolicy"]
@@ -77,9 +146,9 @@ ClusterAdmissionPolicySpec defines the desired state of ClusterAdmissionPolicy
 | Field | Description
 | *`policyServer`* __string__ | PolicyServer identifies an existing PolicyServer resource.
 | *`module`* __string__ | Module is the location of the WASM module to be loaded. Can be a local file (file://), a remote file served by an HTTP server (http://, https://), or an artifact served by an OCI-compatible registry (registry://).
-| *`mode`* __PolicyMode__ | Mode defines the execution mode of this policy. Can be set to either "protect" or "monitor". If it's empty, it is defaulted to "protect". Transitioning this setting from "monitor" to "protect" is allowed, but is disallowed to transition from "protect" to "monitor". To perform this transition, the policy should be recreated in "monitor" mode instead.
+| *`mode`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-policymode[$$PolicyMode$$]__ | Mode defines the execution mode of this policy. Can be set to either "protect" or "monitor". If it's empty, it is defaulted to "protect". Transitioning this setting from "monitor" to "protect" is allowed, but is disallowed to transition from "protect" to "monitor". To perform this transition, the policy should be recreated in "monitor" mode instead.
 | *`settings`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | Settings is a free-form object that contains the policy configuration values. x-kubernetes-embedded-resource: false
-| *`rules`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#rulewithoperations-v1-admissionregistration[$$RuleWithOperations$$] array__ | Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule.
+| *`rules`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#rulewithoperations-v1-admissionregistration[$$RuleWithOperations$$]__ | Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule.
 | *`failurePolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#failurepolicytype-v1-admissionregistration[$$FailurePolicyType$$]__ | FailurePolicy defines how unrecognized errors and timeout errors from the policy are handled. Allowed values are "Ignore" or "Fail". * "Ignore" means that an error calling the webhook is ignored and the API   request is allowed to continue. * "Fail" means that an error calling the webhook causes the admission to   fail and the API request to be rejected. The default behaviour is "Fail"
 | *`mutating`* __boolean__ | Mutating indicates whether a policy has the ability to mutate incoming requests or not.
 | *`matchPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#matchpolicytype-v1-admissionregistration[$$MatchPolicyType$$]__ | matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent". 
@@ -97,73 +166,18 @@ ClusterAdmissionPolicySpec defines the desired state of ClusterAdmissionPolicy
 |===
 
 
-[id="{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-admissionpolicy"]
-==== AdmissionPolicy
 
-AdmissionPolicy is the Schema for the admissionpolicies API
+
+[id="{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-policymode"]
+==== PolicyMode (string) 
+
+
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-admissionpolicylist[$$AdmissionPolicyList$$]
+- xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-admissionpolicyspec[$$AdmissionPolicySpec$$]
+- xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-clusteradmissionpolicyspec[$$ClusterAdmissionPolicySpec$$]
 ****
-
-[cols="25a,75a", options="header"]
-|===
-| Field | Description
-| *`apiVersion`* __string__ | `policies.kubewarden.io/v1alpha2`
-| *`kind`* __string__ | `AdmissionPolicy`
-| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
-
-| *`spec`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-admissionpolicyspec[$$AdmissionPolicySpec$$]__ |
-|===
-
-
-[id="{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-admissionpolicylist"]
-==== AdmissionPolicyList
-
-AdmissionPolicyList contains a list of AdmissionPolicy
-
-
-
-[cols="25a,75a", options="header"]
-|===
-| Field | Description
-| *`apiVersion`* __string__ | `policies.kubewarden.io/v1alpha2`
-| *`kind`* __string__ | `AdmissionPolicyList`
-| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
-
-| *`items`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-admissionpolicy[$$AdmissionPolicy$$]__ |
-|===
-
-
-[id="{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-admissionpolicyspec"]
-==== AdmissionPolicySpec
-
-AdmissionPolicySpec defines the desired state of AdmissionPolicy
-
-.Appears In:
-****
-- xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-admissionpolicy[$$AdmissionPolicy$$]
-****
-
-[cols="25a,75a", options="header"]
-|===
-| Field | Description
-| *`policyServer`* __string__ | PolicyServer identifies an existing PolicyServer resource.
-| *`module`* __string__ | Module is the location of the WASM module to be loaded. Can be a local file (file://), a remote file served by an HTTP server (http://, https://), or an artifact served by an OCI-compatible registry (registry://).
-| *`mode`* __PolicyMode__ | Mode defines the execution mode of this policy. Can be set to either "protect" or "monitor". If it's empty, it is defaulted to "protect". Transitioning this setting from "monitor" to "protect" is allowed, but is disallowed to transition from "protect" to "monitor". To perform this transition, the policy should be recreated in "monitor" mode instead.
-| *`settings`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | Settings is a free-form object that contains the policy configuration values. x-kubernetes-embedded-resource: false
-| *`rules`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#rulewithoperations-v1-admissionregistration[$$RuleWithOperations$$] array__ | Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule.
-| *`failurePolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#failurepolicytype-v1-admissionregistration[$$FailurePolicyType$$]__ | FailurePolicy defines how unrecognized errors and timeout errors from the policy are handled. Allowed values are "Ignore" or "Fail". * "Ignore" means that an error calling the webhook is ignored and the API   request is allowed to continue. * "Fail" means that an error calling the webhook causes the admission to   fail and the API request to be rejected. The default behaviour is "Fail"
-| *`mutating`* __boolean__ | Mutating indicates whether a policy has the ability to mutate incoming requests or not.
-| *`matchPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#matchpolicytype-v1-admissionregistration[$$MatchPolicyType$$]__ | matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
-- Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.
-- Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.
-Defaults to "Equivalent"
-| *`objectSelector`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#labelselector-v1-meta[$$LabelSelector$$]__ | ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
-| *`sideEffects`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#sideeffectclass-v1-admissionregistration[$$SideEffectClass$$]__ | SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
-| *`timeoutSeconds`* __integer__ | TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
-|===
 
 
 
@@ -230,6 +244,20 @@ PolicyServerSpec defines the desired state of PolicyServer
 | *`verificationConfig`* __string__ | Name of VerificationConfig configmap in the same namespace, containing Sigstore verification configuration. The configuration must be under a key named verification-config in the Configmap.
 |===
 
+
+
+
+
+
+[id="{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-policystatusenum"]
+==== PolicyStatusEnum (string) 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-policystatus[$$PolicyStatus$$]
+****
 
 
 


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Simple v0.5.1 release containing updated docs/crds and https://github.com/kubewarden/kubewarden-controller/pull/193.

Needed by https://github.com/kubewarden/helm-charts/pull/72.

After this is merged, I will continue with https://github.com/kubewarden/kubewarden-controller/blob/main/CONTRIBUTING.md#push-new-tag-to-the-upstream-repository, tagging and pushing a new tag for GHA to do its things.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

