### PR TITLE
Pod permissions.

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -55,6 +55,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - policies.kubewarden.io
   resources:
   - admissionpolicies

--- a/controllers/admissionpolicy_controller.go
+++ b/controllers/admissionpolicy_controller.go
@@ -39,6 +39,7 @@ import (
 //+kubebuilder:rbac:groups=policies.kubewarden.io,resources=admissionpolicies,verbs=get;list;watch;delete
 //+kubebuilder:rbac:groups=policies.kubewarden.io,resources=admissionpolicies/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=policies.kubewarden.io,resources=admissionpolicies/finalizers,verbs=update
+//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 
 // AdmissionPolicyReconciler reconciles an AdmissionPolicy object
 type AdmissionPolicyReconciler struct {

--- a/controllers/clusteradmissionpolicy_controller.go
+++ b/controllers/clusteradmissionpolicy_controller.go
@@ -39,6 +39,7 @@ import (
 //+kubebuilder:rbac:groups=policies.kubewarden.io,resources=clusteradmissionpolicies,verbs=get;list;watch;delete
 //+kubebuilder:rbac:groups=policies.kubewarden.io,resources=clusteradmissionpolicies/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=policies.kubewarden.io,resources=clusteradmissionpolicies/finalizers,verbs=update
+//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 
 // ClusterAdmissionPolicyReconciler reconciles a ClusterAdmissionPolicy object
 type ClusterAdmissionPolicyReconciler struct {


### PR DESCRIPTION
## Description

Adds permissions allowing the controller to get,list and watch pods in the cluster. This is necessary because of the latest changes in the controller where it watches pods.
