### PR TITLE
Add PolicyActive condition.

### DIFF
--- a/controllers/admissionpolicy_controller_test.go
+++ b/controllers/admissionpolicy_controller_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Given an AdmissionPolicy", func() {
 							k8sClient.Create(ctx, policyServer(policyServerName)),
 						).To(HaveSucceededOrAlreadyExisted())
 					})
-					It(fmt.Sprintf("should set its policy status to %q", v1alpha2.PolicyStatusPending), func() {
+					It(fmt.Sprintf("should set its policy status to %q", v1alpha2.PolicyStatusActive), func() {
 						Eventually(func(g Gomega) (*v1alpha2.AdmissionPolicy, error) {
 							return getFreshAdmissionPolicy(policyNamespace, policyName)
 						}, 30*time.Second, 250*time.Millisecond).Should(
@@ -95,7 +95,7 @@ var _ = Describe("Given an AdmissionPolicy", func() {
 								func(admissionPolicy *v1alpha2.AdmissionPolicy) v1alpha2.PolicyStatusEnum {
 									return admissionPolicy.Status.PolicyStatus
 								},
-								Equal(v1alpha2.PolicyStatusPending),
+								Equal(v1alpha2.PolicyStatusActive),
 							),
 						)
 					})

--- a/controllers/clusteradmissionpolicy_controller_test.go
+++ b/controllers/clusteradmissionpolicy_controller_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Given a ClusterAdmissionPolicy", func() {
 							k8sClient.Create(ctx, policyServer(policyServerName)),
 						).To(HaveSucceededOrAlreadyExisted())
 					})
-					It(fmt.Sprintf("should set its policy status to %q", v1alpha2.PolicyStatusPending), func() {
+					It(fmt.Sprintf("should set its policy status to %q", v1alpha2.PolicyStatusActive), func() {
 						Eventually(func(g Gomega) (*v1alpha2.ClusterAdmissionPolicy, error) {
 							return getFreshClusterAdmissionPolicy(policyName)
 						}, 30*time.Second, 250*time.Millisecond).Should(
@@ -87,7 +87,7 @@ var _ = Describe("Given a ClusterAdmissionPolicy", func() {
 								func(clusterAdmissionPolicy *v1alpha2.ClusterAdmissionPolicy) v1alpha2.PolicyStatusEnum {
 									return clusterAdmissionPolicy.Status.PolicyStatus
 								},
-								Equal(v1alpha2.PolicyStatusPending),
+								Equal(v1alpha2.PolicyStatusActive),
 							),
 						)
 					})


### PR DESCRIPTION
Updates the policy reconciliation loop to set the PolicyActive condition to true when the policy status is updated to "active".


## Test
You can test this manually or using the e2e test repository. 

If you want to test it using e2e tests. You need to follow some steps:

```shell
# upload the container image somewhere
# update the makefile setting the container name and tag to be used
 make create-k8s-cluster install-kubewarden basic-e2e-test
```
