### PR TITLE
fix: enable release candidates when required

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,8 @@ jobs:
               release_id: `${RELEASE_ID}`,
               draft: false,
               tag_name: `${TAG_NAME}`,
-              name: `${TAG_NAME}`
+              name: `${TAG_NAME}`,
+              prerelease: `${{ contains(github.event.workflow_run.head_branch, '-alpha') || contains(github.event.workflow_run.head_branch, '-beta') || contains(github.event.workflow_run.head_branch, '-rc') }}`
             });
 
       - name: Trigger chart update


### PR DESCRIPTION
## Description

Updates the release CI to check if the pushed tag has some text indicating a release candidate and set properly the flag to 
publish the release as final release or a candidate.

Related to https://github.com/kubewarden/policy-server/pull/497/files#r1268541197