### PR TITLE
Fix the policy server env var name.

### DIFF
--- a/internal/pkg/admission/policy-server-deployment.go
+++ b/internal/pkg/admission/policy-server-deployment.go
@@ -250,7 +250,7 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *v1alpha2.
 	}
 	if r.AlwaysAcceptAdmissionReviewsInDeploymentsNamespace {
 		admissionContainer.Env = append(admissionContainer.Env, corev1.EnvVar{
-			Name:  "ALWAYS_ACCEPT_ADMISSION_REVIEWS_ON_NAMESPACE",
+			Name:  "KUBEWARDEN_ALWAYS_ACCEPT_ADMISSION_REVIEWS_ON_NAMESPACE",
 			Value: r.DeploymentsNamespace,
 		})
 	}


### PR DESCRIPTION
Updates the env var name used to define the namespace which the policy server should always accept the request.

This PR is necessary after a change done in the review process of the https://github.com/kubewarden/policy-server/pull/247
