### PR TITLE
Revert "Merge pull request #566 from viccuad/feat-webhooks-reconciled"

### DIFF
--- a/controllers/admissionpolicy_controller.go
+++ b/controllers/admissionpolicy_controller.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kubewarden/kubewarden-controller/internal/pkg/constants"
 	"github.com/kubewarden/kubewarden-controller/internal/pkg/naming"
 	policiesv1 "github.com/kubewarden/kubewarden-controller/pkg/apis/policies/v1"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -81,17 +80,16 @@ func (r *AdmissionPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(r.findAdmissionPoliciesForPod),
 		).
+		// Despite this policy server watch is not strictly necessary, we
+		// include it for the integration tests, so that we identify
+		// policy server creations even when the controller-manager is not
+		// present (so no pods end up being created)
 		Watches(
-			// Despite this PolicyServer watch not being strictly necessary, we
-			// include it for the integration tests, so that we identify
-			// PolicyServer creations even when the controller-manager is not
-			// present (so no pods end up being created)
 			&policiesv1.PolicyServer{},
 			handler.EnqueueRequestsFromMapFunc(r.findAdmissionPoliciesForPolicyServer),
 		).
-		Owns(&admissionregistrationv1.ValidatingWebhookConfiguration{}).
-		Owns(&admissionregistrationv1.MutatingWebhookConfiguration{}).
 		Complete(r)
+
 	if err != nil {
 		return errors.Join(errors.New("failed enrolling controller with manager"), err)
 	}

--- a/controllers/clusteradmissionpolicy_controller.go
+++ b/controllers/clusteradmissionpolicy_controller.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kubewarden/kubewarden-controller/internal/pkg/constants"
 	"github.com/kubewarden/kubewarden-controller/internal/pkg/naming"
 	policiesv1 "github.com/kubewarden/kubewarden-controller/pkg/apis/policies/v1"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -81,17 +80,16 @@ func (r *ClusterAdmissionPolicyReconciler) SetupWithManager(mgr ctrl.Manager) er
 			&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(r.findClusterAdmissionPoliciesForPod),
 		).
+		// Despite this policy server watch is not strictly necessary, we
+		// include it for the integration tests, so that we identify
+		// policy server creations even when the controller-manager is not
+		// present (so no pods end up being created)
 		Watches(
-			// Despite this PolicyServer watch not being strictly necessary, we
-			// include it for the integration tests, so that we identify
-			// PolicyServer creations even when the controller-manager is not
-			// present (so no pods end up being created)
 			&policiesv1.PolicyServer{},
 			handler.EnqueueRequestsFromMapFunc(r.findClusterAdmissionPoliciesForPolicyServer),
 		).
-		Owns(&admissionregistrationv1.ValidatingWebhookConfiguration{}).
-		Owns(&admissionregistrationv1.MutatingWebhookConfiguration{}).
 		Complete(r)
+
 	if err != nil {
 		return errors.Join(errors.New("failed enrolling controller with manager"), err)
 	}

--- a/controllers/policyserver_controller.go
+++ b/controllers/policyserver_controller.go
@@ -155,7 +155,7 @@ func (r *PolicyServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&policiesv1.AdmissionPolicy{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
 			// The watch will trigger twice per object change; once with the old
 			// object, and once the new object. We need to be mindful when doing
-			// Updates since they will invalidate the newer versions of the
+			// Updates since they will invalidate the newever versions of the
 			// object.
 			policy, ok := object.(*policiesv1.AdmissionPolicy)
 			if !ok {
@@ -174,7 +174,7 @@ func (r *PolicyServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&policiesv1.ClusterAdmissionPolicy{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
 			// The watch will trigger twice per object change; once with the old
 			// object, and once the new object. We need to be mindful when doing
-			// Updates since they will invalidate the newer versions of the
+			// Updates since they will invalidate the newever versions of the
 			// object.
 			policy, ok := object.(*policiesv1.ClusterAdmissionPolicy)
 			if !ok {


### PR DESCRIPTION
## Description

I've opened this PR to revert the change adding owner reference the webhooks.  This is necessary because the version `v1.9.0-rc2` containing this feature is not able to set the admission policy as active. This is the error from the controller logs:

```
2023-11-01T14:05:06Z    ERROR   Reconciler error        {"controller": "admissionpolicy", "controllerGroup": "policies.kubewarden.io", "controllerKind": "AdmissionPolicy", "AdmissionPolicy": {"name":"pod-privileged","namespace":"kubewarden"}, "namespace": "kubewarden", "name": "pod-privileged", "reconcileID": "cf067c30-e596-4eaa-ae89-91dc683a659e", "error": "error reconciling validating webhook\ncannot set OwnerReference on WebhookConfiguration: cluster-scoped resource must not have a namespace-scoped owner, owner's namespace kubewarden"}
```

As far as I can [see](https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/), the issue is that we are using a namespace scoped resource (AdmissionPolicy) as the owner of a cluster scoped resource (ValidatiningWebHook). This is not allowed:

```
Cross-namespace owner references are disallowed by design. Namespaced dependents can specify cluster-scoped or namespaced owners. A namespaced owner must exist in the same namespace as the dependent. If it does not, the owner reference is treated as absent, and the dependent is subject to deletion once all owners are verified absent.

Cluster-scoped dependents can only specify cluster-scoped owners. In v1.20+, if a cluster-scoped dependent specifies a namespaced kind as an owner, it is treated as having an unresolvable owner reference, and is not able to be garbage collected.

In v1.20+, if the garbage collector detects an invalid cross-namespace ownerReference, or a cluster-scoped dependent with an ownerReference referencing a namespaced kind, a warning Event with a reason of OwnerRefInvalidNamespace and an involvedObject of the invalid dependent is reported. You can check for that kind of Event by running kubectl get events -A --field-selector=reason=OwnerRefInvalidNamespace.
```

