### PR TITLE
docs: Bump docs/crds to k8s 1.25

### DIFF
--- a/docs/crds/README.asciidoc
+++ b/docs/crds/README.asciidoc
@@ -39,7 +39,7 @@ AdmissionPolicy is the Schema for the admissionpolicies API
 | Field | Description
 | *`apiVersion`* __string__ | `policies.kubewarden.io/v1`
 | *`kind`* __string__ | `AdmissionPolicy`
-| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
 | *`spec`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1-admissionpolicyspec[$$AdmissionPolicySpec$$]__ | 
 |===
@@ -57,7 +57,7 @@ AdmissionPolicyList contains a list of AdmissionPolicy
 | Field | Description
 | *`apiVersion`* __string__ | `policies.kubewarden.io/v1`
 | *`kind`* __string__ | `AdmissionPolicyList`
-| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
 | *`items`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1-admissionpolicy[$$AdmissionPolicy$$]__ | 
 |===
@@ -95,7 +95,7 @@ ClusterAdmissionPolicy is the Schema for the clusteradmissionpolicies API
 | Field | Description
 | *`apiVersion`* __string__ | `policies.kubewarden.io/v1`
 | *`kind`* __string__ | `ClusterAdmissionPolicy`
-| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
 | *`spec`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1-clusteradmissionpolicyspec[$$ClusterAdmissionPolicySpec$$]__ | 
 |===
@@ -113,7 +113,7 @@ ClusterAdmissionPolicyList contains a list of ClusterAdmissionPolicy
 | Field | Description
 | *`apiVersion`* __string__ | `policies.kubewarden.io/v1`
 | *`kind`* __string__ | `ClusterAdmissionPolicyList`
-| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
 | *`items`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1-clusteradmissionpolicy[$$ClusterAdmissionPolicy$$]__ | 
 |===
@@ -133,7 +133,7 @@ ClusterAdmissionPolicySpec defines the desired state of ClusterAdmissionPolicy
 |===
 | Field | Description
 | *`PolicySpec`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1-policyspec[$$PolicySpec$$]__ | 
-| *`namespaceSelector`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#labelselector-v1-meta[$$LabelSelector$$]__ | NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook. 
+| *`namespaceSelector`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#labelselector-v1-meta[$$LabelSelector$$]__ | NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook. 
  For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {   "matchExpressions": [     {       "key": "runlevel",       "operator": "NotIn",       "values": [         "0",         "1"       ]     }   ] } 
  If instead you want to only run the webhook on any objects whose namespace is associated with the "environment" of "prod" or "staging"; you will set the selector as follows: "namespaceSelector": {   "matchExpressions": [     {       "key": "environment",       "operator": "In",       "values": [         "prod",         "staging"       ]     }   ] } 
  See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels for more examples of label selectors. 
@@ -182,7 +182,7 @@ PolicyServer is the Schema for the policyservers API
 | Field | Description
 | *`apiVersion`* __string__ | `policies.kubewarden.io/v1`
 | *`kind`* __string__ | `PolicyServer`
-| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
 | *`spec`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1-policyserverspec[$$PolicyServerSpec$$]__ | 
 |===
@@ -200,7 +200,7 @@ PolicyServerList contains a list of PolicyServer
 | Field | Description
 | *`apiVersion`* __string__ | `policies.kubewarden.io/v1`
 | *`kind`* __string__ | `PolicyServerList`
-| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
 | *`items`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1-policyserver[$$PolicyServer$$]__ | 
 |===
@@ -222,7 +222,7 @@ PolicyServerSpec defines the desired state of PolicyServer
 | *`image`* __string__ | Docker image name.
 | *`replicas`* __integer__ | Replicas is the number of desired replicas.
 | *`annotations`* __object (keys:string, values:string)__ | Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations
-| *`env`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#envvar-v1-core[$$EnvVar$$] array__ | List of environment variables to set in the container.
+| *`env`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#envvar-v1-core[$$EnvVar$$] array__ | List of environment variables to set in the container.
 | *`serviceAccountName`* __string__ | Name of the service account associated with the policy server. Namespace service account will be used if not specified.
 | *`imagePullSecret`* __string__ | Name of ImagePullSecret secret in the same namespace, used for pulling policies from repositories.
 | *`insecureSources`* __string array__ | List of insecure URIs to policy repositories.
