### PR TITLE
fix: validate policyserver webhook type

### DIFF
--- a/main.go
+++ b/main.go
@@ -305,7 +305,7 @@ func webhooks(deploymentsNamespace string) []webhookwrapper.WebhookRegistrator {
 				},
 			},
 			WebhookPath: "/validate-policies-kubewarden-io-v1-policyserver",
-			Mutating:    true,
+			Mutating:    false,
 		},
 		{
 			Registrator: (&policiesv1.ClusterAdmissionPolicy{}).SetupWebhookWithManager,


### PR DESCRIPTION
Prior to this commit, the webhook created by the controller to validate the PolicyServer resource was a mutating one, instead of a validating one.
