### PR TITLE
fix: otel annotations should be in the pod spec.

### DIFF
--- a/internal/pkg/admission/policy-server-deployment.go
+++ b/internal/pkg/admission/policy-server-deployment.go
@@ -226,9 +226,6 @@ func (r *Reconciler) adaptDeploymentSettingsForPolicyServer(policyServerDeployme
 			},
 		)
 	}
-	if r.MetricsEnabled {
-		policyServerDeployment.Annotations[constants.OptelInjectAnnotation] = "true"
-	}
 }
 
 func envVarsContainVariable(envVars []corev1.EnvVar, envVarName string) int {
@@ -358,6 +355,8 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *policiesv
 		templateAnnotations = make(map[string]string)
 	}
 	if r.MetricsEnabled {
+		templateAnnotations[constants.OptelInjectAnnotation] = "true"
+
 		envvar := corev1.EnvVar{Name: constants.PolicyServerEnableMetricsEnvVar, Value: "1"}
 		if index := envVarsContainVariable(admissionContainer.Env, constants.PolicyServerEnableMetricsEnvVar); index >= 0 {
 			admissionContainer.Env[index] = envvar

--- a/internal/pkg/admission/policy-server-deployment_test.go
+++ b/internal/pkg/admission/policy-server-deployment_test.go
@@ -486,7 +486,7 @@ func TestPolicyServerDeploymentMetricConfigurationWithValueDefinedByUser(t *test
 		t.Error("Missing {} environment variable", constants.PolicyServerLogFmtEnvVar)
 	}
 
-	value, hasAnnotation := deployment.Annotations["sidecar.opentelemetry.io/inject"]
+	value, hasAnnotation := deployment.Spec.Template.Annotations["sidecar.opentelemetry.io/inject"]
 	if !hasAnnotation {
 		t.Error("Missing OTEL annotation")
 	}
@@ -525,7 +525,7 @@ func TestPolicyServerDeploymentMetricConfigurationWithNoValueDefinedByUSer(t *te
 		t.Error("{} should not be set", constants.PolicyServerLogFmtEnvVar)
 	}
 
-	_, hasAnnotation := deployment.Annotations["sidecar.opentelemetry.io/inject"]
+	_, hasAnnotation := deployment.Spec.Template.Annotations["sidecar.opentelemetry.io/inject"]
 	if hasAnnotation {
 		t.Error("OTEL annotation should not be set")
 	}


### PR DESCRIPTION
## Description

The controller was adding the OTEL annotation to inject the collector container in the deploy annotations but it should be added in the pod spec inside the deployment spec. This commit fixes that and the tests to validate this behavior.


