### PR TITLE
Change SBOM file names and  adds SBOM section in the README file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,13 +33,13 @@ jobs:
       - name: Create SBOM file
         shell: bash
         run: |
-          bom generate -n https://kubewarden.io/kubewarden.spdx -o kubewarden-controller.spdx .
+          bom generate -n https://kubewarden.io/kubewarden.spdx -o kubewarden-controller-sbom.spdx .
 
       - name: Sign BOM file
         run: |
-          cosign sign-blob --output-certificate kubewarden-controller.spdx.cert \
-            --output-signature kubewarden-controller.spdx.sig \
-            kubewarden-controller.spdx
+          cosign sign-blob --output-certificate kubewarden-controller-sbom.spdx.cert \
+            --output-signature kubewarden-controller-sbom.spdx.sig \
+            kubewarden-controller-sbom.spdx
         env:
           COSIGN_EXPERIMENTAL: 1
 
@@ -54,6 +54,6 @@ jobs:
           draft: false
           prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
           files: |
-            kubewarden-controller.spdx
-            kubewarden-controller.spdx.cert
-            kubewarden-controller.spdx.sig
+            kubewarden-controller-sbom.spdx
+            kubewarden-controller-sbom.spdx.cert
+            kubewarden-controller-sbom.spdx.sig

--- a/README.md
+++ b/README.md
@@ -79,3 +79,10 @@ $ kubectl patch clusteradmissionpolicy psp-capabilities -p '{"metadata":{"finali
 
 The [official documentation](https://docs.kubewarden.io) provides more insights
 about how the project works and how to use it.
+
+# Software bill of materials
+
+Kubewarden controller has its software bill of materials (SBOM) published every
+release. It follows the [SPDX](https://spdx.dev/) version 2.2 format and it can be found
+together with the signature and certificate used to signed it in the
+[release assets](https://github.com/kubewarden/kubewarden-controller/releases)


### PR DESCRIPTION
## Description
Adds a new section in the README file and change the SBOM file name attached to the release. This is necessary to improve the project score in the CLO monitor. 

Fix https://github.com/kubewarden/kubewarden-controller/issues/262
