### PR TITLE
fix: Update SecurityContext of the pod inside of policy-server Deployments

### DIFF
--- a/config/crd/bases/policies.kubewarden.io_policyservers.yaml
+++ b/config/crd/bases/policies.kubewarden.io_policyservers.yaml
@@ -176,8 +176,9 @@ spec:
               securityContexts:
                 description: Security configuration to be used in the Policy Server
                   workload. The field allows different configurations for the pod
-                  and containers. This configuration will not be used in containers
-                  added by other controllers (e.g. telemetry sidecars)
+                  and containers. If set for the containers, this configuration will
+                  not be used in containers added by other controllers (e.g. telemetry
+                  sidecars)
                 properties:
                   container:
                     description: securityContext definition to be used in the policy

--- a/internal/pkg/admission/policy-server-deployment.go
+++ b/internal/pkg/admission/policy-server-deployment.go
@@ -122,6 +122,7 @@ func shouldUpdatePolicyServerDeployment(policyServer *policiesv1.PolicyServer, o
 	return *originalDeployment.Spec.Replicas != *newDeployment.Spec.Replicas ||
 		containerImageChanged ||
 		originalDeployment.Spec.Template.Spec.ServiceAccountName != newDeployment.Spec.Template.Spec.ServiceAccountName ||
+		originalDeployment.Spec.Template.Spec.SecurityContext != newDeployment.Spec.Template.Spec.SecurityContext ||
 		originalDeployment.Annotations[constants.PolicyServerDeploymentConfigVersionAnnotation] != newDeployment.Annotations[constants.PolicyServerDeploymentConfigVersionAnnotation] ||
 		!reflect.DeepEqual(originalDeployment.Spec.Template.Spec.Containers[0].Env, newDeployment.Spec.Template.Spec.Containers[0].Env) ||
 		!haveEqualAnnotationsWithoutRestart(originalDeployment, newDeployment), nil

--- a/internal/pkg/admission/policy-server-deployment.go
+++ b/internal/pkg/admission/policy-server-deployment.go
@@ -315,6 +315,11 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *policiesv
 			},
 		)
 	}
+
+	podSecurityContext := &corev1.PodSecurityContext{}
+	if policyServer.Spec.SecurityContexts.Pod != nil {
+		podSecurityContext = policyServer.Spec.SecurityContexts.Pod
+	}
 	if policyServer.Spec.SecurityContexts.Container != nil {
 		admissionContainer.SecurityContext = policyServer.Spec.SecurityContexts.Container
 	} else {
@@ -380,6 +385,7 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *policiesv
 					Annotations: templateAnnotations,
 				},
 				Spec: corev1.PodSpec{
+					SecurityContext:    podSecurityContext,
 					Containers:         []corev1.Container{admissionContainer},
 					ServiceAccountName: policyServer.Spec.ServiceAccountName,
 					Volumes: []corev1.Volume{
@@ -417,9 +423,6 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *policiesv
 				},
 			},
 		},
-	}
-	if policyServer.Spec.SecurityContexts.Pod != nil {
-		policyServerDeployment.Spec.Template.Spec.SecurityContext = policyServer.Spec.SecurityContexts.Pod
 	}
 
 	r.adaptDeploymentSettingsForPolicyServer(policyServerDeployment, policyServer)

--- a/internal/pkg/admission/policy-server-deployment_test.go
+++ b/internal/pkg/admission/policy-server-deployment_test.go
@@ -30,6 +30,10 @@ func TestShouldUpdatePolicyServerDeployment(t *testing.T) {
 		{"different replicas", deployment, createDeployment(2, "sa", "", "image", nil, []corev1.EnvVar{{Name: "env1"}}, nil, map[string]string{}), true},
 		{"different image", deployment, createDeployment(1, "sa", "", "test", nil, []corev1.EnvVar{{Name: "env1"}}, nil, map[string]string{}), true},
 		{"different serviceAccount", deployment, createDeployment(1, "serviceAccount", "", "image", nil, []corev1.EnvVar{{Name: "env1"}}, nil, map[string]string{}), true},
+		{"different podSecurityContext", deployment, createDeployment(1, "sa", "", "image", nil, []corev1.EnvVar{{Name: "env1"}},
+			&corev1.PodSecurityContext{
+				RunAsNonRoot: &[]bool{true}[0],
+			}, map[string]string{}), true},
 		{"new imagePullSecret", deployment, createDeployment(1, "sa", "regcred", "image", nil, []corev1.EnvVar{{Name: "env1"}}, nil, map[string]string{}), true},
 		{"different imagePullSecret", createDeployment(1, "sa", "regcred", "image", nil, nil, nil, map[string]string{}), createDeployment(1, "sa", "regcred2", "image", nil, nil, nil, map[string]string{}), false},
 		{"new insecureSources", deployment, createDeployment(1, "sa", "regcred", "image", []string{"localhost:5000"}, []corev1.EnvVar{{Name: "env1"}}, nil, map[string]string{}), true},

--- a/pkg/apis/policies/v1/policyserver_types.go
+++ b/pkg/apis/policies/v1/policyserver_types.go
@@ -78,8 +78,8 @@ type PolicyServerSpec struct {
 
 	// Security configuration to be used in the Policy Server workload.
 	// The field allows different configurations for the pod and containers.
-	// This configuration will not be used in containers added by other
-	// controllers (e.g. telemetry sidecars)
+	// If set for the containers, this configuration will not be used in
+	// containers added by other controllers (e.g. telemetry sidecars)
 	// +optional
 	SecurityContexts PolicyServerSecurity `json:"securityContexts,omitempty"`
 }


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/helm-charts/pull/361.

Before this, setting the `policyServer.Spec.SecurityContexts.Pod` value would only work on first creation of the Deployment from the PolicyServer CRD (so, on first install of kubewarden-defaults chart for example). With this fix, one can reconfigure the PolicyServers.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Added a unit test.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
