### PR TITLE
ci: Set normal releases as latest in GH Release page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,8 @@ jobs:
               draft: false,
               tag_name: `${TAG_NAME}`,
               name: `${TAG_NAME}`,
-              prerelease: `${{ contains(github.event.workflow_run.head_branch, '-alpha') || contains(github.event.workflow_run.head_branch, '-beta') || contains(github.event.workflow_run.head_branch, '-rc') }}`
+              prerelease: `${{ contains(github.event.workflow_run.head_branch, '-alpha') || contains(github.event.workflow_run.head_branch, '-beta') || contains(github.event.workflow_run.head_branch, '-rc') }}`,
+              make_latest: `${{ !(contains(github.event.workflow_run.head_branch, '-alpha') || contains(github.event.workflow_run.head_branch, '-beta') || contains(github.event.workflow_run.head_branch, '-rc')) }}`
             });
 
       - name: Trigger chart update


### PR DESCRIPTION

## Description

This is done by passing `make_latest` in the REST API update. See:
https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#update-a-release

`make_latest` can be `true`, `false`, `legacy`, with legacy using semver, but I'm not sure from where it obtains the semver version (the release name?).

Hence setting it to `true` when not alpha, beta, or rc.


Relates to https://github.com/kubewarden/kubewarden-controller/issues/534.

## Test

Not tested.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
