### PR TITLE
Configuration to disable SBOM generation.

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -6,6 +6,10 @@ on:
       push-image:
         type: boolean
         required: true
+      generate-sbom:
+        type: boolean
+        required: false
+        default: true
     outputs:
       repository:
         description: "Repository used to build the container image"
@@ -55,10 +59,12 @@ jobs:
           go-version: '1.17'
       -
         name: Install the bom command
+        if: ${{ inputs.generate-sbom == true }}
         shell: bash
         run: go install sigs.k8s.io/bom/cmd/bom@v0.2.2
       -
         name: Install Cosign
+        if: ${{ inputs.generate-sbom == true }}
         uses: sigstore/cosign-installer@main
       -
         name: Retrieve tag name
@@ -98,11 +104,13 @@ jobs:
             ghcr.io/${{github.repository_owner}}/kubewarden-controller:${{ env.TAG_NAME }}
       -
         name: Create SBOM file
+        if: ${{ inputs.generate-sbom == true }}
         shell: bash
         run: |
           bom generate -n https://kubewarden.io/kubewarden.spdx -o kubewarden-controller.spdx .
       -
         name: Attach SBOM file in the container image
+        if: ${{ inputs.generate-sbom == true }}
         shell: bash
         run: |
           set -e

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,6 +11,7 @@ jobs:
     uses: kubewarden/kubewarden-controller/.github/workflows/container-image.yml@main
     with:
       push-image: false
+      generate-sbom: false
   run-e2e-tests:
     name: "Tests"
     needs: [build]


### PR DESCRIPTION
Run running the E2E tests is not necessary generate the SBOM file. Therefore, the workflow used to build the container and generate the SBOM file now has a configuration to disable the SBOM file generation.