### PR TITLE
contextAwareResources field in the policies.yml.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ setup-envtest: $(SETUP_ENVTEST) # Build setup-envtest
 .PHONY: unit-tests
 unit-tests: manifests generate fmt vet setup-envtest ## Run unit tests.
 	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./internal/... -test.v -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./apis/... -test.v -coverprofile cover.out
 
 .PHONY: setup-envtest integration-tests
 integration-tests: manifests generate fmt vet setup-envtest ## Run integration tests.

--- a/apis/policies/v1/admissionpolicy_types.go
+++ b/apis/policies/v1/admissionpolicy_types.go
@@ -140,3 +140,7 @@ func (r *AdmissionPolicy) GetPolicyServer() string {
 func (r *AdmissionPolicy) GetUniqueName() string {
 	return "namespaced-" + r.Namespace + "-" + r.Name
 }
+
+func (r *AdmissionPolicy) GetContextAwareResources() []ContextAwareResource {
+	return []ContextAwareResource{}
+}

--- a/apis/policies/v1/admissionpolicy_types_test.go
+++ b/apis/policies/v1/admissionpolicy_types_test.go
@@ -1,0 +1,12 @@
+package v1
+
+import (
+	"testing"
+)
+
+func TestAdmissionPolicyGetContextAwareResources(t *testing.T) {
+	c := AdmissionPolicy{}
+	if len(c.GetContextAwareResources()) != 0 {
+		t.Errorf("Context aware resources for namespaced policies should be empty")
+	}
+}

--- a/apis/policies/v1/clusteradmissionpolicy_types.go
+++ b/apis/policies/v1/clusteradmissionpolicy_types.go
@@ -206,3 +206,7 @@ func (r *ClusterAdmissionPolicy) GetPolicyServer() string {
 func (r *ClusterAdmissionPolicy) GetUniqueName() string {
 	return "clusterwide-" + r.Name
 }
+
+func (r *ClusterAdmissionPolicy) GetContextAwareResources() []ContextAwareResource {
+	return r.Spec.ContextAwareResources
+}

--- a/apis/policies/v1/clusteradmissionpolicy_types_test.go
+++ b/apis/policies/v1/clusteradmissionpolicy_types_test.go
@@ -54,3 +54,27 @@ func isNamespaceFoundInSelector(selector *v1.LabelSelector, namespace string) bo
 
 	return isKubewardenNsFound
 }
+
+func TestClusterAdmissionPolicyGetContextAwareResources(t *testing.T) {
+	policy := ClusterAdmissionPolicy{
+		Spec: ClusterAdmissionPolicySpec{
+			ContextAwareResources: []ContextAwareResource{
+				{
+					APIVersion: "v1",
+					Kind:       "Pods",
+				},
+			},
+		},
+	}
+	if len(policy.GetContextAwareResources()) != 1 {
+		t.Fatal("Missing context aware resources definition")
+	}
+
+	if policy.GetContextAwareResources()[0].APIVersion != "v1" {
+		t.Errorf("Invalid context aware resource APIVersion")
+	}
+
+	if policy.GetContextAwareResources()[0].Kind != "Pods" {
+		t.Errorf("Invalid context aware resource kind")
+	}
+}

--- a/apis/policies/v1/policy.go
+++ b/apis/policies/v1/policy.go
@@ -96,4 +96,5 @@ type Policy interface {
 	GetObjectMeta() *metav1.ObjectMeta
 	GetPolicyServer() string
 	GetUniqueName() string
+	GetContextAwareResources() []ContextAwareResource
 }

--- a/internal/pkg/admission/policy-server-configmap.go
+++ b/internal/pkg/admission/policy-server-configmap.go
@@ -21,11 +21,12 @@ import (
 )
 
 type PolicyServerConfigEntry struct {
-	NamespacedName  types.NamespacedName `json:"namespacedName"`
-	URL             string               `json:"url"`
-	PolicyMode      string               `json:"policyMode"`
-	AllowedToMutate bool                 `json:"allowedToMutate"`
-	Settings        runtime.RawExtension `json:"settings,omitempty"`
+	NamespacedName        types.NamespacedName              `json:"namespacedName"`
+	URL                   string                            `json:"url"`
+	PolicyMode            string                            `json:"policyMode"`
+	AllowedToMutate       bool                              `json:"allowedToMutate"`
+	ContextAwareResources []policiesv1.ContextAwareResource `json:"contextAwareResources,omitempty"`
+	Settings              runtime.RawExtension              `json:"settings,omitempty"`
 }
 
 type sourceAuthorityType string
@@ -207,10 +208,11 @@ func (r *Reconciler) createPoliciesMap(admissionPolicies []policiesv1.Policy) Po
 				Namespace: admissionPolicy.GetNamespace(),
 				Name:      admissionPolicy.GetName(),
 			},
-			URL:             admissionPolicy.GetModule(),
-			PolicyMode:      string(admissionPolicy.GetPolicyMode()),
-			AllowedToMutate: admissionPolicy.IsMutating(),
-			Settings:        admissionPolicy.GetSettings(),
+			URL:                   admissionPolicy.GetModule(),
+			PolicyMode:            string(admissionPolicy.GetPolicyMode()),
+			AllowedToMutate:       admissionPolicy.IsMutating(),
+			Settings:              admissionPolicy.GetSettings(),
+			ContextAwareResources: admissionPolicy.GetContextAwareResources(),
 		}
 	}
 	return policies


### PR DESCRIPTION
Adds the contextAwareResources field in the policies.yml file. This field is added when a ClusterAdmissionPolicy is configured to has access to resource in the cluster setting the `contextAwareResources` field in the policy definition.

Fix #401 
