### PR TITLE
feat: Add IsContextAware(), for AdmPolicies returns always false

### DIFF
--- a/pkg/apis/policies/v1/admissionpolicy_types.go
+++ b/pkg/apis/policies/v1/admissionpolicy_types.go
@@ -82,6 +82,10 @@ func (r *AdmissionPolicy) IsMutating() bool {
 	return r.Spec.Mutating
 }
 
+func (r *AdmissionPolicy) IsContextAware() bool {
+	return false
+}
+
 func (r *AdmissionPolicy) GetSettings() runtime.RawExtension {
 	return r.Spec.Settings
 }

--- a/pkg/apis/policies/v1/clusteradmissionpolicy_types.go
+++ b/pkg/apis/policies/v1/clusteradmissionpolicy_types.go
@@ -142,6 +142,10 @@ func (r *ClusterAdmissionPolicy) IsMutating() bool {
 	return r.Spec.Mutating
 }
 
+func (r *ClusterAdmissionPolicy) IsContextAware() bool {
+	return len(r.Spec.ContextAwareResources) > 0
+}
+
 func (r *ClusterAdmissionPolicy) GetSettings() runtime.RawExtension {
 	return r.Spec.Settings
 }

--- a/pkg/apis/policies/v1/policy.go
+++ b/pkg/apis/policies/v1/policy.go
@@ -89,6 +89,7 @@ type Policy interface {
 	SetPolicyModeStatus(policyMode PolicyModeStatus)
 	GetModule() string
 	IsMutating() bool
+	IsContextAware() bool
 	GetSettings() runtime.RawExtension
 	GetStatus() *PolicyStatus
 	SetStatus(status PolicyStatusEnum)


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/kubewarden-controller/issues/461

feat: Add IsContextAware(), for AdmPolicies returns always false
We are context aware if spec.ContextAwareResources has at least one entry.
AdmissionPolicies cannot be context aware so far.
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

No test needed.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
