### PR TITLE
fix: Disable conversion webhooks on CRDs, not needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ integration-tests: manifests generate fmt vet envtest ## Run integration tests.
 
 .PHONY: generate-crds
 generate-crds: manifests kustomize ## generate final crds with kustomize. Normally shipped in Helm charts.
+	mkdir -p generated-crds
 	$(KUSTOMIZE) build config/crd -o generated-crds # If -o points to a folder, kustomize saves them as several files instead of 1
 
 ##@ Build

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -10,9 +10,9 @@ resources:
 patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-- patches/webhook_in_clusteradmissionpolicies.yaml
-- patches/webhook_in_policyservers.yaml
-- patches/webhook_in_admissionpolicies.yaml
+#- patches/webhook_in_clusteradmissionpolicies.yaml
+#- patches/webhook_in_policyservers.yaml
+#- patches/webhook_in_admissionpolicies.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.


### PR DESCRIPTION
## Description

- fix: Disable conversion webhooks on CRDs, not needed. Thanks @Rafa for realizing!
- build: Create generated-crds dir if doesn't exist.
  I thought I did it on the previous pr..

## Test

Locally with `make generate-crds`.

