### PR TITLE
fix: updates cosign to v2.

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -34,19 +34,15 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: sigstore/cosign-installer@v2.8.1
+      - uses: sigstore/cosign-installer@v3
+
       - name: Sign the images
         run: |
-          cosign sign \
+          cosign sign --yes \
             ${{needs.build.outputs.repository}}@${{needs.build.outputs.digest}}
-        env:
-          COSIGN_EXPERIMENTAL: 1
 
-      - uses: sigstore/cosign-installer@v2.8.1
       - name: Sign the SBOM
         run: |
           tag=$(echo '${{needs.build.outputs.digest}}' | sed 's/:/-/g')
-          cosign sign \
+          cosign sign --yes \
             "${{needs.build.outputs.repository}}:$tag.sbom"
-        env:
-          COSIGN_EXPERIMENTAL: 1

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -63,7 +63,7 @@ jobs:
       -
         name: Install Cosign
         if: ${{ inputs.generate-sbom == true }}
-        uses: sigstore/cosign-installer@v2.8.1
+        uses: sigstore/cosign-installer@v3
       -
         name: Retrieve tag name (main branch)
         if: ${{ startsWith(github.ref, 'refs/heads/main') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         run: go install sigs.k8s.io/bom/cmd/bom@v0.2.2
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v2.8.1
+        uses: sigstore/cosign-installer@v3
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -61,7 +61,7 @@ jobs:
 
       - name: Sign BOM file
         run: |
-          cosign sign-blob --output-certificate kubewarden-controller-sbom.spdx.cert \
+          cosign sign-blob --yes --output-certificate kubewarden-controller-sbom.spdx.cert \
             --output-signature kubewarden-controller-sbom.spdx.sig \
             kubewarden-controller-sbom.spdx
         env:


### PR DESCRIPTION
## Description

Updates the CI scripts updating the cosign-installer to v3. Thus, the cosign version now is v2. Which has breaking changes requiring some changes on how the command is called and removing the need of using environment variable to enable keyless signature.

Related to https://github.com/kubewarden/kubewarden-controller/issues/411