### PR TITLE
Skip Kubewarden namespace in the webhook configuration.

### DIFF
--- a/internal/pkg/admission/mutating-webhook.go
+++ b/internal/pkg/admission/mutating-webhook.go
@@ -95,7 +95,7 @@ func (r *Reconciler) mutatingWebhookConfiguration(
 				Rules:                   policy.GetRules(),
 				FailurePolicy:           policy.GetFailurePolicy(),
 				MatchPolicy:             policy.GetMatchPolicy(),
-				NamespaceSelector:       policy.GetNamespaceSelector(),
+				NamespaceSelector:       r.webhookNamespaceSelector(policy),
 				ObjectSelector:          policy.GetObjectSelector(),
 				SideEffects:             sideEffects,
 				TimeoutSeconds:          policy.GetTimeoutSeconds(),

--- a/internal/pkg/admission/policy-server-deployment.go
+++ b/internal/pkg/admission/policy-server-deployment.go
@@ -248,12 +248,6 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *v1alpha2.
 			},
 		},
 	}
-	if r.AlwaysAcceptAdmissionReviewsInDeploymentsNamespace {
-		admissionContainer.Env = append(admissionContainer.Env, corev1.EnvVar{
-			Name:  "KUBEWARDEN_ALWAYS_ACCEPT_ADMISSION_REVIEWS_ON_NAMESPACE",
-			Value: r.DeploymentsNamespace,
-		})
-	}
 	if policyServer.Spec.VerificationConfig != "" {
 		admissionContainer.VolumeMounts = append(admissionContainer.VolumeMounts,
 			corev1.VolumeMount{

--- a/internal/pkg/admission/validating-webhook.go
+++ b/internal/pkg/admission/validating-webhook.go
@@ -95,7 +95,7 @@ func (r *Reconciler) validatingWebhookConfiguration(
 				Rules:                   policy.GetRules(),
 				FailurePolicy:           policy.GetFailurePolicy(),
 				MatchPolicy:             policy.GetMatchPolicy(),
-				NamespaceSelector:       policy.GetNamespaceSelector(),
+				NamespaceSelector:       r.webhookNamespaceSelector(policy),
 				ObjectSelector:          policy.GetObjectSelector(),
 				SideEffects:             sideEffects,
 				TimeoutSeconds:          policy.GetTimeoutSeconds(),

--- a/internal/pkg/admission/webhook_utils.go
+++ b/internal/pkg/admission/webhook_utils.go
@@ -1,0 +1,25 @@
+package admission
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubewarden/kubewarden-controller/apis/v1alpha2"
+)
+
+func (r *Reconciler) webhookNamespaceSelector(policy v1alpha2.Policy) *metav1.LabelSelector {
+	namespaceSelector := policy.GetNamespaceSelector()
+	if r.AlwaysAcceptAdmissionReviewsInDeploymentsNamespace {
+		if namespaceSelector == nil {
+			namespaceSelector = &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{},
+			}
+		}
+		skipKubewardenNamespaceSelector := metav1.LabelSelectorRequirement{
+			Key:      "kubernetes.io/metadata.name",
+			Operator: metav1.LabelSelectorOpNotIn,
+			Values:   []string{r.DeploymentsNamespace},
+		}
+		namespaceSelector.MatchExpressions = append(namespaceSelector.MatchExpressions, skipKubewardenNamespaceSelector)
+	}
+	return namespaceSelector
+}

--- a/internal/pkg/constants/constants.go
+++ b/internal/pkg/constants/constants.go
@@ -45,6 +45,9 @@ const (
 	// Finalizers
 	KubewardenFinalizer = "kubewarden"
 
-	// Kubernetes
+	// Kubernetes annotations
 	KubernetesRevisionAnnotation = "deployment.kubernetes.io/revision"
+
+	// Kubernetes labels
+	KubernetesNamespaceNameLabel = "kubernetes.io/metadata.name"
 )


### PR DESCRIPTION
Updates the reconciler to add a namespace selector in the webhooks configuration to skip request from the Kubewarden's namespace. Therefore, avoiding issues during the policy server rollout due request being rejected by the old policy server instance.
