### PR TITLE
fix: record policy count metric.

### DIFF
--- a/internal/pkg/admission/reconciler.go
+++ b/internal/pkg/admission/reconciler.go
@@ -9,7 +9,6 @@ import (
 	policiesv1 "github.com/kubewarden/kubewarden-controller/apis/policies/v1"
 	"github.com/kubewarden/kubewarden-controller/internal/pkg/admissionregistration"
 	"github.com/kubewarden/kubewarden-controller/internal/pkg/constants"
-	"github.com/kubewarden/kubewarden-controller/internal/pkg/metrics"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -288,19 +287,4 @@ func (r *Reconciler) GetPolicies(ctx context.Context, policyServer *policiesv1.P
 	}
 
 	return policies, nil
-}
-
-// UpdateAdmissionPolicyStatus Updates the status subresource of the passed
-// clusterAdmissionPolicy with a Client apt for it.
-func (r *Reconciler) UpdateAdmissionPolicyStatus(
-	ctx context.Context,
-	policy policiesv1.Policy,
-) error {
-	if err := r.Client.Status().Update(ctx, policy); err != nil {
-		return fmt.Errorf("failed to update status of Policy %q, %w", policy.GetObjectMeta(), err)
-	}
-	if err := metrics.RecordPolicyCount(ctx, policy); err != nil {
-		return fmt.Errorf("failed to record policy mestrics: %w", err)
-	}
-	return nil
 }


### PR DESCRIPTION
## Description

Updates the controller to read the function call to record the policy count metric. It also removes a function not called in the code.


Fix #444 

## Test

```shell
kubectl port-forward -n kubewarden --address 0.0.0.0  pod/kubewarden-controller-64f6c5c67b-7jzt9 8080:8080 & 

curl "http://localhost:8080/metrics"                                     
# HELP kubewarden_policy_total How many policies are installed in the cluster
# TYPE kubewarden_policy_total counter
kubewarden_policy_total{failure_policy="",job="unknown_service:manager",module="registry://ghcr.io/kubewarden/policies/pod-privileged:v0.2.2",mutating="false",name="clusterwide-pod-privileged3",namespace="",policy_server="default",policy_status="active"} 37
kubewarden_policy_total{failure_policy="",job="unknown_service:manager",module="registry://ghcr.io/kubewarden/policies/pod-privileged:v0.2.2",mutating="false",name="clusterwide-pod-privileged3",namespace="",policy_server="default",policy_status="pending"} 31
kubewarden_policy_total{failure_policy="",job="unknown_service:manager",module="registry://ghcr.io/kubewarden/policies/pod-privileged:v0.2.2",mutating="false",name="namespaced-default-pod-privileged3",namespace="default",policy_server="default",policy_status="active"} 2
kubewarden_policy_total{failure_policy="",job="unknown_service:manager",module="registry://ghcr.io/kubewarden/policies/pod-privileged:v0.2.2",mutating="false",name="namespaced-default-pod-privileged3",namespace="default",policy_server="default",policy_status="pending"} 29

```


## Additional Information

I feel the current metric definition is weird and I'm not sure it makes sense. However, I'm open this because this is the definition we accepted to use in the past. 

I'll take a look if I can improve it while I'm testing all the monitoring story. If I find something better, I'll open another PR to enhance it. 