### PR TITLE
feat(docs): using telepresence in development mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ testbin/*
 
 # Manually generated crds. Directory is needed though
 generated-crds/*
+cert/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-This document contains instructions on how to build and run locally the controller
+This document contains instructions on how to build and run the controller locally
 allowing developers to test their changes.
 
 ## Building
@@ -54,7 +54,7 @@ to access workloads in the cluster and receive requests to the controller runnin
 in the developer machine.  
 
 > Install the telepresence binary from the Github releases page. The official 
-> once from Ambassador Labs may require login. 
+> ones from Ambassador Labs may require login. 
 
 Before running the controller, install the custom resource definitions:
 
@@ -71,10 +71,10 @@ kubectl create ns kubewarden
 Now, as we are using `telepresence` to intercept the intra cluster
 communication, we need to create the controller deployment and service that
 `telepresence` will intercept. For this, install the Kuberwarden stack
-following the steps described quickstart guide. In other words, install
-Kubewarden controller helm chart. However, a change is required. The controller
-deployment must allow root users. This is disable by default and it is required
-because `telepresence` will add a init container in the deployment which need
+following the steps described in the quickstart guide. In other words, install
+the Kubewarden controller helm chart. However, a change is required. The controller
+deployment must allow root users. This is disabled by default and it is required
+because `telepresence` will add a init container in the deployment which needs
 root access.
 
 ```console
@@ -137,9 +137,9 @@ spec:
 EOF
 ```
 
-> Note: if you want to use some kind o NetworkPolicy to block the original controller traffic
-> you may need to have a multi node cluster. Because in a single node cluster the traffic 
-> policies will not be applied. Because the traffic will not leave the node and never the
+> Note: if you want to use some kind of NetworkPolicy to block the original controller traffic
+> you may need to have a multi node cluster. In a single node cluster the traffic 
+> policies will not be applied. Because the traffic will not leave the node and will never be
 > checked against the network policies
 
 To intercept requests sent to the Kubewarden controller run the following command:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
 # Contributing
 
+This document contains instructions on how to build and run locally the controller
+allowing developers to test their changes.
+
 ## Building
 
 To build kubewarden-controller some packages are required. If you are using
@@ -20,9 +23,8 @@ make
 You can run the controller by executing `make run`. This Makefile
 target executes the controller locally as a regular process.
 
-In order to execute this Makefile target, you need to have created a
-Kubernetes cluster with `k3d`, `kind` or `minikube` that is reachable
-through your `~/.kube/config` kubeconfig file.
+In order to execute this Makefile target, you need to have created a Kubernetes
+cluster with that is reachable through your `~/.kube/config` kubeconfig file.
 
 These are the relevant environment variables:
 
@@ -41,12 +43,18 @@ These are the relevant environment variables:
   enabled. If not provided and `WEBHOOK_HOST_LISTEN` is provided,
   it will be defaulted to `WEBHOOK_HOST_LISTEN`.
 
-The Subject Alternative Names of the generated certificate in
-development mode will contain whatever was provided on
-`WEBHOOK_HOST_ADVERTISE` (or whatever it was defaulted to, if it was
-not provided).
+The Subject Alternative Names of the generated certificate in development mode
+will contain whatever was provided on `WEBHOOK_HOST_ADVERTISE` (or whatever it
+was defaulted to, if it was not provided).
 
-### Install Custom Resource Definitions
+To run the controller in the developer workstation it's possible to use
+[telepresence](https://github.com/telepresenceio/telepresence). It allows
+developers to "add" the local workstation in the cluster. Thus, it's possible
+to access workloads in the cluster and receive requests to the controller running
+in the developer machine.  
+
+> Install the telepresence binary from the Github releases page. The official 
+> once from Ambassador Labs may require login. 
 
 Before running the controller, install the custom resource definitions:
 
@@ -54,42 +62,144 @@ Before running the controller, install the custom resource definitions:
 kubectl apply -f config/crd/bases
 ```
 
-### Create the `kubewarden` namespace
+Create the `kubewarden` namespace
 
 ```console
 kubectl create ns kubewarden
 ```
 
-### Running
-
-#### Running with k3d
+Now, as we are using `telepresence` to intercept the intra cluster
+communication, we need to create the controller deployment and service that
+`telepresence` will intercept. For this, install the Kuberwarden stack
+following the steps described quickstart guide. In other words, install
+Kubewarden controller helm chart. However, a change is required. The controller
+deployment must allow root users. This is disable by default and it is required
+because `telepresence` will add a init container in the deployment which need
+root access.
 
 ```console
-KUBEWARDEN_DEVELOPMENT_MODE=1 \
-  WEBHOOK_HOST_LISTEN=$(docker inspect k3d-k3s-default-server-0 | jq -r '.[] | .NetworkSettings.Networks."k3d-k3s-default".Gateway') \
-  make run
+# Remember to install the requirements needed. See the quickstart guide for more information
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
+kubectl wait --for=condition=Available deployment --timeout=2m -n cert-manager --all
+helm install --wait -n kubewarden  kubewarden-controller kubewarden/kubewarden-controller
 ```
 
-#### Running with kind
+
+
+Now, install `telepresence` in the cluster and connect it to the `kubewarden` namespace
 
 ```console
-KUBEWARDEN_DEVELOPMENT_MODE=1 \
-  WEBHOOK_HOST_LISTEN=$(docker inspect kind-control-plane | jq -r '.[] | .NetworkSettings.Networks.kind.Gateway') \
-  make run
+telepresence helm install
+telepresence connect -n kubewarden
 ```
 
-#### Running with minikube
+At this point you should be able to reach workloads running in the cluster. To validate
+this use a `curl` command:
 
 ```console
-KUBEWARDEN_DEVELOPMENT_MODE=1 \
-  WEBHOOK_HOST_LISTEN=0.0.0.0 \
-  WEBHOOK_HOST_ADVERTISE=host.minikube.internal \
-  make run
+curl -XGET --insecure https://kubewarden-controller-webhook-service.kubewarden.svc.cluster.local/mutate-policies-kubewarden-io-v1-admissionpolicy
+```
+
+In order to avoid two controllers trying to reconcile the same resources, it's necessary to
+remove the deployment installed by the `kubewarden-controller` helm chart and deploy a dummy
+deployment just to allow `telepresence` to intercept the communications.
+
+```console
+kubectl delete deployment -n kubewarden kubewarden-controller
+kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: kubewarden-controller
+    app.kubernetes.io/name: kubewarden-controller
+  name: kubewarden-controller
+  namespace: kubewarden
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: kubewarden-controller
+      app.kubernetes.io/name: kubewarden-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: kubewarden-controller
+        app.kubernetes.io/name: kubewarden-controller
+    spec:
+      containers:
+      - name: echo-server
+        image: gcr.io/google-containers/echoserver:1.8
+        ports:
+        - containerPort: 9443
+      serviceAccount: kubewarden-controller
+      serviceAccountName: kubewarden-controller
+  replicas: 1
+EOF
+```
+
+> Note: if you want to use some kind o NetworkPolicy to block the original controller traffic
+> you may need to have a multi node cluster. Because in a single node cluster the traffic 
+> policies will not be applied. Because the traffic will not leave the node and never the
+> checked against the network policies
+
+To intercept requests sent to the Kubewarden controller run the following command:
+
+```console
+telepresence intercept kubewarden-controller --port 9443:443
+```
+
+> You can use the `telepresence list` command to check out other services available to
+> intercept communication
+
+This command will trigger a new controller pod with the `telepresence` agent which
+will reroute the request to the pod for your local machine. Therefore, the developer
+can run the controller locally to start receiving the requests:
+
+```console
+WEBHOOK_HOST_LISTEN=127.0.0.1 make run
+```
+
+After that, when a request is sent to the Kubewarden controller service, your
+local instance should handle it. Try again:
+
+
+```console
+curl -XGET --insecure https://kubewarden-controller-webhook-service.kubewarden.svc.cluster.local/mutate-policies-kubewarden-io-v1-admissionpolicy
+```
+
+If you want to remove controller interception, use the `leave` subcommand. It make
+the service running in the cluster start to receiving the requests again:
+
+```console
+telepresence leave kubewarden-controller
+```
+
+After that, if you want to remove all the agents added by the `telepresence` in
+the controller pod, run:
+
+```console
+telepresence uninstall --all-agents
+```
+
+Remember to disconnect `telepresence` from cluster that it is connected:
+
+```console
+telepresence quit
+```
+
+If you forget to quit, next time you try to connect into a cluster, some errors
+can happen. 
+
+Finally, if you want to uninstall the `telepresence` stack from the cluster if
+the `helm` subcommand:
+
+```console
+telepresence helm uninstall
 ```
 
 ## Tagging a new release
 
-### Make sure CRD docs are updated:
+Make sure CRD docs are updated:
 
 ```console
 $ cd docs/crds
@@ -97,9 +207,7 @@ $ make generate
 $ # commit resulting changes
 ```
 
-### Create a new tag
-
-Assuming your official kubewarden remote is called `upstream`:
+Create a new tag, assuming your official kubewarden remote is called `upstream`:
 
 ```console
 $ git tag -a vX.Y.Z  -m "vX.Y.Z" -s

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,11 @@ build: generate fmt vet ## Build manager binary.
 	go build -o bin/manager .
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run . -deployments-namespace kubewarden --default-policy-server default
+	rm -rf cert
+	mkdir cert
+	kubectl get secrets -n kubewarden webhook-server-cert -o jsonpath --template '{.data.tls\.crt}' | base64 -d > cert/tls.crt
+	kubectl get secrets -n kubewarden webhook-server-cert -o jsonpath --template '{.data.tls\.key}' | base64 -d > cert/tls.key
+	go run . -deployments-namespace kubewarden --default-policy-server default --cert-dir cert
 
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .

--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ func main() {
 	var enableMetrics bool
 	var enableTracing bool
 	var openTelemetryEndpoint string
+	var certDir string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8088", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -95,6 +96,10 @@ func main() {
 		"deployments-namespace",
 		"",
 		"The namespace where the kubewarden resources will be created.")
+	flag.StringVar(&certDir,
+		"cert-dir",
+		"",
+		"directory that contains the server key and certificate. Defaults to `<temp-dir>/k8s-webhook-server/serving-certs`")
 	flag.BoolVar(&alwaysAcceptAdmissionReviewsOnDeploymentsNamespace,
 		"always-accept-admission-reviews-on-deployments-namespace",
 		false,
@@ -140,6 +145,10 @@ func main() {
 		Host: environment.webhookHostListen,
 		Port: 9443,
 	}
+	if certDir != "" {
+		serverOptions.CertDir = certDir
+	}
+
 	mgr, err := webhookwrapper.NewManager(
 		ctrl.Options{
 			Scheme: scheme,


### PR DESCRIPTION
## Description

Updates the CONTRIBUTING.md adding instructions on how to use telepresence to run the Kubewarden controller locally.

Fix https://github.com/kubewarden/kubewarden-controller/issues/548

## Test

Follow the instructions added in the PR.