### PR TITLE
fix: Only watch on kubewarden ns for namespaced resources

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,6 +134,12 @@ func main() {
 			LeaderElection:         enableLeaderElection,
 			LeaderElectionID:       "a4ddbf36.kubewarden.io",
 			ClientDisableCacheFor:  []client.Object{&corev1.ConfigMap{}, &appsv1.Deployment{}},
+			// Watch for kubewarden namespace on namespaced resources:
+			// Note: If a namespace is specified, controllers can still Watch for a
+			// cluster-scoped resource (in our case, ClusterAdmissionPolicies,
+			// webhooks, etc). For namespaced resources, the cache will only
+			// hold objects from the desired namespace.
+			Namespace: deploymentsNamespace,
 		},
 		setupLog,
 		environment.developmentMode,


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
fix: Only watch on kubewarden ns for namespaced resources.
This should also improve resource consumption on clusters with a lot of Pods, as we would not be triggering with their changes.
This introduces no changes for cluster-scope resources.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
With a controller with this, use rolebinding instead of clusterrolebinding for `kubewarden-controller-manager-cluster-role`.
Everything should still work fine, and the controller logs shouldn't have:
```
*v1.Pod: pods is forbidden: User "system:serviceaccount:kubewarden:kubewarden-controller" cannot list resource "pods" in API group "" at the cluster scope
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

See https://togithub.com/kubernetes-sigs/controller-runtime/blob/main/designs/use-selectors-at-cache.md
See https://togithub.com/kubernetes-sigs/controller-runtime/issues/244
