### PR TITLE
feat: sign container image

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -33,6 +33,6 @@ jobs:
       - name: Sign the images
         run: |
           cosign sign \
-            ${{needs.build.outputs.repository}}:${{needs.build.outputs.tag}}
+            ${{needs.build.outputs.repository}}@${{needs.build.outputs.digest}}
         env:
           COSIGN_EXPERIMENTAL: 1

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -14,3 +14,25 @@ jobs:
     uses: kubewarden/kubewarden-controller/.github/workflows/container-image.yml@main
     with:
       push-image: true
+
+  sign:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      id-token: write
+    needs: build
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: sigstore/cosign-installer@main
+      - name: Sign the images
+        run: |
+          cosign sign \
+            ${{needs.build.outputs.repository}}:${{needs.build.outputs.tag}}
+        env:
+          COSIGN_EXPERIMENTAL: 1

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -30,6 +30,7 @@ jobs:
       repository: ${{ steps.setoutput.outputs.repository }}
       tag: ${{ steps.setoutput.outputs.tag }}
       artifact: ${{ steps.setoutput.outputs.artifact }}
+      digest: ${{ steps.setoutput.outputs.digest }}
     steps:
       -
         name: Checkout code

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -16,6 +16,9 @@ on:
       artifact:
         description: "Uploaded artifact with the container tarball"
         value: ${{ jobs.build.outputs.artifact }}
+      digest:
+        description: "Image digest"
+        value: ${{ jobs.build.outputs.digest }}
 
 
 
@@ -57,6 +60,7 @@ jobs:
       -
         name: Build and push container image
         if: ${{ inputs.push-image }}
+        id: build-image
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -93,3 +97,5 @@ jobs:
           echo "::set-output name=repository::ghcr.io/${{github.repository_owner}}/kubewarden-controller"
           echo "::set-output name=tag::${{ env.TAG_NAME }}"
           echo "::set-output name=artifact::kubewarden-controller-image-${{env.TAG_NAME}}"
+          echo "::set-output name=digest::${{ steps.build-image.outputs.digest }}"
+


### PR DESCRIPTION
Use cosign keyless to sign the kubewarden-controller image. 

I tested in my fork. You can see the [github actions](https://github.com/raulcabello/kubewarden-controller/actions) and you can verify the signature with:
```
COSIGN_EXPERIMENTAL=1 cosign verify ghcr.io/raulcabello/kubewarden-controller:latest | jq
```



Fix #230 
