### PR TITLE
Add read-all permission to all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
   pull_request:
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   unit_tests:
     name: Unit tests

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - "*"
 
+# Declare default permissions as read only.
+permissions: read-all
+
 
 jobs:
   build:

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,5 +1,8 @@
 name: Build container image
 
+# Declare default permissions as read only.
+permissions: read-all
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,5 +1,8 @@
 name: End-to-end tests
 
+# Declare default permissions as read only.
+permissions: read-all
+
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -5,6 +5,10 @@ on:
     - 'v*'
     branches:
     - 'main'
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   fossa-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/openssf.yml
+++ b/.github/workflows/openssf.yml
@@ -15,8 +15,6 @@ jobs:
       security-events: write
       # Used to receive a badge. (Upcoming feature)
       id-token: write
-      actions: read
-      contents: read
 
     steps:
       - name: "Checkout code"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ on:
   push:
     tags:
     - 'v*'
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   ci:
     uses: kubewarden/kubewarden-controller/.github/workflows/ci.yml@main


### PR DESCRIPTION
Setting token permissions to read-only follows the principle of least privilege. This is important because attackers may use a compromised token with write access to push malicious code into the project. [More info
](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)

This will increase our CLOMonitor score 

Fix https://github.com/kubewarden/kubewarden-controller/issues/333