### PR TITLE
Use WORKFLOW_PAT token to trigger CI.

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -20,7 +20,7 @@ exclude-labels:
   - later
   - wontfix
   - kind/question
-  - skip-changelog
+  - release/skip-changelog
 
 change-template: '- $TITLE (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Trigger chart update
         uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588
         with:
-          token: ${{ secrets.HELM_CHART_REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.WORKFLOW_PAT }}
           repository: "${{github.repository_owner}}/helm-charts"
           event-type: update-chart
           client-payload: '{"version": "${{ github.ref_name }}", "oldVersion": "${{ steps.get_last_release_tag.outputs.old_release_tag }}", "repository": "${{ github.repository }}", "crds_asset_id": "${{steps.upload_release_assets.outputs.crds_asset_id}}"}'


### PR DESCRIPTION
## Description

Updates the release.yaml workflow file to use the WORKFLOW_PAT token to trigger the Helm chart update. This token is already used for that in past CI jobs.