### PR TITLE
feat: don't mark policy as uniquely reachable until all terminating pods have disappeared.

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -14,7 +14,7 @@ jobs:
   run-e2e-tests:
     name: "Tests"
     needs: [build]
-    uses: kubewarden/kubewarden-end-to-end-tests/.github/workflows/e2e-tests.yml@v0.2.1
+    uses: kubewarden/kubewarden-end-to-end-tests/.github/workflows/e2e-tests.yml@v0.2.2
     with:
       controller-image-repository: ${{ needs.build.outputs.repository }}
       controller-image-tag: ${{ needs.build.outputs.tag }}

--- a/controllers/policystatus_utils.go
+++ b/controllers/policystatus_utils.go
@@ -122,9 +122,6 @@ func isPolicyUniquelyReachable(ctx context.Context, apiReader client.Reader, pol
 		return false
 	}
 	for _, pod := range pods.Items {
-		if pod.DeletionTimestamp != nil {
-			continue
-		}
 		if pod.Labels[appsv1.DefaultDeploymentUniqueLabelKey] != podTemplateHash || !isPodReady(pod) {
 			return false
 		}


### PR DESCRIPTION
## Description

Don't skip pods with deletion timestamp in the isUniquelyReachable method

Fix https://github.com/kubewarden/kubewarden-controller/issues/242
