### PR TITLE
ci: Use actions/create-release

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,4 +22,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: v1.47.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          name: Release kubewarden-controller ${{ github.ref }}
+          name: Release kubewarden-controller ${{ GITHUB_REF_NAME }}
           draft: false
           prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
           files: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,6 +56,7 @@ linters:
     - interfacer
     # TODO: enable once we can set some exceptions
     - funlen
+    - ifshort # deprecated
 
 linters-settings:
   cyclop:

--- a/apis/policies/v1/webhook_suite_test.go
+++ b/apis/policies/v1/webhook_suite_test.go
@@ -123,7 +123,7 @@ var _ = BeforeSuite(func() {
 	dialer := &net.Dialer{Timeout: time.Second}
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
-		// nolint:gosec
+		//nolint:gosec
 		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
 		if err != nil {
 			return fmt.Errorf("failed polling webhook server: %w", err)
@@ -166,7 +166,7 @@ func makeClusterAdmissionPolicyTemplate(name, namespace, policyServerName string
 	}
 }
 
-// nolint: dupl
+//nolint: dupl
 func deleteClusterAdmissionPolicy(ctx context.Context, name, namespace string) {
 	nsn := types.NamespacedName{
 		Name:      name,
@@ -211,7 +211,7 @@ func makePolicyServerTemplate(name, namespace string) *PolicyServer {
 	}
 }
 
-// nolint: dupl
+//nolint: dupl
 func deletePolicyServer(ctx context.Context, name, namespace string) {
 	nsn := types.NamespacedName{
 		Name:      name,

--- a/internal/pkg/admission/policy-server-ca-secret_test.go
+++ b/internal/pkg/admission/policy-server-ca-secret_test.go
@@ -22,7 +22,7 @@ func TestFetchOrInitializePolicyServerCARootSecret(t *testing.T) {
 	admissionregCA, err := admissionregistration.GenerateCA()
 	generateCACalled := false
 
-	// nolint: wrapcheck
+	//nolint: wrapcheck
 	generateCAFunc := func() (*admissionregistration.CA, error) {
 		generateCACalled = true
 		return admissionregCA, err
@@ -79,7 +79,7 @@ func TestFetchOrInitializePolicyServerSecret(t *testing.T) {
 	admissionregCA, _ := admissionregistration.GenerateCA()
 	caSecret := &corev1.Secret{Data: map[string][]byte{constants.PolicyServerCARootCACert: admissionregCA.CaCert, constants.PolicyServerCARootPrivateKeyCertName: x509.MarshalPKCS1PrivateKey(admissionregCA.CaPrivateKey)}}
 
-	// nolint:unparam
+	//nolint:unparam
 	generateCertFunc := func(ca []byte, commonName string, extraSANs []string, CAPrivateKey *rsa.PrivateKey) ([]byte, []byte, error) {
 		generateCertCalled = true
 		return servingCert, servingKey, nil

--- a/internal/pkg/admission/policy-server-configmap.go
+++ b/internal/pkg/admission/policy-server-configmap.go
@@ -39,7 +39,7 @@ type policyServerSourceAuthority struct {
 	Data string              `json:"data"` // contains a PEM encoded certificate
 }
 
-// nolint:tagliatelle
+//nolint:tagliatelle
 type policyServerSourcesEntry struct {
 	InsecureSources   []string                                 `json:"insecure_sources,omitempty"`
 	SourceAuthorities map[string][]policyServerSourceAuthority `json:"source_authorities,omitempty"`


### PR DESCRIPTION
This is the offical GH action for releases, and we use it in kwctl and
others.

With this, I hope that release naming will be fixed to
  `Release kubewarden-controller v1.1.0`
from
  `Release kubewarden-controller refs/tags/v1.1.0`
