### PR TITLE
Upgrade artifact upload/download to v4

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -82,7 +82,7 @@ jobs:
             ghcr.io/${{github.repository_owner}}/kubewarden-controller:${{ env.TAG_NAME }}
       - name: Upload container image to use in other jobs
         if: ${{ inputs.push-image == false }}
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: kubewarden-controller-image-${{ env.TAG_NAME }}
           path: /tmp/kubewarden-controller-image-${{ env.TAG_NAME }}.tar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           make generate-crds
           tar -czf CRDS.tar.gz -C generated-crds $(ls generated-crds)
       - name: Upload CRDs as artifacts
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: CRDS
           path: CRDS.tar.gz
@@ -94,12 +94,13 @@ jobs:
             core.setFailed(`Draft release not found`)
 
       - name: Download SBOM artifact
-        uses: actions/download-artifact@7a1cd3216ca9260cd8022db641d960b1db4d1be4 # v4.0.0
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
-          name: sbom
+          pattern: sbom-*
+          merge-multiple: true
 
       - name: Download CRDs artifact
-        uses: actions/download-artifact@7a1cd3216ca9260cd8022db641d960b1db4d1be4 # v4.0.0
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: CRDS
 

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -77,7 +77,7 @@ jobs:
             ghcr.io/${{github.repository_owner}}/kubewarden-controller:${SBOM_TAG}
 
       - name: Upload SBOMs as artifacts
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: sbom
-          path: kubewarden-controller-sbom-*
+          name: sbom-${{ matrix.arch }}
+          path: kubewarden-controller-sbom-${{ matrix.arch }}*


### PR DESCRIPTION
## Description

Upload / download artifact github action are not compatible between v3 and v4. This breaks release job and e2e tests.

Fixes:
 - [e2e tests](https://github.com/kubewarden/kubewarden-controller/actions/runs/7333614032/job/19969318246)
 - release job


## Test
Tested on my fork: https://github.com/kravciak/kubewarden-controller/actions/runs/7337350368/job/19978338359

