### PR TITLE
remove v1alpha2 from the webhooks

### DIFF
--- a/apis/policies/v1/admissionpolicy_webhook.go
+++ b/apis/policies/v1/admissionpolicy_webhook.go
@@ -41,7 +41,7 @@ func (r *AdmissionPolicy) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return nil
 }
 
-//+kubebuilder:webhook:path=/mutate-policies-kubewarden-io-v1-admissionpolicy,mutating=true,failurePolicy=fail,sideEffects=None,groups=policies.kubewarden.io,resources=admissionpolicies,verbs=create;update,versions=v1;v1alpha2,name=madmissionpolicy.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-policies-kubewarden-io-v1-admissionpolicy,mutating=true,failurePolicy=fail,sideEffects=None,groups=policies.kubewarden.io,resources=admissionpolicies,verbs=create;update,versions=v1,name=madmissionpolicy.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &AdmissionPolicy{}
 
@@ -56,7 +56,7 @@ func (r *AdmissionPolicy) Default() {
 	}
 }
 
-//+kubebuilder:webhook:path=/validate-policies-kubewarden-io-v1-admissionpolicy,mutating=false,failurePolicy=fail,sideEffects=None,groups=policies.kubewarden.io,resources=admissionpolicies,verbs=create;update,versions=v1alpha2;v1,name=vadmissionpolicy.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-policies-kubewarden-io-v1-admissionpolicy,mutating=false,failurePolicy=fail,sideEffects=None,groups=policies.kubewarden.io,resources=admissionpolicies,verbs=create;update,versions=v1,name=vadmissionpolicy.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &AdmissionPolicy{}
 

--- a/apis/policies/v1/clusteradmissionpolicy_webhook.go
+++ b/apis/policies/v1/clusteradmissionpolicy_webhook.go
@@ -46,7 +46,7 @@ func (r *ClusterAdmissionPolicy) SetupWebhookWithManager(mgr ctrl.Manager) error
 	return nil
 }
 
-//+kubebuilder:webhook:path=/mutate-policies-kubewarden-io-v1-clusteradmissionpolicy,mutating=true,failurePolicy=fail,sideEffects=None,groups=policies.kubewarden.io,resources=clusteradmissionpolicies,verbs=create;update,versions=v1;v1alpha2,name=mclusteradmissionpolicy.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-policies-kubewarden-io-v1-clusteradmissionpolicy,mutating=true,failurePolicy=fail,sideEffects=None,groups=policies.kubewarden.io,resources=clusteradmissionpolicies,verbs=create;update,versions=v1,name=mclusteradmissionpolicy.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &ClusterAdmissionPolicy{}
 
@@ -61,7 +61,7 @@ func (r *ClusterAdmissionPolicy) Default() {
 	}
 }
 
-//+kubebuilder:webhook:path=/validate-policies-kubewarden-io-v1-clusteradmissionpolicy,mutating=false,failurePolicy=fail,sideEffects=None,groups=policies.kubewarden.io,resources=clusteradmissionpolicies,verbs=create;update,versions=v1alpha2;v1,name=vclusteradmissionpolicy.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-policies-kubewarden-io-v1-clusteradmissionpolicy,mutating=false,failurePolicy=fail,sideEffects=None,groups=policies.kubewarden.io,resources=clusteradmissionpolicies,verbs=create;update,versions=v1,name=vclusteradmissionpolicy.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &ClusterAdmissionPolicy{}
 

--- a/apis/policies/v1/policyserver_webhook.go
+++ b/apis/policies/v1/policyserver_webhook.go
@@ -39,7 +39,7 @@ func (ps *PolicyServer) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return nil
 }
 
-//+kubebuilder:webhook:path=/mutate-policies-kubewarden-io-v1-policyserver,mutating=true,failurePolicy=fail,sideEffects=None,groups=policies.kubewarden.io,resources=policyservers,verbs=create;update,versions=v1;v1alpha2,name=mpolicyserver.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-policies-kubewarden-io-v1-policyserver,mutating=true,failurePolicy=fail,sideEffects=None,groups=policies.kubewarden.io,resources=policyservers,verbs=create;update,versions=v1,name=mpolicyserver.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &PolicyServer{}
 

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -20,7 +20,6 @@ webhooks:
     - policies.kubewarden.io
     apiVersions:
     - v1
-    - v1alpha2
     operations:
     - CREATE
     - UPDATE
@@ -42,7 +41,6 @@ webhooks:
     - policies.kubewarden.io
     apiVersions:
     - v1
-    - v1alpha2
     operations:
     - CREATE
     - UPDATE
@@ -64,7 +62,6 @@ webhooks:
     - policies.kubewarden.io
     apiVersions:
     - v1
-    - v1alpha2
     operations:
     - CREATE
     - UPDATE
@@ -92,7 +89,6 @@ webhooks:
   - apiGroups:
     - policies.kubewarden.io
     apiVersions:
-    - v1alpha2
     - v1
     operations:
     - CREATE
@@ -114,7 +110,6 @@ webhooks:
   - apiGroups:
     - policies.kubewarden.io
     apiVersions:
-    - v1alpha2
     - v1
     operations:
     - CREATE


### PR DESCRIPTION
We are converting v1alpha2 resources into v1 using the none conversion strategy
If we add both apiVersions v1 and v1alpha2 to the webhooks we can't create v1alpha2 resources

Removed in the helm charts too https://github.com/kubewarden/helm-charts/pull/103