### PR TITLE
Set telemetry configuration in policy server deployment.

### DIFF
--- a/internal/pkg/admission/reconciler.go
+++ b/internal/pkg/admission/reconciler.go
@@ -25,6 +25,7 @@ type Reconciler struct {
 	DeploymentsNamespace                               string
 	AlwaysAcceptAdmissionReviewsInDeploymentsNamespace bool
 	Log                                                logr.Logger
+	MetricsEnabled                                     bool
 }
 
 type reconcilerErrors []error

--- a/internal/pkg/constants/constants.go
+++ b/internal/pkg/constants/constants.go
@@ -24,6 +24,7 @@ const (
 	PolicyServerMetricsPortEnvVar                   = "KUBEWARDEN_POLICY_SERVER_SERVICES_METRICS_PORT"
 	PolicyServerMetricsPort                         = 8080
 	PolicyServerReadinessProbe                      = "/readiness"
+	PolicyServerLogFmtEnvVar                        = "KUBEWARDEN_LOG_FMT"
 
 	// PolicyServer ConfigMap
 	PolicyServerConfigPoliciesEntry         = "policies.yml"
@@ -47,4 +48,7 @@ const (
 
 	// Kubernetes
 	KubernetesRevisionAnnotation = "deployment.kubernetes.io/revision"
+
+	// OPTEL
+	OptelInjectAnnotation = "sidecar.opentelemetry.io/inject"
 )

--- a/main.go
+++ b/main.go
@@ -195,6 +195,7 @@ func main() {
 		Log:                  ctrl.Log.WithName("reconciler"),
 		DeploymentsNamespace: deploymentsNamespace,
 		AlwaysAcceptAdmissionReviewsInDeploymentsNamespace: alwaysAcceptAdmissionReviewsOnDeploymentsNamespace,
+		MetricsEnabled: enableMetrics,
 	}
 
 	if err = (&controllers.PolicyServerReconciler{


### PR DESCRIPTION
## Description

Updates the telemetry configuration in all the policy servers by default if the Kubewarden controller has telemetry enabled.

Related to https://github.com/kubewarden/ui/issues/287
