### PR TITLE
fix: Initialize nil maps when updating webhooks 

### DIFF
--- a/controllers/admissionpolicy_controller.go
+++ b/controllers/admissionpolicy_controller.go
@@ -164,7 +164,7 @@ func (r *AdmissionPolicyReconciler) findAdmissionPolicyForWebhookConfiguration(_
 
 	policyScope, found := webhookConfiguration.GetLabels()[constants.WebhookConfigurationPolicyScopeLabelKey]
 	if !found {
-		r.Log.Error(nil, "Found a webhook configuration without a scope label", "name", webhookConfiguration.GetName())
+		r.Log.Info("Found a webhook configuration without a scope label, reconciling it", "name", webhookConfiguration.GetName())
 		return []reconcile.Request{}
 	}
 
@@ -175,13 +175,13 @@ func (r *AdmissionPolicyReconciler) findAdmissionPolicyForWebhookConfiguration(_
 
 	policyNamespace, found := webhookConfiguration.GetAnnotations()[constants.WebhookConfigurationPolicyNamespaceAnnotationKey]
 	if !found {
-		r.Log.Error(nil, "Found a webhook configuration without a namespace annotation", "name", webhookConfiguration.GetName())
+		r.Log.Info("Found a webhook configuration without a namespace annotation, reconciling it", "name", webhookConfiguration.GetName())
 		return []reconcile.Request{}
 	}
 
 	policyName, found := webhookConfiguration.GetAnnotations()[constants.WebhookConfigurationPolicyNameAnnotationKey]
 	if !found {
-		r.Log.Error(nil, "Found webhook configuration without a policy name annotation", "name", webhookConfiguration.GetName())
+		r.Log.Info("Found a webhook configuration without a policy name annotation, reconciling it", "name", webhookConfiguration.GetName())
 		return []reconcile.Request{}
 	}
 

--- a/controllers/clusteradmissionpolicy_controller.go
+++ b/controllers/clusteradmissionpolicy_controller.go
@@ -161,7 +161,7 @@ func (r *ClusterAdmissionPolicyReconciler) findClusterAdmissionPolicyForWebhookC
 
 	policyScope, found := webhookConfiguration.GetLabels()[constants.WebhookConfigurationPolicyScopeLabelKey]
 	if !found {
-		r.Log.Error(nil, "Found a webhook configuration without a scope label", "name", webhookConfiguration.GetName())
+		r.Log.Info("Found a webhook configuration without a scope label, reconciling it", "name", webhookConfiguration.GetName())
 		return []reconcile.Request{}
 	}
 
@@ -172,7 +172,7 @@ func (r *ClusterAdmissionPolicyReconciler) findClusterAdmissionPolicyForWebhookC
 
 	policyName, found := webhookConfiguration.GetAnnotations()[constants.WebhookConfigurationPolicyNameAnnotationKey]
 	if !found {
-		r.Log.Error(nil, "Found webhook configuration without a policy name annotation", "name", webhookConfiguration.GetName())
+		r.Log.Info("Found a webhook configuration without a policy name annotation, reconciling it", "name", webhookConfiguration.GetName())
 		return []reconcile.Request{}
 	}
 

--- a/internal/pkg/admission/mutating-webhook.go
+++ b/internal/pkg/admission/mutating-webhook.go
@@ -51,10 +51,16 @@ func (r *Reconciler) updateMutatingWebhook(ctx context.Context,
 
 	patch := originalWebhook.DeepCopy()
 
+	if patch.ObjectMeta.Labels == nil {
+		patch.ObjectMeta.Labels = make(map[string]string)
+	}
 	for key, value := range newWebhook.ObjectMeta.Labels {
 		patch.ObjectMeta.Labels[key] = value
 	}
 
+	if patch.ObjectMeta.Annotations == nil {
+		patch.ObjectMeta.Annotations = make(map[string]string)
+	}
 	for key, value := range newWebhook.ObjectMeta.Annotations {
 		patch.ObjectMeta.Annotations[key] = value
 	}

--- a/internal/pkg/admission/validating-webhook.go
+++ b/internal/pkg/admission/validating-webhook.go
@@ -51,8 +51,15 @@ func (r *Reconciler) updateValidatingWebhook(ctx context.Context,
 
 	patch := originalWebhook.DeepCopy()
 
+	if patch.ObjectMeta.Labels == nil {
+		patch.ObjectMeta.Labels = make(map[string]string)
+	}
 	for key, value := range newWebhook.ObjectMeta.Labels {
 		patch.ObjectMeta.Labels[key] = value
+	}
+
+	if patch.ObjectMeta.Annotations == nil {
+		patch.ObjectMeta.Annotations = make(map[string]string)
 	}
 	for key, value := range newWebhook.ObjectMeta.Annotations {
 		patch.ObjectMeta.Annotations[key] = value

--- a/internal/pkg/admission/validating-webhook.go
+++ b/internal/pkg/admission/validating-webhook.go
@@ -46,7 +46,7 @@ func (r *Reconciler) updateValidatingWebhook(ctx context.Context,
 		Name: policy.GetUniqueName(),
 	}, &originalWebhook)
 	if err != nil && apierrors.IsNotFound(err) {
-		return fmt.Errorf("cannot retrieve mutating webhook: %w", err)
+		return fmt.Errorf("cannot retrieve validating webhook: %w", err)
 	}
 
 	patch := originalWebhook.DeepCopy()


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/kubewarden-controller/issues/608

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Added new test cases to integration tests (instead of adding an upgrade integration testsuite).



<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

Adding integration tests for upgrade scenarios to `controllers/admissionpolicy_controller_test.go` is not trivial. One needs a test that sets up policies and their webhooks manually, and then run the reconciler and check that the webhooks were reconciled correctly, with labels and annotations.

Problem is, We define the unique ginkgo suite in `controllers/suite_test.go/BeforeSuite()`. `BeforeSuite()` runs once before any of the container nodes (the ones with `Describe()`) run. There's no possibility to run anything beforehand, and the k8s env and reconciler is shared between all the container nodes. It's not possible to have more than 1 `BeforeSuite()` per package.

Possible solutions (none particularly good):
1. Move the initialization of k8s env and reconciler from the unique `BeforeSuite()` to a per container `BeforeEach()`. This means we create a k8s env per ginkgo spec container, which is costlier.
2. Provide a callback to the k8s env to pause the reconciler, inject the old webhooks, and rerun the reconciler. This breaks tests if we run them in parallel.
3. Create a new separate k8s env in a new ginkgo container via a `BeforeTest()`, and run the upgrade tests there. Ignore the general k8s env from `BeforeSuite()` in that ginkgo container performing the upgrade tests.
4. Implement integration tests somewhere else.
