### PR TITLE
Add GetBackgroundAudit to Policy interface

### DIFF
--- a/pkg/apis/policies/v1/admissionpolicy_types.go
+++ b/pkg/apis/policies/v1/admissionpolicy_types.go
@@ -141,3 +141,7 @@ func (r *AdmissionPolicy) GetPolicyServer() string {
 func (r *AdmissionPolicy) GetUniqueName() string {
 	return "namespaced-" + r.Namespace + "-" + r.Name
 }
+
+func (r *AdmissionPolicy) GetBackgroundAudit() bool {
+	return r.Spec.BackgroundAudit
+}

--- a/pkg/apis/policies/v1/clusteradmissionpolicy_types.go
+++ b/pkg/apis/policies/v1/clusteradmissionpolicy_types.go
@@ -175,3 +175,7 @@ func (r *ClusterAdmissionPolicy) GetPolicyServer() string {
 func (r *ClusterAdmissionPolicy) GetUniqueName() string {
 	return "clusterwide-" + r.Name
 }
+
+func (r *ClusterAdmissionPolicy) GetBackgroundAudit() bool {
+	return r.Spec.BackgroundAudit
+}

--- a/pkg/apis/policies/v1/policy.go
+++ b/pkg/apis/policies/v1/policy.go
@@ -96,4 +96,5 @@ type Policy interface {
 	GetObjectMeta() *metav1.ObjectMeta
 	GetPolicyServer() string
 	GetUniqueName() string
+	GetBackgroundAudit() bool
 }


### PR DESCRIPTION
Add the background audit field to the `Policy` interface. So we can use the `Policy` interface as an abstraction of both `AdmissionPolicy` and `ClusterAdmissionPolicy` in the `audit-scanner` (as we are already doing the `kubewarden-controller`) 