### PR TITLE
Run container-build inside of the release workflow and add container image sbom

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -2,6 +2,10 @@ name: Build container image every change.
 
 on:
   workflow_call:
+    outputs:
+      digest:
+        description: "Container image digest"
+        value: ${{jobs.build.outputs.digest}}
   push:
     branches:
       - "*"

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -1,11 +1,10 @@
 name: Build container image every change.
 
 on:
+  workflow_call:
   push:
     branches:
       - "*"
-    tags:
-      - 'v*'
 
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,9 @@ jobs:
       - name: Create SBOM file
         shell: bash
         run: |
-          bom generate -n https://kubewarden.io/kubewarden.spdx -o kubewarden-controller-sbom.spdx .
+          bom generate -n https://kubewarden.io/kubewarden.spdx \
+            --image "ghcr.io/${{github.repository_owner}}/kubewarden-controller@${{ needs.container-build.outputs.digest }}" \
+            . > kubewarden-controller-sbom.spdx
 
       - name: Sign BOM file
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   ci:
     uses: kubewarden/kubewarden-controller/.github/workflows/ci.yml@main
+  container-build:
+    uses: kubewarden/kubewarden-controller/.github/workflows/container-build.yml@sbom
   release:
     permissions:
       id-token: write
@@ -14,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - ci
+      - container-build
     steps:
       - name: Install Golang
         uses: actions/setup-go@v3
@@ -50,7 +53,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          name: Release kubewarden-controller ${{ GITHUB_REF_NAME }}
+          name: Release kubewarden-controller ${{ github.ref }}
           draft: false
           prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ jobs:
   ci:
     uses: kubewarden/kubewarden-controller/.github/workflows/ci.yml@main
   container-build:
-    uses: kubewarden/kubewarden-controller/.github/workflows/container-build.yml@sbom
+    uses: kubewarden/kubewarden-controller/.github/workflows/container-build.yml@main
   release:
     permissions:
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Retrieve tag name
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          echo TAG_NAME=$(echo ${{ github.ref }} | sed -e "s|refs/tags/||") >> $GITHUB_ENV
+
       - name: Create SBOM file
         shell: bash
         run: |
@@ -54,8 +59,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          name: Release kubewarden-controller ${{ github.ref }}
+          tag_name: ${{ env.TAG_NAME }}
+          name: Release kubewarden-controller ${{ env.TAG_NAME }}
           draft: false
           prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
           files: |


### PR DESCRIPTION
Run container-build inside of the release workflow, so the release is created after the container image is created.
Release will not be created if container creation failed.

Add container image sbom to the release

[This](https://github.com/raulcabello/kubewarden-controller/releases/tag/vsbomtest18) is how a release looks like

Fix https://github.com/kubewarden/kubewarden-controller/issues/261

Replaces https://github.com/kubewarden/kubewarden-controller/pull/272
