### PR TITLE
fix: Disable cert-manager ca injection patches in CRDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ testbin/*
 *.swp
 *.swo
 *~
+
+# Manually generated crds. Directory is needed though
+generated-crds/*

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,10 @@ unit-tests: manifests generate fmt vet envtest ## Run unit tests.
 integration-tests: manifests generate fmt vet envtest ## Run integration tests.
 	ACK_GINKGO_DEPRECATIONS=1.16.4 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./apis/... ./controllers/... -ginkgo.v -ginkgo.progress -test.v -coverprofile cover.out
 
+.PHONY: generate-crds
+generate-crds: manifests kustomize ## generate final crds with kustomize. Normally shipped in Helm charts.
+	$(KUSTOMIZE) build config/crd -o generated-crds # If -o points to a folder, kustomize saves them as several files instead of 1
+
 ##@ Build
 
 build: generate fmt vet ## Build manager binary.

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -17,9 +17,9 @@ patchesStrategicMerge:
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-- patches/cainjection_in_clusteradmissionpolicies.yaml
-- patches/cainjection_in_policyservers.yaml
-- patches/cainjection_in_admissionpolicies.yaml
+# - patches/cainjection_in_clusteradmissionpolicies.yaml
+# - patches/cainjection_in_policyservers.yaml
+# - patches/cainjection_in_admissionpolicies.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.


### PR DESCRIPTION

## Description

- fix: Disable cert-manager ca injection patches in CRDs
  These are not needed; we only need them on the webhooks.
Leaving the patches files themselves, as they are automatically
generated.

- build: Add `make generate-crds` for final CRDs that go to Helm charts
 This allows further automation when releasing Helm charts.

## Test

Generated crds by manually running `make generate-crds`

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
