### PR TITLE
ci: Fix e2e tests, no need for `id-token` write perms for them

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -1,4 +1,4 @@
-name: Build container image and SBOMs
+name: Build container image, sign it, and generate SBOMs
 
 on:
   workflow_call:

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -18,9 +18,18 @@ jobs:
     uses: ./.github/workflows/container-image.yml
     permissions:
       packages: write
-      id-token: write
     with:
       push-image: true
+
+  sign:
+    name: Sign container image
+    needs: build
+    uses: ./.github/workflows/sign-image.yml
+    permissions:
+      packages: write
+      id-token: write
+    with:
+      image-digest: ${{ needs.build.outputs.digest }}
 
   sbom:
     name: Generate SBOM and push them to OCI registry

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -14,7 +14,6 @@ on:
 
 jobs:
   build:
-    name: Build container image
     uses: ./.github/workflows/container-image.yml
     permissions:
       packages: write
@@ -22,7 +21,6 @@ jobs:
       push-image: true
 
   sign:
-    name: Sign container image
     needs: build
     uses: ./.github/workflows/sign-image.yml
     permissions:
@@ -32,7 +30,6 @@ jobs:
       image-digest: ${{ needs.build.outputs.digest }}
 
   sbom:
-    name: Generate SBOM and push them to OCI registry
     needs: build
     uses: ./.github/workflows/sbom.yml
     permissions:

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -25,7 +25,6 @@ jobs:
     name: Build container image
     permissions:
       packages: write
-      id-token: write
     runs-on: ubuntu-latest
     outputs:
       repository: ${{ steps.setoutput.outputs.repository }}
@@ -49,10 +48,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Install cosign
-        if: ${{ inputs.push-image }}
-        uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 # v3
       -
         name: Retrieve tag name (main branch)
         if: ${{ startsWith(github.ref, 'refs/heads/main') }}
@@ -80,12 +75,6 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{github.repository_owner}}/kubewarden-controller:${{ env.TAG_NAME }}
-      -
-        name: Sign container image
-        if: ${{ inputs.push-image }}
-        run: |
-          cosign sign --yes \
-            ghcr.io/${{github.repository_owner}}/kubewarden-controller@${{ steps.build-image.outputs.digest }}
       -
         # Only build amd64 because buildx does not allow multiple platforms when
         # exporting the image to a tarball. As we use this only for end-to-end tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     permissions: read-all
 
   build:
-    name: Build container image and SBOMs
+    name: Build container image, sign it, and generate SBOMs
     uses: ./.github/workflows/container-build.yml
     permissions:
       id-token: write

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   sbom:
-    name: Build SBOM, sign and attach them to OCI image
+    name: Generate SBOM, sign and attach them to OCI image
     strategy:
       matrix:
         arch: [amd64, arm64]

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,4 +1,4 @@
-name: Build container image
+name: Generate SBOMs
 
 on:
   workflow_call:

--- a/.github/workflows/sign-image.yml
+++ b/.github/workflows/sign-image.yml
@@ -1,0 +1,32 @@
+name: Sign image
+
+on:
+  workflow_call:
+    inputs:
+      image-digest:
+        type: string
+        required: true
+
+jobs:
+  sign:
+    name: Sign image
+    permissions:
+      packages: write
+      id-token: write
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 # v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign container image
+        run: |
+          cosign sign --yes \
+            ghcr.io/${{github.repository_owner}}/kubewarden-controller@${{ inputs.image-digest }}


### PR DESCRIPTION
## Description

This removes the `id-token` permission from container-image.yml, by separating the image signing into sign-image.yml.

This makes container-image.yml reusable as a workflow. If not, one gets:
```
The nested job 'build' is requesting 'id-token: write', but is only allowed 'id-token: none'
```

This happens on the e2e-tests.yml workflow without this change.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To be tested on my CI fork run. Notice the separation of the container signing into its own job.
Run of build image:
https://github.com/viccuad/kubewarden-controller/actions/runs/5667913267

Run of end-to-end-tests, without the error now:
https://github.com/viccuad/kubewarden-controller/actions/runs/5667954405
(they fail on the e2e tests proper, but not on the build image)

No changes to release job.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
