### PR TITLE
Use main e2e tests branch instead of tag

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,7 +15,7 @@ jobs:
   run-e2e-tests:
     name: "Tests"
     needs: [build]
-    uses: kubewarden/kubewarden-end-to-end-tests/.github/workflows/e2e-tests.yml@v0.2.2
+    uses: kubewarden/kubewarden-end-to-end-tests/.github/workflows/e2e-tests.yml@main
     with:
       controller-image-repository: ${{ needs.build.outputs.repository }}
       controller-image-tag: ${{ needs.build.outputs.tag }}


### PR DESCRIPTION
## Description

Second part of https://github.com/kubewarden/kubewarden-end-to-end-tests/pull/32#discussion_r934788987 for switching to main branch
