### PR TITLE
feat: Create SBOM of container image

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -24,8 +24,6 @@ on:
         description: "Image digest"
         value: ${{ jobs.build.outputs.digest }}
 
-
-
 jobs:
   build:
     name: Build container image
@@ -35,6 +33,10 @@ jobs:
       tag: ${{ steps.setoutput.outputs.tag }}
       artifact: ${{ steps.setoutput.outputs.artifact }}
       digest: ${{ steps.setoutput.outputs.digest }}
+    permissions:
+      # needed for cosign:
+      packages: write
+      id-token: write
     steps:
       -
         name: Checkout code
@@ -59,6 +61,7 @@ jobs:
           go-version: '1.17'
       -
         name: Install the bom command
+        if: ${{ inputs.generate-sbom == true }}
         uses: kubewarden/github-actions/kubernetes-bom-installer@v1
       -
         name: Install Cosign
@@ -87,10 +90,13 @@ jobs:
           tags: |
             ghcr.io/${{github.repository_owner}}/kubewarden-controller:${{ env.TAG_NAME }}
       -
+        name: Build linux/amd64 container image into .tar for e2e tests
+        # This step is only triggered from e2e tests, e2e tests consume the
+        # controller image as a tar.
+        #
         # Only build amd64 because buildx does not allow multiple platforms when
         # exporting the image to a tarball. As we use this only for end-to-end tests
         # and they run on amd64 arch, let's skip the arm64 build for now.
-        name: Build linux/amd64 container image
         if: ${{ inputs.push-image == false }}
         uses: docker/build-push-action@v3
         with:
@@ -101,25 +107,85 @@ jobs:
           tags: |
             ghcr.io/${{github.repository_owner}}/kubewarden-controller:${{ env.TAG_NAME }}
       -
-        name: Create SBOM file
-        if: ${{ inputs.generate-sbom == true }}
-        shell: bash
-        run: |
-          bom generate -n https://kubewarden.io/kubewarden.spdx -o kubewarden-controller.spdx .
-      -
-        name: Attach SBOM file in the container image
-        if: ${{ inputs.generate-sbom == true }}
-        shell: bash
-        run: |
-          set -e
-          cosign attach sbom --sbom kubewarden-controller.spdx "ghcr.io/${{github.repository_owner}}/kubewarden-controller@${{ steps.build-image.outputs.digest }}"
-      -
         name: Upload container image to use in other jobs
+        # this step is only triggered from e2e tests, e2e tests consume the
+        # controller image as a tar.
         if: ${{ inputs.push-image == false }}
         uses: actions/upload-artifact@v3
         with:
           name: kubewarden-controller-image-${{ env.TAG_NAME }}
           path: /tmp/kubewarden-controller-image-${{ env.TAG_NAME }}.tar
