### PR TITLE
fix!: Don't reconcile KUBEWARDEN_LOG_FMT envvar

### DIFF
--- a/internal/pkg/admission/policy-server-deployment.go
+++ b/internal/pkg/admission/policy-server-deployment.go
@@ -332,12 +332,6 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *policiesv
 		} else {
 			admissionContainer.Env = append(admissionContainer.Env, envvar)
 		}
-		logFmtEnvVar := corev1.EnvVar{Name: constants.PolicyServerLogFmtEnvVar, Value: "otlp"}
-		if index := envVarsContainVariable(admissionContainer.Env, constants.PolicyServerLogFmtEnvVar); index >= 0 {
-			admissionContainer.Env[index] = logFmtEnvVar
-		} else {
-			admissionContainer.Env = append(admissionContainer.Env, logFmtEnvVar)
-		}
 	}
 
 	policyServerDeployment := &appsv1.Deployment{

--- a/internal/pkg/admission/policy-server-deployment_test.go
+++ b/internal/pkg/admission/policy-server-deployment_test.go
@@ -11,14 +11,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const policyServerName = "testing"
-const policyServerContainerName = "policy-server-testing"
-const invalidPolicyServerName = "invalid"
-const dropCapabilityAll = "all"
+const (
+	policyServerName          = "testing"
+	policyServerContainerName = "policy-server-testing"
+	invalidPolicyServerName   = "invalid"
+	dropCapabilityAll         = "all"
+)
 
 func TestShouldUpdatePolicyServerDeployment(t *testing.T) {
 	deployment := createDeployment(1, "sa", "", "image", nil, []corev1.EnvVar{{Name: "env1"}}, map[string]string{})
-	var tests = []struct {
+	tests := []struct {
 		name     string
 		original *appsv1.Deployment
 		new      *appsv1.Deployment
@@ -57,7 +59,8 @@ func TestShouldUpdatePolicyServerDeployment(t *testing.T) {
 
 func createDeployment(replicasInt int, serviceAccount, imagePullSecret, image string,
 	insecureSources []string,
-	env []corev1.EnvVar, annotations map[string]string) *appsv1.Deployment {
+	env []corev1.EnvVar, annotations map[string]string,
+) *appsv1.Deployment {
 	replicas := int32(replicasInt)
 	const (
 		imagePullSecretVolumeName        = "imagepullsecret"
@@ -435,7 +438,7 @@ func TestDefaultContainerSecurityContext(t *testing.T) {
 }
 
 func TestMetricAndLogFmtEnvVarsDetection(t *testing.T) {
-	for _, envVarName := range []string{constants.PolicyServerEnableMetricsEnvVar, constants.PolicyServerLogFmtEnvVar} {
+	for _, envVarName := range []string{constants.PolicyServerEnableMetricsEnvVar} {
 		env := []corev1.EnvVar{{Name: "env1"}, {Name: "env2"}, {Name: envVarName}, {Name: "env3"}}
 		envIndex := envVarsContainVariable(env, envVarName)
 		if envIndex != 2 {
@@ -459,12 +462,11 @@ func TestPolicyServerDeploymentMetricConfigurationWithValueDefinedByUser(t *test
 	policyServer := &policiesv1.PolicyServer{
 		Spec: policiesv1.PolicyServerSpec{
 			Image: "image",
-			Env:   []corev1.EnvVar{{Name: constants.PolicyServerEnableMetricsEnvVar, Value: "0"}, {Name: constants.PolicyServerLogFmtEnvVar, Value: "invalid"}},
+			Env:   []corev1.EnvVar{{Name: constants.PolicyServerEnableMetricsEnvVar, Value: "0"}},
 		},
 	}
 	deployment := reconciler.deployment("v1", policyServer)
 	hasMetricEnvvar := false
-	hasLogFmtEnvvar := false
 	for _, envvar := range deployment.Spec.Template.Spec.Containers[0].Env {
 		if envvar.Name == constants.PolicyServerEnableMetricsEnvVar {
 			hasMetricEnvvar = true
@@ -472,18 +474,9 @@ func TestPolicyServerDeploymentMetricConfigurationWithValueDefinedByUser(t *test
 				t.Error("Present but not reconciled {} value", constants.PolicyServerEnableMetricsEnvVar)
 			}
 		}
-		if envvar.Name == constants.PolicyServerLogFmtEnvVar {
-			hasLogFmtEnvvar = true
-			if envvar.Value != "otlp" {
-				t.Error("Present but not reconciled {} value", constants.PolicyServerLogFmtEnvVar)
-			}
-		}
 	}
 	if !hasMetricEnvvar {
 		t.Error("Missing {} environment variable", constants.PolicyServerEnableMetricsEnvVar)
-	}
-	if !hasLogFmtEnvvar {
-		t.Error("Missing {} environment variable", constants.PolicyServerLogFmtEnvVar)
 	}
 
 	value, hasAnnotation := deployment.Spec.Template.Annotations["sidecar.opentelemetry.io/inject"]
@@ -509,20 +502,13 @@ func TestPolicyServerDeploymentMetricConfigurationWithNoValueDefinedByUSer(t *te
 	}
 	deployment := reconciler.deployment("v1", policyServer)
 	hasMetricEnvvar := false
-	hasLogFmtEnvvar := false
 	for _, envvar := range deployment.Spec.Template.Spec.Containers[0].Env {
 		if envvar.Name == constants.PolicyServerEnableMetricsEnvVar {
 			hasMetricEnvvar = true
 		}
-		if envvar.Name == constants.PolicyServerLogFmtEnvVar {
-			hasLogFmtEnvvar = true
-		}
 	}
 	if hasMetricEnvvar {
 		t.Error("{} should not be set", constants.PolicyServerEnableMetricsEnvVar)
-	}
-	if hasLogFmtEnvvar {
-		t.Error("{} should not be set", constants.PolicyServerLogFmtEnvVar)
 	}
 
 	_, hasAnnotation := deployment.Spec.Template.Annotations["sidecar.opentelemetry.io/inject"]

--- a/internal/pkg/admission/policy-server-deployment_test.go
+++ b/internal/pkg/admission/policy-server-deployment_test.go
@@ -437,7 +437,7 @@ func TestDefaultContainerSecurityContext(t *testing.T) {
 	}
 }
 
-func TestMetricAndLogFmtEnvVarsDetection(t *testing.T) {
+func TestMetricsEnvVarDetection(t *testing.T) {
 	for _, envVarName := range []string{constants.PolicyServerEnableMetricsEnvVar} {
 		env := []corev1.EnvVar{{Name: "env1"}, {Name: "env2"}, {Name: envVarName}, {Name: "env3"}}
 		envIndex := envVarsContainVariable(env, envVarName)

--- a/internal/pkg/constants/constants.go
+++ b/internal/pkg/constants/constants.go
@@ -1,11 +1,9 @@
 package constants
 
-var (
-	// DefaultPolicyServer is set to a non empty value if policies that
-	// are missing a policy server should be defaulted to this one
-	// before being persisted.
-	DefaultPolicyServer string
-)
+// DefaultPolicyServer is set to a non empty value if policies that
+// are missing a policy server should be defaulted to this one
+// before being persisted.
+var DefaultPolicyServer string
 
 const (
 	// PolicyServer CA Secret
@@ -24,7 +22,6 @@ const (
 	PolicyServerMetricsPortEnvVar                   = "KUBEWARDEN_POLICY_SERVER_SERVICES_METRICS_PORT"
 	PolicyServerMetricsPort                         = 8080
 	PolicyServerReadinessProbe                      = "/readiness"
-	PolicyServerLogFmtEnvVar                        = "KUBEWARDEN_LOG_FMT"
 
 	// PolicyServer ConfigMap
 	PolicyServerConfigPoliciesEntry         = "policies.yml"


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/helm-charts/issues/310

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

Reconciling this env var means users cannot set it as needed, for example to configure exporters to output JSON.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Not needed.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
