### PR TITLE
Add `always-accept-admission-reviews-on-deployments-namespace` flag

### DIFF
--- a/internal/pkg/admission/policy-server-deployment.go
+++ b/internal/pkg/admission/policy-server-deployment.go
@@ -196,6 +196,12 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *v1alpha2.
 			},
 		},
 	}
+	if r.AlwaysAcceptAdmissionReviewsInDeploymentsNamespace {
+		admissionContainer.Env = append(admissionContainer.Env, corev1.EnvVar{
+			Name:  "ALWAYS_ACCEPT_ADMISSION_REVIEWS_ON_NAMESPACE",
+			Value: r.DeploymentsNamespace,
+		})
+	}
 	if policyServer.Spec.VerificationConfig != "" {
 		admissionContainer.VolumeMounts = append(admissionContainer.VolumeMounts,
 			corev1.VolumeMount{

--- a/internal/pkg/admission/reconciler.go
+++ b/internal/pkg/admission/reconciler.go
@@ -21,10 +21,11 @@ import (
 )
 
 type Reconciler struct {
-	Client               client.Client
-	APIReader            client.Reader
-	DeploymentsNamespace string
-	Log                  logr.Logger
+	Client                                             client.Client
+	APIReader                                          client.Reader
+	DeploymentsNamespace                               string
+	AlwaysAcceptAdmissionReviewsInDeploymentsNamespace bool
+	Log                                                logr.Logger
 }
 
 type reconcilerErrors []error

--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var deploymentsNamespace string
+	var alwaysAcceptAdmissionReviewsOnDeploymentsNamespace bool
 	var probeAddr string
 	var enableMetrics bool
 	var openTelemetryEndpoint string
@@ -79,6 +80,10 @@ func main() {
 		"deployments-namespace",
 		"",
 		"The namespace where the kubewarden resources will be created.")
+	flag.BoolVar(&alwaysAcceptAdmissionReviewsOnDeploymentsNamespace,
+		"always-accept-admission-reviews-on-deployments-namespace",
+		false,
+		"Always accept admission reviews targeting the deployments-namespace.")
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
@@ -123,6 +128,7 @@ func main() {
 		APIReader:            mgr.GetAPIReader(),
 		Log:                  ctrl.Log.WithName("reconciler"),
 		DeploymentsNamespace: deploymentsNamespace,
+		AlwaysAcceptAdmissionReviewsInDeploymentsNamespace: alwaysAcceptAdmissionReviewsOnDeploymentsNamespace,
 	}
 
 	if err = (&controllers.PolicyServerReconciler{


### PR DESCRIPTION
Depends on: https://github.com/kubewarden/policy-server/pull/247

This allows the user to configure the controller in a way that when it
reconciles the policy-server deployment, the policy-server will be
configured in a way to always accept requests targeting the namespace
where policy-servers are running (the provided
`--deployments-namespace` argument in the controller)