+      -
+        name: Create directory to store SBOM files of build
+        if: ${{ inputs.generate-sbom == true }}
+        shell: bash
+        run: |
+          mkdir kubewarden-controller-sboms
+      -
+        name: Create SBOM file of build
+        if: ${{ inputs.generate-sbom == true }}
+        shell: bash
+        run: |
+          bom generate -n https://kubewarden.io/kubewarden.spdx \
+            --format json \
+            . > kubewarden-controller-sboms/kubewarden-controller-sbom.spdx
+      -
+        name: Sign SBOM files of build
+        if: ${{ inputs.generate-sbom == true }}
+        run: |
+          cosign sign-blob --output-certificate kubewarden-controller-sboms/kubewarden-controller-sbom.spdx.cert \
+            --output-signature kubewarden-controller-sboms/kubewarden-controller-sbom.spdx.sig \
+            kubewarden-controller-sboms/kubewarden-controller-sbom.spdx
+        env:
+          COSIGN_EXPERIMENTAL: 1
+      -
+        name: Upload SBOM files of build
+        uses: actions/upload-artifact@v2
+        if: ${{ inputs.generate-sbom == true }}
+        with:
+          name: kubewarden-controller-sboms
+          path: |
+            kubewarden-controller-sboms/
+      -
+        name: Create directory to store SBOM files of container image
+        if: ${{ inputs.generate-sbom == true }}
+        shell: bash
+        run: |
+          mkdir kubewarden-controller-container-image-sboms
+      -
+        name: Create SBOM file of container image
+        if: ${{ inputs.generate-sbom == true }}
+        shell: bash
+        run: |
+          bom generate -n https://kubewarden.io/kubewarden.spdx \
+            --format json \
+            --image "ghcr.io/${{github.repository_owner}}/kubewarden-controller@${{ steps.build-image.outputs.digest }}" \
+            . > kubewarden-controller-container-image-sboms/kubewarden-controller-container-image-sbom.spdx
+      -
+        name: Sign SBOM files of container image
+        if: ${{ inputs.generate-sbom == true }}
+        run: |
+          cosign sign-blob --output-certificate kubewarden-controller-container-image-sboms/kubewarden-controller-container-image-sbom.spdx.cert \
+            --output-signature kubewarden-controller-container-image-sboms/kubewarden-controller-container-image-sbom.spdx.sig \
+            kubewarden-controller-container-image-sboms/kubewarden-controller-container-image-sbom.spdx
+        env:
+          COSIGN_EXPERIMENTAL: 1
+      -
+        name: Attach SBOM file of build in the container image
+        if: ${{ inputs.generate-sbom == true }}
+        shell: bash
+        run: |
+          set -e
+          cosign attach sbom --sbom kubewarden-controller-container-image-sboms/kubewarden-controller.spdx \
+            "ghcr.io/${{github.repository_owner}}/kubewarden-controller@${{ steps.build-image.outputs.digest }}"
+      -
+        name: Upload SBOM files of container image
+        if: ${{ inputs.generate-sbom == true }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: kubewarden-controller-container-image-sboms
+          path: |
+            kubewarden-controller-container-image-sboms/
       -
         id: setoutput
         name: Set output parameters
@@ -128,4 +194,3 @@ jobs:
           echo "::set-output name=tag::${{ env.TAG_NAME }}"
           echo "::set-output name=artifact::kubewarden-controller-image-${{env.TAG_NAME}}"
           echo "::set-output name=digest::${{ steps.build-image.outputs.digest }}"
-


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Partial fix of https://github.com/kubewarden/kubewarden-controller/issues/261

As it stands on this commit, the functionality of creating SBOMs added, but never
shipped in a release.

One would need to download them from the `release.yml` worklow and add
them to the release, as done in policy-server.

This isn't as trivial as in policy-server, as we use a 3rd workflow in
`container-build.yml` to trigger `container-image.yml`, and that makes
it difficult (if not impossible) to download them. I have tried several incantations of workflows and failed.

The `container-image.yml` workflow is parametrized to build the
kubewarden-controller container image as a tar, to be consumed by the
e2e tests. This is done so we don't polute the registry with container
images for each branch/PR/main commit. Maybe we should revisit this and
find a different approach.

The `container-image.yml` workflow is being consumed in `e2e-tests.yml`, which passes the output
to
https://github.com/kubewarden/kubewarden-end-to-end-tests/blob/main/.github/workflows/e2e-tests.yml.
Then, it is
passed to kubewarden/setup-kubewarden-cluster-action@v1.1.0.


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pr on your fork,

1. delete fake tag: `git tag -d v1.2.0-rc1 && git push --delete yourremote v1.2.0-rc1`
2. delete old releases manually in your forks' release page
3. push branch to your own fork
2. create fake tag: `git tag -a v1.2.0-rc1 -m "v1.2.0-rc1" -s && git push yourremote main v1.2.0-rc1`
4. watch workflow runs

Example of a workflow run with SBOM artifacts: https://github.com/viccuad/kubewarden-controller/actions/runs/3023713161


## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

Missing:
- Depend on ci.yml for workflows that should
- Currently we only sign production images. But the way we do it via `container-build.yml` is clumsy. Maybe it should be a conditional on `container-image.yml` when triggered by a tag.
- Remove `container-build.yml`, only use `container-image.yml`. Depend on `container-image.yml` for `e2e-tests.yml`.
- The tricky one: Release should depend on `container-image.yml` succeeding (so we have the SBOM artifacts in GHA) with something like:
  ```
  name: Release kubewarden-controller
  on:
    workflow_run:
      workflows: ["Build container image"]
      types:
        - completed
      branches:
        - "main"
    push:
      tags:
      - 'v*'

  jobs:
   release:
      name: Create release
      runs-on: ubuntu-latest
      if: ${{ github.event.workflow_run.conclusion == 'success' }}
  ```
  But then, I can't get release to trigger on tags..