### PR TITLE
ci: Set `image:latest` tag depending on branch name

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -8,7 +8,8 @@ on:
         value: ${{jobs.build.outputs.digest}}
   push:
     branches:
-      - "*"
+      - "main"
+      - "feat-**"
 
 jobs:
   build:

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -65,12 +65,17 @@ jobs:
         if: ${{ inputs.generate-sbom == true }}
         uses: sigstore/cosign-installer@v2.8.1
       -
-        name: Retrieve tag name
-        if: ${{ startsWith(github.ref, 'refs/heads/') }}
+        name: Retrieve tag name (main branch)
+        if: ${{ startsWith(github.ref, 'refs/heads/main') }}
         run: |
           echo TAG_NAME=latest >> $GITHUB_ENV
       -
-        name: Retrieve tag name
+        name: Retrieve tag name (feat branch)
+        if: ${{ startsWith(github.ref, 'refs/heads/feat') }}
+        run: |
+          echo "TAG_NAME=latest-$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
+      -
+        name: Retrieve tag name (tag)
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |
             echo TAG_NAME=$(echo $GITHUB_REF | sed -e "s|refs/tags/||") >> $GITHUB_ENV


### PR DESCRIPTION
## Description

Fixes feature branches overwriting `:latest` tag. Now,
- for main branch, build `:latest` tag.
- for feat-foo branch, build `:latest-feat-foo` tag.

Now, don't build `:latest` besides from main or feat-foo branches.

## Test

Tested it on my fork, consuming my version of the workflow.
- Build of `:latest` from viccuad/main branch:
  https://github.com/viccuad/kubewarden-controller/actions/runs/4935561822/jobs/8822024336
- Build of `:latest-feat-audit`, from viccuad/feat-audit branch:
  https://github.com/viccuad/kubewarden-controller/actions/runs/4935576031/jobs/8822055682
  https://github.com/viccuad/kubewarden-controller/pkgs/container/kubewarden-controller/92103647?tag=latest-feat-audit

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
