### PR TITLE
fix: controller failed to update policy server service.

### DIFF
--- a/internal/pkg/admission/policy-server-service.go
+++ b/internal/pkg/admission/policy-server-service.go
@@ -35,8 +35,13 @@ func init() {
 }
 
 func (r *Reconciler) reconcilePolicyServerService(ctx context.Context, policyServer *policiesv1.PolicyServer) error {
-	err := r.Client.Create(ctx, r.service(policyServer))
-	if err == nil || apierrors.IsAlreadyExists(err) {
+	service := r.service(policyServer)
+	err := r.Client.Create(ctx, service)
+
+	if err != nil && apierrors.IsAlreadyExists(err) {
+		err = r.Client.Update(ctx, service)
+	}
+	if err == nil {
 		return nil
 	}
 	return fmt.Errorf("cannot reconcile policy-server service: %w", err)


### PR DESCRIPTION
## Description

The controller is not able to update the policy server service because it always call the create function in the reconciliation loop. Therefore, if the user edits the policy server enabling telemetry, the service will not be updated adding the metric port in the service.

To fix that, this change adds a call to the update function when the creation failed due an "already exists" error.

Fix #432 

