### PR TITLE
deps: Pin cosign to 1.* by pinning cosign-installer GHA

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -33,7 +33,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: sigstore/cosign-installer@main
+      - uses: sigstore/cosign-installer@v2.8.1
       - name: Sign the images
         run: |
           cosign sign \
@@ -41,7 +41,7 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: 1
 
-      - uses: sigstore/cosign-installer@main
+      - uses: sigstore/cosign-installer@v2.8.1
       - name: Sign the SBOM
         run: |
           tag=$(echo '${{needs.build.outputs.digest}}' | sed 's/:/-/g')

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -63,7 +63,7 @@ jobs:
       -
         name: Install Cosign
         if: ${{ inputs.generate-sbom == true }}
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@v2.8.1
       -
         name: Retrieve tag name
         if: ${{ startsWith(github.ref, 'refs/heads/') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         run: go install sigs.k8s.io/bom/cmd/bom@v0.2.2
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@v2.8.1
 
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description

Cosign 2.0 was [released last week](https://blog.sigstore.dev/cosign-2-0-released/) (yay!) but, as expected because semver, it's not backwards compatible (nay!).

Pin cosign-installer GHA so it downloads cosign 1.*.
Latest [cosign-installer downloads cosign 2.*](https://github.com/sigstore/cosign-installer/releases/tag/v3.0.0).

## Test

Tested in other repos.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
