### PR TITLE
Fix release drafter autolabeler

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -40,6 +40,8 @@ autolabeler:
     title: 'fix'
   - label: 'kind/chore'
     title: 'chore'
+  - label: 'area/dependencies'
+    title: 'build(deps)'
 
 version-resolver:
   major:


### PR DESCRIPTION
## Description

Adds a new entry in the autolabel configuration to set the label `area/dependencies` when the PR title starts with `build(deps)`


