### PR TITLE
feat!: Add `--enable-tracing`, separate metrics and tracing reconciliation

### DIFF
--- a/internal/pkg/admission/policy-server-deployment.go
+++ b/internal/pkg/admission/policy-server-deployment.go
@@ -323,8 +323,9 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *policiesv
 	if templateAnnotations == nil {
 		templateAnnotations = make(map[string]string)
 	}
+
 	if r.MetricsEnabled {
-		templateAnnotations[constants.OptelInjectAnnotation] = "true"
+		templateAnnotations[constants.OptelInjectAnnotation] = "true" //nolint:goconst
 
 		envvar := corev1.EnvVar{Name: constants.PolicyServerEnableMetricsEnvVar, Value: "1"}
 		if index := envVarsContainVariable(admissionContainer.Env, constants.PolicyServerEnableMetricsEnvVar); index >= 0 {
@@ -332,6 +333,11 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *policiesv
 		} else {
 			admissionContainer.Env = append(admissionContainer.Env, envvar)
 		}
+	}
+
+	if r.TracingEnabled {
+		templateAnnotations[constants.OptelInjectAnnotation] = "true"
+
 		logFmtEnvVar := corev1.EnvVar{Name: constants.PolicyServerLogFmtEnvVar, Value: "otlp"}
 		if index := envVarsContainVariable(admissionContainer.Env, constants.PolicyServerLogFmtEnvVar); index >= 0 {
 			admissionContainer.Env[index] = logFmtEnvVar

--- a/internal/pkg/admission/reconciler.go
+++ b/internal/pkg/admission/reconciler.go
@@ -25,6 +25,7 @@ type Reconciler struct {
 	AlwaysAcceptAdmissionReviewsInDeploymentsNamespace bool
 	Log                                                logr.Logger
 	MetricsEnabled                                     bool
+	TracingEnabled                                     bool
 }
 
 type reconcilerErrors []error

--- a/main.go
+++ b/main.go
@@ -75,6 +75,7 @@ func main() {
 	var alwaysAcceptAdmissionReviewsOnDeploymentsNamespace bool
 	var probeAddr string
 	var enableMetrics bool
+	var enableTracing bool
 	var openTelemetryEndpoint string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8088", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -82,7 +83,9 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&enableMetrics, "enable-metrics", false,
-		"Enable metrics collection about policy server and cluster admission policies")
+		"Enable metrics collection for PolicyServers and ClusterAdmissionPolicies")
+	flag.BoolVar(&enableTracing, "enable-tracing", false,
+		"Enable tracing collection for PolicyServerReconciler and ClusterAdmissionPolicies")
 	flag.StringVar(&openTelemetryEndpoint, "opentelemetry-endpoint", "127.0.0.1:4317", "The OpenTelemetry connection endpoint")
 	flag.StringVar(&constants.DefaultPolicyServer, "default-policy-server", "", "The default policy server to set on policies before they are persisted")
 	opts := zap.Options{
@@ -207,6 +210,7 @@ func main() {
 		DeploymentsNamespace: deploymentsNamespace,
 		AlwaysAcceptAdmissionReviewsInDeploymentsNamespace: alwaysAcceptAdmissionReviewsOnDeploymentsNamespace,
 		MetricsEnabled: enableMetrics,
+		TracingEnabled: enableTracing,
 	}
 
 	if err = (&controllers.PolicyServerReconciler{

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 	flag.BoolVar(&enableMetrics, "enable-metrics", false,
 		"Enable metrics collection for all Policy Servers and the Kubewarden Controller")
 	flag.BoolVar(&enableTracing, "enable-tracing", false,
-		"Enable tracing collection for PolicyServerReconciler and ClusterAdmissionPolicies")
+		"Enable tracing collection for all Policy Servers")
 	flag.StringVar(&openTelemetryEndpoint, "opentelemetry-endpoint", "127.0.0.1:4317", "The OpenTelemetry connection endpoint")
 	flag.StringVar(&constants.DefaultPolicyServer, "default-policy-server", "", "The default policy server to set on policies before they are persisted")
 	opts := zap.Options{

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&enableMetrics, "enable-metrics", false,
-		"Enable metrics collection for PolicyServers and ClusterAdmissionPolicies")
+		"Enable metrics collection for all Policy Servers and the Kubewarden Controller")
 	flag.BoolVar(&enableTracing, "enable-tracing", false,
 		"Enable tracing collection for PolicyServerReconciler and ClusterAdmissionPolicies")
 	flag.StringVar(&openTelemetryEndpoint, "opentelemetry-endpoint", "127.0.0.1:4317", "The OpenTelemetry connection endpoint")


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Related to https://github.com/kubewarden/helm-charts/issues/310


Metrics doesn't set the log format of PolicyServers anymore.
Add logic for enabling tracing when enableTracing is true.


## Test

<!-- Please provides a short description about how to test your pullrequest -->
Unit tests.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
