### PR TITLE
Add missing read-all permissions

### DIFF
--- a/.github/workflows/openssf.yml
+++ b/.github/workflows/openssf.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [ main ]
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   analysis:
     name: Scorecards analysis


### PR DESCRIPTION
Add missing read-all permissions to openssf scorecard analysis. See [workflow example](https://github.com/ossf/scorecard-action#workflow-example)

Fix https://github.com/kubewarden/kubewarden.io/issues/129
