### PR TITLE
test: Pin golanci-lint in GHA from latest to 1.45.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,4 +22,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: v1.45.2


### PR DESCRIPTION
This should solve the lint problems for now, but it's not a permanent
solution.

## Description

Related to https://github.com/kubewarden/kubewarden-controller/issues/217, but I don't consider it enough to close the card.