### PR TITLE
Remove deprecated set-output command

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -124,8 +124,7 @@ jobs:
         id: setoutput
         name: Set output parameters
         run: |
-          echo "::set-output name=repository::ghcr.io/${{github.repository_owner}}/kubewarden-controller"
-          echo "::set-output name=tag::${{ env.TAG_NAME }}"
-          echo "::set-output name=artifact::kubewarden-controller-image-${{env.TAG_NAME}}"
-          echo "::set-output name=digest::${{ steps.build-image.outputs.digest }}"
-
+          echo "repository=ghcr.io/${{github.repository_owner}}/kubewarden-controller" >> $GITHUB_OUTPUT
+          echo "tag=${{ env.TAG_NAME }}" >> $GITHUB_OUTPUT
+          echo "artifact=kubewarden-controller-image-${{env.TAG_NAME}}" >> $GITHUB_OUTPUT
+          echo "digest=${{ steps.build-image.outputs.digest }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fix for warning in github action logs

https://github.com/kubewarden/kubewarden-controller/actions/runs/3333531536

## Description

Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

