### PR TITLE
feat: add permission to each job

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -10,14 +10,12 @@ on:
     branches:
       - "*"
 
-# Declare default permissions as read only.
-permissions: read-all
-
-
 jobs:
   build:
     name: Build
     uses: kubewarden/kubewarden-controller/.github/workflows/container-image.yml@main
+    permissions:
+      packages: write
     with:
       push-image: true
 

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,8 +1,5 @@
 name: Build container image
 
-# Declare default permissions as read only.
-permissions: read-all
-
 on:
   workflow_call:
     inputs:
@@ -27,11 +24,11 @@ on:
         description: "Image digest"
         value: ${{ jobs.build.outputs.digest }}
 
-
-
 jobs:
   build:
     name: Build container image
+    permissions:
+      packages: write
     runs-on: ubuntu-latest
     outputs:
       repository: ${{ steps.setoutput.outputs.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,13 @@ permissions: read-all
 jobs:
   ci:
     uses: kubewarden/kubewarden-controller/.github/workflows/ci.yml@main
+    permissions: read-all
+
   container-build:
     uses: kubewarden/kubewarden-controller/.github/workflows/container-build.yml@main
+    permissions:
+      id-token: write
+      packages: write
   release:
     permissions:
       id-token: write


### PR DESCRIPTION
Build image gh action was broken when we introduced permissions: read-all at the top level of all files. 
This PR sets the permissions at job level instead, which fixes the issue. This should also be ok with CLOMonitor. We won't get the maximun score for the token permission (10) but it should give us more than 4 that is required for the check to be green. [More info](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)
Everything worked fine when I created a release in my fork with [this changes](https://github.com/raulcabello/kubewarden-controller/actions/runs/3384112138)