### PR TITLE
deps: Pin crd-ref-docs binary with new `make crd-ref-docs` target

### DIFF
--- a/docs/crds/Makefile
+++ b/docs/crds/Makefile
@@ -1,3 +1,22 @@
+ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+BIN_DIR := $(abspath $(ROOT_DIR)/bin)
+
+# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
+ifeq (,$(shell go env GOBIN))
+GOBIN=$(shell go env GOPATH)/bin
+else
+GOBIN=$(shell go env GOBIN)
+endif
+
+CRD_REF_DOCS_VER := v0.0.9
+CRD_REF_DOCS_BIN := crd-ref-docs
+CRD_REF_DOCS := $(BIN_DIR)/$(CRD_REF_DOCS_BIN)
+
+crd-ref-docs: $(CRD_REF_DOCS)
+
+$(CRD_REF_DOCS): ## Install crd-ref-docs
+	GOBIN=$(BIN_DIR) go install github.com/elastic/crd-ref-docs@$(CRD_REF_DOCS_VER)
+
 .PHONY: generate
 generate:
-	crd-ref-docs --config=config.yml --renderer=markdown --source-path=../../pkg/apis --output-path=CRD-docs-for-docs-repo.md
+	$(CRD_REF_DOCS) --log-level INFO --config=config.yml --renderer=markdown --source-path=../../pkg/apis --output-path=CRD-docs-for-docs-repo.md


### PR DESCRIPTION


## Description
Pin crd-ref-docs binary with new `make crd-ref-docs` target.
<!-- Please provide the link to the GitHub issue you are addressing -->
This target is adapted from the `make golangci-lint` one in the Makefile on the root project.
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->


## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested by running `make generate` from the docs/crds folder. The target creates a `docs/crds/bin/` folder where it installs the `crd-ref-docs` cli. Which is consumed by `make generate`.
 
<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
