### PR TITLE
Add OpenSSF scan to github workflows

### DIFF
--- a/.github/workflows/openssf.yml
+++ b/.github/workflows/openssf.yml
@@ -1,0 +1,31 @@
+name: Scorecards supply-chain security
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  analysis:
+    name: Scorecards analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Used to receive a badge. (Upcoming feature)
+      id-token: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@v2.0.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish the results for public repositories to enable scorecard badges. For more details, see
+          # https://github.com/ossf/scorecard-action#publishing-results.
+          publish_results: true


### PR DESCRIPTION
Fix https://github.com/kubewarden/kubewarden.io/issues/128

## Test

See how badge looks like in the [test project](https://github.com/raulcabello/openssf-test) I created. This is the [github action](https://github.com/raulcabello/openssf-test/actions/runs/3061397214/jobs/4941114158) that triggered the analysis.

I could not use my fork as OpenSSF does not support analyzing forks