### PR TITLE
Update policy server security context.

### DIFF
--- a/internal/pkg/admission/policy-server-deployment.go
+++ b/internal/pkg/admission/policy-server-deployment.go
@@ -330,8 +330,19 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *policiesv
 		)
 	}
 	enableReadOnlyFilesystem := true
+	privileged := false
+	runAsNonRoot := true
+	allowPrivilegeEscalation := false
+	capabilities := corev1.Capabilities{
+		Add:  []corev1.Capability{},
+		Drop: []corev1.Capability{"all"},
+	}
 	admissionContainerSecurityContext := corev1.SecurityContext{
-		ReadOnlyRootFilesystem: &enableReadOnlyFilesystem,
+		ReadOnlyRootFilesystem:   &enableReadOnlyFilesystem,
+		Privileged:               &privileged,
+		AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+		Capabilities:             &capabilities,
+		RunAsNonRoot:             &runAsNonRoot,
 	}
 	admissionContainer.SecurityContext = &admissionContainerSecurityContext
 


### PR DESCRIPTION
Updates the code where the policy server is created to configure the securityContext of the Policy Server container. The process cannot run in a privileged container, cannot run with root user, can run on a read only file system and all the capabilities are dropped.

Fix #203 
