### PR TITLE
fix: exclude kubewarden namespace in webhooks

### DIFF
--- a/apis/policies/v1/admissionpolicy_types.go
+++ b/apis/policies/v1/admissionpolicy_types.go
@@ -115,7 +115,7 @@ func (r *AdmissionPolicy) GetMatchPolicy() *admissionregistrationv1.MatchPolicyT
 }
 
 // GetNamespaceSelector returns the namespace of the AdmissionPolicy since it is the only namespace we want the policy to be applied to.
-func (r *AdmissionPolicy) GetNamespaceSelector(string) *metav1.LabelSelector {
+func (r *AdmissionPolicy) GetUpdatedNamespaceSelector(string) *metav1.LabelSelector {
 	return &metav1.LabelSelector{
 		MatchLabels: map[string]string{"kubernetes.io/metadata.name": r.ObjectMeta.Namespace},
 	}

--- a/apis/policies/v1/admissionpolicy_types.go
+++ b/apis/policies/v1/admissionpolicy_types.go
@@ -115,7 +115,7 @@ func (r *AdmissionPolicy) GetMatchPolicy() *admissionregistrationv1.MatchPolicyT
 }
 
 // GetNamespaceSelector returns the namespace of the AdmissionPolicy since it is the only namespace we want the policy to be applied to.
-func (r *AdmissionPolicy) GetNamespaceSelector() *metav1.LabelSelector {
+func (r *AdmissionPolicy) GetNamespaceSelector(string) *metav1.LabelSelector {
 	return &metav1.LabelSelector{
 		MatchLabels: map[string]string{"kubernetes.io/metadata.name": r.ObjectMeta.Namespace},
 	}

--- a/apis/policies/v1/clusteradmissionpolicy_types.go
+++ b/apis/policies/v1/clusteradmissionpolicy_types.go
@@ -151,7 +151,7 @@ func (r *ClusterAdmissionPolicy) GetRules() []admissionregistrationv1.RuleWithOp
 	return r.Spec.Rules
 }
 
-func (r *ClusterAdmissionPolicy) GetNamespaceSelector(deploymentNamespace string) *metav1.LabelSelector {
+func (r *ClusterAdmissionPolicy) GetUpdatedNamespaceSelector(deploymentNamespace string) *metav1.LabelSelector {
 	// exclude namespace where kubewarden was deployed
 	if r.Spec.NamespaceSelector != nil {
 		r.Spec.NamespaceSelector.MatchExpressions = append(r.Spec.NamespaceSelector.MatchExpressions, metav1.LabelSelectorRequirement{

--- a/apis/policies/v1/clusteradmissionpolicy_types.go
+++ b/apis/policies/v1/clusteradmissionpolicy_types.go
@@ -151,7 +151,24 @@ func (r *ClusterAdmissionPolicy) GetRules() []admissionregistrationv1.RuleWithOp
 	return r.Spec.Rules
 }
 
-func (r *ClusterAdmissionPolicy) GetNamespaceSelector() *metav1.LabelSelector {
+func (r *ClusterAdmissionPolicy) GetNamespaceSelector(deploymentNamespace string) *metav1.LabelSelector {
+	// exclude namespace where kubewarden was deployed
+	if r.Spec.NamespaceSelector != nil {
+		r.Spec.NamespaceSelector.MatchExpressions = append(r.Spec.NamespaceSelector.MatchExpressions, metav1.LabelSelectorRequirement{
+			Key:      "kubernetes.io/metadata.name",
+			Operator: "NotIn",
+			Values:   []string{deploymentNamespace},
+		})
+	} else {
+		r.Spec.NamespaceSelector = &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key:      "kubernetes.io/metadata.name",
+				Operator: "NotIn",
+				Values:   []string{deploymentNamespace},
+			}},
+		}
+	}
+
 	return r.Spec.NamespaceSelector
 }
 

--- a/apis/policies/v1/clusteradmissionpolicy_types_test.go
+++ b/apis/policies/v1/clusteradmissionpolicy_types_test.go
@@ -9,7 +9,7 @@ import (
 func TestGetNamespaceSelectorWithEmptyNamespaceSelector(t *testing.T) {
 	kubewardenNs := "kubewarden"
 	c := ClusterAdmissionPolicy{}
-	nsSelector := c.GetNamespaceSelector(kubewardenNs)
+	nsSelector := c.GetUpdatedNamespaceSelector(kubewardenNs)
 	isKubewardenNsFound := isNamespaceFoundInSelector(nsSelector, kubewardenNs)
 
 	if !isKubewardenNsFound {
@@ -32,7 +32,7 @@ func TestGetNamespaceSelectorWithExistingMatchExpressions(t *testing.T) {
 			},
 		},
 	}
-	nsSelector := policy.GetNamespaceSelector(kubewardenNs)
+	nsSelector := policy.GetUpdatedNamespaceSelector(kubewardenNs)
 	isKubewardenNsFound := isNamespaceFoundInSelector(nsSelector, kubewardenNs)
 
 	if !isKubewardenNsFound {

--- a/apis/policies/v1/clusteradmissionpolicy_types_test.go
+++ b/apis/policies/v1/clusteradmissionpolicy_types_test.go
@@ -1,8 +1,9 @@
 package v1
 
 import (
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetNamespaceSelectorWithEmptyNamespaceSelector(t *testing.T) {
@@ -18,7 +19,7 @@ func TestGetNamespaceSelectorWithEmptyNamespaceSelector(t *testing.T) {
 
 func TestGetNamespaceSelectorWithExistingMatchExpressions(t *testing.T) {
 	kubewardenNs := "kubewarden"
-	c := ClusterAdmissionPolicy{
+	policy := ClusterAdmissionPolicy{
 		Spec: ClusterAdmissionPolicySpec{
 			NamespaceSelector: &v1.LabelSelector{
 				MatchExpressions: []v1.LabelSelectorRequirement{
@@ -31,7 +32,7 @@ func TestGetNamespaceSelectorWithExistingMatchExpressions(t *testing.T) {
 			},
 		},
 	}
-	nsSelector := c.GetNamespaceSelector(kubewardenNs)
+	nsSelector := policy.GetNamespaceSelector(kubewardenNs)
 	isKubewardenNsFound := isNamespaceFoundInSelector(nsSelector, kubewardenNs)
 
 	if !isKubewardenNsFound {

--- a/apis/policies/v1/clusteradmissionpolicy_types_test.go
+++ b/apis/policies/v1/clusteradmissionpolicy_types_test.go
@@ -1,0 +1,55 @@
+package v1
+
+import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestGetNamespaceSelectorWithEmptyNamespaceSelector(t *testing.T) {
+	kubewardenNs := "kubewarden"
+	c := ClusterAdmissionPolicy{}
+	nsSelector := c.GetNamespaceSelector(kubewardenNs)
+	isKubewardenNsFound := isNamespaceFoundInSelector(nsSelector, kubewardenNs)
+
+	if !isKubewardenNsFound {
+		t.Errorf("Kubewarden namespace not added to namespace selector")
+	}
+}
+
+func TestGetNamespaceSelectorWithExistingMatchExpressions(t *testing.T) {
+	kubewardenNs := "kubewarden"
+	c := ClusterAdmissionPolicy{
+		Spec: ClusterAdmissionPolicySpec{
+			NamespaceSelector: &v1.LabelSelector{
+				MatchExpressions: []v1.LabelSelectorRequirement{
+					{
+						Key:      "In",
+						Operator: "kubernetes.io/metadata.name",
+						Values:   []string{"foo"},
+					},
+				},
+			},
+		},
+	}
+	nsSelector := c.GetNamespaceSelector(kubewardenNs)
+	isKubewardenNsFound := isNamespaceFoundInSelector(nsSelector, kubewardenNs)
+
+	if !isKubewardenNsFound {
+		t.Errorf("Kubewarden namespace not added to namespace selector")
+	}
+}
+
+func isNamespaceFoundInSelector(selector *v1.LabelSelector, namespace string) bool {
+	isKubewardenNsFound := false
+
+	for _, matchExpression := range selector.MatchExpressions {
+		if len(matchExpression.Values) == 1 &&
+			matchExpression.Values[0] == namespace &&
+			matchExpression.Key == "kubernetes.io/metadata.name" &&
+			matchExpression.Operator == "NotIn" {
+			isKubewardenNsFound = true
+		}
+	}
+
+	return isKubewardenNsFound
+}

--- a/apis/policies/v1/policy.go
+++ b/apis/policies/v1/policy.go
@@ -90,7 +90,7 @@ type Policy interface {
 	GetRules() []admissionregistrationv1.RuleWithOperations
 	GetFailurePolicy() *admissionregistrationv1.FailurePolicyType
 	GetMatchPolicy() *admissionregistrationv1.MatchPolicyType
-	GetNamespaceSelector() *metav1.LabelSelector
+	GetNamespaceSelector(deploymentNamespace string) *metav1.LabelSelector
 	GetObjectSelector() *metav1.LabelSelector
 	GetTimeoutSeconds() *int32
 	GetObjectMeta() *metav1.ObjectMeta

--- a/apis/policies/v1/policy.go
+++ b/apis/policies/v1/policy.go
@@ -90,7 +90,7 @@ type Policy interface {
 	GetRules() []admissionregistrationv1.RuleWithOperations
 	GetFailurePolicy() *admissionregistrationv1.FailurePolicyType
 	GetMatchPolicy() *admissionregistrationv1.MatchPolicyType
-	GetNamespaceSelector(deploymentNamespace string) *metav1.LabelSelector
+	GetUpdatedNamespaceSelector(deploymentNamespace string) *metav1.LabelSelector
 	GetObjectSelector() *metav1.LabelSelector
 	GetTimeoutSeconds() *int32
 	GetObjectMeta() *metav1.ObjectMeta

--- a/internal/pkg/admission/mutating-webhook.go
+++ b/internal/pkg/admission/mutating-webhook.go
@@ -95,7 +95,7 @@ func (r *Reconciler) mutatingWebhookConfiguration(
 				Rules:                   policy.GetRules(),
 				FailurePolicy:           policy.GetFailurePolicy(),
 				MatchPolicy:             policy.GetMatchPolicy(),
-				NamespaceSelector:       policy.GetNamespaceSelector(r.DeploymentsNamespace),
+				NamespaceSelector:       policy.GetUpdatedNamespaceSelector(r.DeploymentsNamespace),
 				ObjectSelector:          policy.GetObjectSelector(),
 				SideEffects:             sideEffects,
 				TimeoutSeconds:          policy.GetTimeoutSeconds(),

--- a/internal/pkg/admission/mutating-webhook.go
+++ b/internal/pkg/admission/mutating-webhook.go
@@ -95,7 +95,7 @@ func (r *Reconciler) mutatingWebhookConfiguration(
 				Rules:                   policy.GetRules(),
 				FailurePolicy:           policy.GetFailurePolicy(),
 				MatchPolicy:             policy.GetMatchPolicy(),
-				NamespaceSelector:       policy.GetNamespaceSelector(),
+				NamespaceSelector:       policy.GetNamespaceSelector(r.DeploymentsNamespace),
 				ObjectSelector:          policy.GetObjectSelector(),
 				SideEffects:             sideEffects,
 				TimeoutSeconds:          policy.GetTimeoutSeconds(),

--- a/internal/pkg/admission/validating-webhook.go
+++ b/internal/pkg/admission/validating-webhook.go
@@ -95,7 +95,7 @@ func (r *Reconciler) validatingWebhookConfiguration(
 				Rules:                   policy.GetRules(),
 				FailurePolicy:           policy.GetFailurePolicy(),
 				MatchPolicy:             policy.GetMatchPolicy(),
-				NamespaceSelector:       policy.GetNamespaceSelector(r.DeploymentsNamespace),
+				NamespaceSelector:       policy.GetUpdatedNamespaceSelector(r.DeploymentsNamespace),
 				ObjectSelector:          policy.GetObjectSelector(),
 				SideEffects:             sideEffects,
 				TimeoutSeconds:          policy.GetTimeoutSeconds(),

--- a/internal/pkg/admission/validating-webhook.go
+++ b/internal/pkg/admission/validating-webhook.go
@@ -95,7 +95,7 @@ func (r *Reconciler) validatingWebhookConfiguration(
 				Rules:                   policy.GetRules(),
 				FailurePolicy:           policy.GetFailurePolicy(),
 				MatchPolicy:             policy.GetMatchPolicy(),
-				NamespaceSelector:       policy.GetNamespaceSelector(),
+				NamespaceSelector:       policy.GetNamespaceSelector(r.DeploymentsNamespace),
 				ObjectSelector:          policy.GetObjectSelector(),
 				SideEffects:             sideEffects,
 				TimeoutSeconds:          policy.GetTimeoutSeconds(),


### PR DESCRIPTION
There is a problem when the PolicyServer pod is deleted. It can't be recreated because the webhook endpoint points to the PolicyServer which is not available. Error message:

```
Error creating: Internal error occurred: failed calling webhook "clusterwide-do-not-share-host-paths.kubewarden.admission": failed to call webhook: Post "https://policy-server-default.kubewarden.svc:8443/validate/clusterwide-do-not-share-host-paths?timeout=10s": dial tcp 10.100.59.167:8443: connect: connection refused
```

This will prevent any Pod from being created in the cluster. This PR excludes in the webhooks the namespace where Kubewarden was deployed.

Updates will work without doing any extra change. Controller will trigger a reconciliation for each policy the first time it starts. It will find a difference [here](https://github.com/kubewarden/kubewarden-controller/blob/main/internal/pkg/admission/mutating-webhook.go#L50) between the old and new webhook, and then apply the changes with the namespace selector.

Fix https://github.com/kubewarden/kubewarden-controller/issues/326

Signed-off-by: raulcabello <raul.cabello@suse.com>