@@ -251,15 +251,15 @@ PolicyServerSpec defines the desired state of PolicyServer
 | *`module`* __string__ | Module is the location of the WASM module to be loaded. Can be a local file (file://), a remote file served by an HTTP server (http://, https://), or an artifact served by an OCI-compatible registry (registry://). If prefix is missing, it will default to registry:// and use that internally.
 | *`mode`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1-policymode[$$PolicyMode$$]__ | Mode defines the execution mode of this policy. Can be set to either "protect" or "monitor". If it's empty, it is defaulted to "protect". Transitioning this setting from "monitor" to "protect" is allowed, but is disallowed to transition from "protect" to "monitor". To perform this transition, the policy should be recreated in "monitor" mode instead.
 | *`settings`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | Settings is a free-form object that contains the policy configuration values. x-kubernetes-embedded-resource: false
-| *`rules`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#rulewithoperations-v1-admissionregistration[$$RuleWithOperations$$] array__ | Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule.
-| *`failurePolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#failurepolicytype-v1-admissionregistration[$$FailurePolicyType$$]__ | FailurePolicy defines how unrecognized errors and timeout errors from the policy are handled. Allowed values are "Ignore" or "Fail". * "Ignore" means that an error calling the webhook is ignored and the API   request is allowed to continue. * "Fail" means that an error calling the webhook causes the admission to   fail and the API request to be rejected. The default behaviour is "Fail"
+| *`rules`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#rulewithoperations-v1-admissionregistration[$$RuleWithOperations$$] array__ | Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule.
+| *`failurePolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#failurepolicytype-v1-admissionregistration[$$FailurePolicyType$$]__ | FailurePolicy defines how unrecognized errors and timeout errors from the policy are handled. Allowed values are "Ignore" or "Fail". * "Ignore" means that an error calling the webhook is ignored and the API   request is allowed to continue. * "Fail" means that an error calling the webhook causes the admission to   fail and the API request to be rejected. The default behaviour is "Fail"
 | *`mutating`* __boolean__ | Mutating indicates whether a policy has the ability to mutate incoming requests or not.
-| *`matchPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#matchpolicytype-v1-admissionregistration[$$MatchPolicyType$$]__ | matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent". 
+| *`matchPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#matchpolicytype-v1-admissionregistration[$$MatchPolicyType$$]__ | matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent". 
  - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook. 
  - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook. 
  Defaults to "Equivalent"
-| *`objectSelector`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#labelselector-v1-meta[$$LabelSelector$$]__ | ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
-| *`sideEffects`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#sideeffectclass-v1-admissionregistration[$$SideEffectClass$$]__ | SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
+| *`objectSelector`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#labelselector-v1-meta[$$LabelSelector$$]__ | ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
+| *`sideEffects`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#sideeffectclass-v1-admissionregistration[$$SideEffectClass$$]__ | SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
 | *`timeoutSeconds`* __integer__ | TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
 |===
 
@@ -309,7 +309,7 @@ AdmissionPolicy is the Schema for the admissionpolicies API
 | Field | Description
 | *`apiVersion`* __string__ | `policies.kubewarden.io/v1alpha2`
 | *`kind`* __string__ | `AdmissionPolicy`
-| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
 | *`spec`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-admissionpolicyspec[$$AdmissionPolicySpec$$]__ | 
 |===
@@ -327,7 +327,7 @@ AdmissionPolicyList contains a list of AdmissionPolicy
 | Field | Description
 | *`apiVersion`* __string__ | `policies.kubewarden.io/v1alpha2`
 | *`kind`* __string__ | `AdmissionPolicyList`
-| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
 | *`items`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-admissionpolicy[$$AdmissionPolicy$$]__ | 
 |===
@@ -365,7 +365,7 @@ ClusterAdmissionPolicy is the Schema for the clusteradmissionpolicies API
 | Field | Description
 | *`apiVersion`* __string__ | `policies.kubewarden.io/v1alpha2`
 | *`kind`* __string__ | `ClusterAdmissionPolicy`
-| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
 | *`spec`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-clusteradmissionpolicyspec[$$ClusterAdmissionPolicySpec$$]__ | 
 |===
@@ -383,7 +383,7 @@ ClusterAdmissionPolicyList contains a list of ClusterAdmissionPolicy
 | Field | Description
 | *`apiVersion`* __string__ | `policies.kubewarden.io/v1alpha2`
 | *`kind`* __string__ | `ClusterAdmissionPolicyList`
-| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
 | *`items`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-clusteradmissionpolicy[$$ClusterAdmissionPolicy$$]__ | 
 |===
@@ -403,7 +403,7 @@ ClusterAdmissionPolicySpec defines the desired state of ClusterAdmissionPolicy
 |===
 | Field | Description
 | *`PolicySpec`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-policyspec[$$PolicySpec$$]__ | 
-| *`namespaceSelector`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#labelselector-v1-meta[$$LabelSelector$$]__ | NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook. 
+| *`namespaceSelector`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#labelselector-v1-meta[$$LabelSelector$$]__ | NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook. 
  For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {   "matchExpressions": [     {       "key": "runlevel",       "operator": "NotIn",       "values": [         "0",         "1"       ]     }   ] } 
  If instead you want to only run the webhook on any objects whose namespace is associated with the "environment" of "prod" or "staging"; you will set the selector as follows: "namespaceSelector": {   "matchExpressions": [     {       "key": "environment",       "operator": "In",       "values": [         "prod",         "staging"       ]     }   ] } 
  See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels for more examples of label selectors. 
@@ -452,7 +452,7 @@ PolicyServer is the Schema for the policyservers API
 | Field | Description
 | *`apiVersion`* __string__ | `policies.kubewarden.io/v1alpha2`
 | *`kind`* __string__ | `PolicyServer`
-| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
 | *`spec`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-policyserverspec[$$PolicyServerSpec$$]__ | 
 |===
@@ -470,7 +470,7 @@ PolicyServerList contains a list of PolicyServer
 | Field | Description
 | *`apiVersion`* __string__ | `policies.kubewarden.io/v1alpha2`
 | *`kind`* __string__ | `PolicyServerList`
-| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
 | *`items`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-policyserver[$$PolicyServer$$]__ | 
 |===
@@ -492,7 +492,7 @@ PolicyServerSpec defines the desired state of PolicyServer
 | *`image`* __string__ | Docker image name.
 | *`replicas`* __integer__ | Replicas is the number of desired replicas.
 | *`annotations`* __object (keys:string, values:string)__ | Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations
-| *`env`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#envvar-v1-core[$$EnvVar$$]__ | List of environment variables to set in the container.
+| *`env`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#envvar-v1-core[$$EnvVar$$]__ | List of environment variables to set in the container.
 | *`serviceAccountName`* __string__ | Name of the service account associated with the policy server. Namespace service account will be used if not specified.
 | *`imagePullSecret`* __string__ | Name of ImagePullSecret secret in the same namespace, used for pulling policies from repositories.
 | *`insecureSources`* __string array__ | List of insecure URIs to policy repositories.
@@ -521,15 +521,15 @@ PolicyServerSpec defines the desired state of PolicyServer
 | *`module`* __string__ | Module is the location of the WASM module to be loaded. Can be a local file (file://), a remote file served by an HTTP server (http://, https://), or an artifact served by an OCI-compatible registry (registry://).
 | *`mode`* __xref:{anchor_prefix}-github-com-kubewarden-kubewarden-controller-apis-policies-v1alpha2-policymode[$$PolicyMode$$]__ | Mode defines the execution mode of this policy. Can be set to either "protect" or "monitor". If it's empty, it is defaulted to "protect". Transitioning this setting from "monitor" to "protect" is allowed, but is disallowed to transition from "protect" to "monitor". To perform this transition, the policy should be recreated in "monitor" mode instead.
 | *`settings`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | Settings is a free-form object that contains the policy configuration values. x-kubernetes-embedded-resource: false
-| *`rules`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#rulewithoperations-v1-admissionregistration[$$RuleWithOperations$$]__ | Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule.
-| *`failurePolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#failurepolicytype-v1-admissionregistration[$$FailurePolicyType$$]__ | FailurePolicy defines how unrecognized errors and timeout errors from the policy are handled. Allowed values are "Ignore" or "Fail". * "Ignore" means that an error calling the webhook is ignored and the API   request is allowed to continue. * "Fail" means that an error calling the webhook causes the admission to   fail and the API request to be rejected. The default behaviour is "Fail"
+| *`rules`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#rulewithoperations-v1-admissionregistration[$$RuleWithOperations$$]__ | Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule.
+| *`failurePolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#failurepolicytype-v1-admissionregistration[$$FailurePolicyType$$]__ | FailurePolicy defines how unrecognized errors and timeout errors from the policy are handled. Allowed values are "Ignore" or "Fail". * "Ignore" means that an error calling the webhook is ignored and the API   request is allowed to continue. * "Fail" means that an error calling the webhook causes the admission to   fail and the API request to be rejected. The default behaviour is "Fail"
 | *`mutating`* __boolean__ | Mutating indicates whether a policy has the ability to mutate incoming requests or not.
-| *`matchPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#matchpolicytype-v1-admissionregistration[$$MatchPolicyType$$]__ | matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent". 
+| *`matchPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#matchpolicytype-v1-admissionregistration[$$MatchPolicyType$$]__ | matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent". 
  - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook. 
  - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook. 
  Defaults to "Equivalent"
-| *`objectSelector`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#labelselector-v1-meta[$$LabelSelector$$]__ | ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
-| *`sideEffects`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#sideeffectclass-v1-admissionregistration[$$SideEffectClass$$]__ | SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
+| *`objectSelector`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#labelselector-v1-meta[$$LabelSelector$$]__ | ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
+| *`sideEffects`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#sideeffectclass-v1-admissionregistration[$$SideEffectClass$$]__ | SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
 | *`timeoutSeconds`* __integer__ | TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
 |===
 

--- a/docs/crds/config.yml
+++ b/docs/crds/config.yml
@@ -8,4 +8,4 @@ processor:
 
 render:
   # Version of Kubernetes to use when generating links to Kubernetes API documentation.
-  kubernetesVersion: "1.20"
+  kubernetesVersion: "1.25"


### PR DESCRIPTION



## Description
regenerate docs with `docs/crds $ make generate`.



## Test

It regenerated them, plus the rendered docs aren't being used right now.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
