### PR TITLE
Fix golangci-linter warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,11 +42,13 @@ linters:
     - gocognit
     - godot
     - goerr113
+    - golint
     - gofumpt
     - gomnd
     - maligned
     - nlreturn
     - paralleltest
+    - scopelint
     - testpackage
     - wsl
     - lll # long lines


### PR DESCRIPTION
Disable linters that have been deprecated
