### PR TITLE
fix: GH action, reuse actions from the same checkout

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: Build
-    uses: kubewarden/kubewarden-controller/.github/workflows/container-image.yml@main
+    uses: ./.github/workflows/container-image.yml
     permissions:
       packages: write
     with:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: "Build"
-    uses: kubewarden/kubewarden-controller/.github/workflows/container-image.yml@main
+    uses: ./.github/workflows/container-image.yml
     permissions:
       packages: write
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,11 @@ permissions: read-all
 
 jobs:
   ci:
-    uses: kubewarden/kubewarden-controller/.github/workflows/ci.yml@main
+    uses: ./.github/workflows/ci.yml
     permissions: read-all
 
   container-build:
-    uses: kubewarden/kubewarden-controller/.github/workflows/container-build.yml@main
+    uses: ./.github/workflows/container-build.yml
     permissions:
       id-token: write
       packages: write


### PR DESCRIPTION
Prior to this commit, some GH actions reused workflows that came from the `main` branch, regardless of the branch (or tag) triggering the execution.

This can be a bit dangerous and have side effects. This commit ensures everything stays in sync.
