### PR TITLE
fix: missing metrics port in the policy server service.

### DIFF
--- a/internal/pkg/admission/policy-server-service.go
+++ b/internal/pkg/admission/policy-server-service.go
@@ -70,7 +70,7 @@ func (r *Reconciler) service(policyServer *policiesv1.PolicyServer) *corev1.Serv
 			},
 		},
 	}
-	if metricsEnabled(policyServer) {
+	if r.MetricsEnabled {
 		svc.Spec.Ports = append(
 			svc.Spec.Ports,
 			corev1.ServicePort{
@@ -81,15 +81,4 @@ func (r *Reconciler) service(policyServer *policiesv1.PolicyServer) *corev1.Serv
 		)
 	}
 	return &svc
-}
-
-// If an environment variable `KUBEWARDEN_ENABLE_METRICS` is exported -- regardless of its value --,
-// metrics are considered enabled.
-func metricsEnabled(policyServer *policiesv1.PolicyServer) bool {
-	for _, envVar := range policyServer.Spec.Env {
-		if envVar.Name == constants.PolicyServerEnableMetricsEnvVar {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/pkg/admission/policy-server-service_test.go
+++ b/internal/pkg/admission/policy-server-service_test.go
@@ -5,71 +5,24 @@ import (
 
 	policiesv1 "github.com/kubewarden/kubewarden-controller/apis/policies/v1"
 	"github.com/kubewarden/kubewarden-controller/internal/pkg/constants"
-	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestMetricsEnabled(t *testing.T) {
-	cases := []struct {
-		policyServer           policiesv1.PolicyServer
-		expectedMetricsEnabled bool
-	}{
-		{
-			policyServer: policyServerWithEnvVar(
-				"SOME_VAR", "SOME_VALUE",
-			),
-			expectedMetricsEnabled: false,
-		},
-		{
-			policyServer: policyServerWithEnvVar(
-				constants.PolicyServerEnableMetricsEnvVar, "1",
-			),
-			expectedMetricsEnabled: true,
-		},
-		{
-			policyServer: policyServerWithEnvVar(
-				constants.PolicyServerEnableMetricsEnvVar, "true",
-			),
-			expectedMetricsEnabled: true,
-		},
-		// If the environment variable is exported -- regardless of its value --, metrics are
-		// considered enabled
-		{
-			policyServer: policyServerWithEnvVar(
-				constants.PolicyServerEnableMetricsEnvVar, "",
-			),
-			expectedMetricsEnabled: true,
-		},
-		{
-			policyServer: policyServerWithEnvVar(
-				constants.PolicyServerEnableMetricsEnvVar, "0",
-			),
-			expectedMetricsEnabled: true,
-		},
-		{
-			policyServer: policyServerWithEnvVar(
-				constants.PolicyServerEnableMetricsEnvVar, "false",
-			),
-			expectedMetricsEnabled: true,
+	reconciler := newReconciler([]client.Object{}, true)
+	if !reconciler.MetricsEnabled {
+		t.Fatal("Metric not enabled")
+	}
+	policyServer := &policiesv1.PolicyServer{
+		Spec: policiesv1.PolicyServerSpec{
+			Image: "image",
 		},
 	}
-
-	for _, testCase := range cases {
-		expected, actual := testCase.expectedMetricsEnabled, metricsEnabled(&testCase.policyServer)
-		if actual != expected {
-			t.Errorf("metrics enabled value (%v) does not match expected value: %v", actual, expected)
+	service := reconciler.service(policyServer)
+	for _, port := range service.Spec.Ports {
+		if port.Port == constants.PolicyServerMetricsPort {
+			return
 		}
 	}
-}
-
-func policyServerWithEnvVar(name, value string) policiesv1.PolicyServer {
-	return policiesv1.PolicyServer{
-		Spec: policiesv1.PolicyServerSpec{
-			Env: []corev1.EnvVar{
-				{
-					Name:  name,
-					Value: value,
-				},
-			},
-		},
-	}
+	t.Error("Policy Server service is missing metrics port")
 }

--- a/internal/pkg/admission/reconciler_test.go
+++ b/internal/pkg/admission/reconciler_test.go
@@ -75,7 +75,7 @@ func TestGetPolicies(t *testing.T) {
 	for _, test := range tests {
 		ttest := test // ensure ttest is correctly scoped when used in function literal
 		t.Run(ttest.name, func(t *testing.T) {
-			reconciler := newReconciler(ttest.policies)
+			reconciler := newReconciler(ttest.policies, false)
 			policies, err := reconciler.GetPolicies(context.Background(), &policiesv1.PolicyServer{
 				ObjectMeta: metav1.ObjectMeta{Name: policyServer},
 			}, IncludeDeleted)
@@ -89,7 +89,7 @@ func TestGetPolicies(t *testing.T) {
 	}
 }
 
-func newReconciler(policies []client.Object) Reconciler {
+func newReconciler(policies []client.Object, metricsEnabled bool) Reconciler {
 	customScheme := scheme.Scheme
 	customScheme.AddKnownTypes(schema.GroupVersion{Group: "policies.kubewarden.io", Version: "v1"}, &policiesv1.ClusterAdmissionPolicy{}, &policiesv1.AdmissionPolicy{}, &policiesv1.ClusterAdmissionPolicyList{}, &policiesv1.AdmissionPolicyList{})
 	cl := fake.NewClientBuilder().WithScheme(customScheme).WithObjects(policies...).Build()
@@ -97,5 +97,6 @@ func newReconciler(policies []client.Object) Reconciler {
 	return Reconciler{
 		Client:               cl,
 		DeploymentsNamespace: namespace,
+		MetricsEnabled:       metricsEnabled,
 	}
 }


### PR DESCRIPTION
## Description

In the latest changes in the controller we remove the need to define the OTEL environment variables in the policy server definition. This causes a problem because the controller uses this information to detect if it should adds the metrics port in the policy server service.

This commit fixes that by checking the flag in the controller to know if metrics are enabled or not.

Related to https://github.com/kubewarden/kubewarden-controller/pull/442
