### PR TITLE
chore(deps): use version tag instead of commit ref.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
             });
 
       - name: Trigger chart update
-        uses: peter-evans/repository-dispatch@02f5adb87b06ea7a7b98326fa63e1782701201cd
+        uses: peter-evans/repository-dispatch@v2.1.1
         with:
           token: ${{ secrets.WORKFLOW_PAT }}
           repository: "${{github.repository_owner}}/helm-charts"


### PR DESCRIPTION
## Description

Updates the step in the release workflow where the helm charts update is trigger to use version tag of the Github action in use, instead of using the commit reference.

