### PR TITLE
chore(dx): use tilt for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ testbin/*
 
 # Manually generated crds. Directory is needed though
 generated-crds/*
+
+# Tilt settings
+tilt-settings.yaml

--- a/Tiltfile
+++ b/Tiltfile
@@ -36,6 +36,8 @@ for o in objects:
     # running process.
     if o.get('kind') == 'Deployment' and o.get('metadata').get('name') == 'kubewarden-controller':
         o['spec']['template']['spec']['securityContext']['runAsNonRoot'] = False
+        # Disable the leader election to speed up the startup time.
+        o['spec']['template']['spec']['containers'][0]['args'].remove('--leader-elect')
         break
 updated_install = encode_yaml_stream(objects)
 k8s_yaml(updated_install)

--- a/Tiltfile
+++ b/Tiltfile
@@ -27,7 +27,7 @@ install = helm(
     settings.get('helm_charts_path') + '/charts/kubewarden-controller/', 
     name='kubewarden-controller', 
     namespace='kubewarden', 
-    set='image.repository=' + settings.get('image'),
+    set=['image.repository=' + settings.get('image'), 'global.cattle.SystemDefaultRegistry=' + settings.get('registry')]
 )
 
 objects = decode_yaml_stream(install)
@@ -41,7 +41,6 @@ for o in objects:
         break
 updated_install = encode_yaml_stream(objects)
 k8s_yaml(updated_install)
-
 
 # enable hot reloading by doing the following:
 # - locally build the whole project
@@ -69,7 +68,7 @@ dockerfile = 'tilt.dockerfile'
 
 load('ext://restart_process', 'docker_build_with_restart')
 docker_build_with_restart(
-    'ghcr.io/' + settings.get('image'),
+    settings.get('registry') + '/' + settings.get('image'),
     '.',
     dockerfile = dockerfile,
     entrypoint = entrypoint,

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,83 @@
+# -*- mode: Python -*-
+
+tilt_settings_file = "./tilt-settings.yaml"
+settings = read_yaml(tilt_settings_file)
+
+kubectl_cmd = "kubectl"
+
+# verify kubectl command exists
+if str(local("command -v " + kubectl_cmd + " || true", quiet = True)) == "":
+    fail("Required command '" + kubectl_cmd + "' not found in PATH")
+
+# Install cert manager
+load('ext://cert_manager', 'deploy_cert_manager')
+deploy_cert_manager()
+
+# Create the kubewarden namespace
+# This is required since the helm() function doesn't support the create_namespace flag
+load('ext://namespace', 'namespace_create')
+namespace_create('kubewarden')
+
+# Install CRDs
+crd = kustomize('config/crd')
+k8s_yaml(crd)
+
+# Install kubewarden-controller helm chart
+install = helm(
+    settings.get('helm_charts_path') + '/charts/kubewarden-controller/', 
+    name='kubewarden-controller', 
+    namespace='kubewarden', 
+    set='image.repository=' + settings.get('image'),
+)
+
+objects = decode_yaml_stream(install)
+for o in objects:
+    # Update the root security group. Tilt requires root access to update the
+    # running process.
+    if o.get('kind') == 'Deployment' and o.get('metadata').get('name') == 'kubewarden-controller':
+        o['spec']['template']['spec']['securityContext']['runAsNonRoot'] = False
+        break
+updated_install = encode_yaml_stream(objects)
+k8s_yaml(updated_install)
+
+
+# enable hot reloading by doing the following:
+# - locally build the whole project
+# - create a docker imagine using tilt's hot-swap wrapper
+# - push that container to the local tilt registry
+# Once done, rebuilding now should be a lot faster since only the relevant
+# binary is rebuilt and the hot swat wrapper takes care of the rest.
+local_resource(
+    'manager',
+    "CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/manager ./",
+    deps = [
+        "main.go",
+        "go.mod",
+        "go.sum",
+        "internal",
+        "controllers",
+        "pkg",
+    ],
+)
+
+# Build the docker image for our controller. We use a specific Dockerfile
+# since tilt can't run on a scratch container.
+entrypoint = ['/manager', '-zap-devel']
+dockerfile = 'tilt.dockerfile'
+
+load('ext://restart_process', 'docker_build_with_restart')
+docker_build_with_restart(
+    'ghcr.io/' + settings.get('image'),
+    '.',
+    dockerfile = dockerfile,
+    entrypoint = entrypoint,
+    # `only` here is important, otherwise, the container will get updated
+    # on _any_ file change.
+    only=[
+      './bin',
+    ],
+    live_update = [
+        sync('./bin/manager', '/manager'),
+    ],
+)
+

--- a/tilt-settings.yaml.example
+++ b/tilt-settings.yaml.example
@@ -1,0 +1,2 @@
+image: <your github handle>/kubewarden-controller
+helm_charts_path: ../helm-charts/

--- a/tilt-settings.yaml.example
+++ b/tilt-settings.yaml.example
@@ -1,2 +1,3 @@
+registry: ghcr.io
 image: <your github handle>/kubewarden-controller
 helm_charts_path: ../helm-charts/

--- a/tilt.dockerfile
+++ b/tilt.dockerfile
@@ -1,0 +1,5 @@
+FROM alpine
+WORKDIR /
+COPY ./bin/manager /manager
+
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
## Description

This PR is a POC on using Tilt for local development.

It adds a `Tiltfile` on the root of the project, an example settings file, and a Tilt-specific Dockerfile that is used by Tilt to inject the controller in the cluster and auto-reload it when the code changes.

The Tiltfile executes the following steps:

1. Read the `tilt-settings.yaml` file
2. Deploy cert-manager
3. Applys the CRD from the `config/crd` path of the projects. I didn't use the `kubewarden-crds` helm chart here since a developer could be interested in the latest CRD changes while developing.
4. Read the kubewarden controller rendered templates from the helm chart, overriding the image value with one in a private registry (as for now only `ghcr.io` is supported, see the usage section below).
5. Patch the deployment template adding the possibility to run the process as root. This is needed since Tilt requires root access to live-update the running process.
6. Enable hot reload by watching the source files.
7. Build the controller container, which is wrapped with tilt custom code to allow the auto-reload.
8. Finally, push the controller container and inject it automatically into the deployment.

The last step takes few seconds to complete.
The ghcr.io personal registry will host a new container image that has a `tilt-*` label. Then Tilt will inject the image (or auto reload the existing one) specified by the helm chart values in step 4.

## Usage

To use this setup, a developer needs to run a fresh k3d  cluster and needs login to `ghcr.io` from the docker daemon (`docker login ghcr.io -u user --password-stdin`).
Since k3d uses the same docker daemon, the cluster can access the private ghcr.io registry. This is easier than setting up a local registry or using the `k3d import` command (which apparently is slower).

Then, we need to create `tilt-settings.yaml` in the root of the project.
An example `tilt-settings.yaml.example` is provided.
The settings files look like this:

```
registry: ghcr.io
image: <your github handle>/kubewarden-controller
helm_charts_path: ../helm-charts/
```

where `image` is the ghcr.io location of the tilt managed controller image (it does not need to exist) and the `helm_charts_path` is the path to the local kubewarden helm charts repository.

Now we can start tilt with `tilt up --stream=true` and after the setup, we will see the controller logs running.

Any modification to the controller code will be pushed in the cluster and the controller will be auto-reloaded.
You can test it by adding some info logs in the `main.go` function.




