### PR TITLE
ci: Save coverage files, add codecov workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,15 @@ jobs:
         with:
           go-version: "1.21"
       - run: make unit-tests
+      - name: Upload unit-tests coverage to Codecov
+        uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+        with:
+          name: unit-tests
+          directory: coverage/unit-tests
+          flags: unit-tests
+          verbose: true
 
   integration_tests:
     name: Integration tests
@@ -28,6 +37,15 @@ jobs:
         with:
           go-version: "1.21"
       - run: make integration-tests
+      - name: Upload integration-tests coverage to Codecov
+        uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+        with:
+          name: integration-tests
+          directory: coverage/integration-tests
+          flags: integration-tests
+          verbose: true
 
   golangci:
     name: Golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -110,13 +110,13 @@ setup-envtest: $(SETUP_ENVTEST) # Build setup-envtest
 
 .PHONY: unit-tests
 unit-tests: manifests generate fmt vet setup-envtest ## Run unit tests.
-	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./internal/... -test.v -coverprofile cover.out
-	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./pkg/... -test.v -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./internal/... -race -test.v -coverprofile=coverage/unit-tests/coverage-internal.txt -covermode=atomic
+	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./pkg/... -race -test.v -coverprofile=coverage/unit-tests/coverage-pkg.txt -covermode=atomic
 
 .PHONY: setup-envtest integration-tests
 integration-tests: manifests generate fmt vet setup-envtest ## Run integration tests.
-	ACK_GINKGO_DEPRECATIONS=2.12.0 KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./pkg/... -ginkgo.v -ginkgo.progress -test.v -coverprofile cover.out
-	ACK_GINKGO_DEPRECATIONS=2.12.0 K3S_TESTCONTAINER_VERSION="$(K3S_TESTCONTAINER_VERSION)" POLICY_SERVER_VERSION="$(POLICY_SERVER_VERSION)" go test ./controllers/... -ginkgo.v -ginkgo.progress -test.v -coverprofile cover.out
+	ACK_GINKGO_DEPRECATIONS=2.12.0 KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./pkg/... -ginkgo.v -ginkgo.progress -race -test.v -coverprofile=coverage/integration-tests/coverage-pkg.txt -covermode=atomic
+	ACK_GINKGO_DEPRECATIONS=2.12.0 K3S_TESTCONTAINER_VERSION="$(K3S_TESTCONTAINER_VERSION)" POLICY_SERVER_VERSION="$(POLICY_SERVER_VERSION)" go test ./controllers/... -ginkgo.v -ginkgo.progress -race -test.v -coverprofile=coverage/integration-tests/coverage-controllers.txt -covermode=atomic
 
 .PHONY: generate-crds
 generate-crds: $(KUSTOMIZE) manifests kustomize ## generate final crds with kustomize. Normally shipped in Helm charts.

--- a/coverage/integration-tests/.gitignore
+++ b/coverage/integration-tests/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/coverage/unit-tests/.gitignore
+++ b/coverage/unit-tests/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
## Description

Relates to https://github.com/kubewarden/kubewarden-controller/issues/623.
 
Change makefile targets to save coverage into specific `coverage/{unit-tests,integration-tests}/*` folders.

Add new `codecov.yml` GHA workflow that runs `make test` and uploads the coverage results to codecov via their `codecov` cli.

Tagged unit-tests and integration-tests results separately by setting the codecov flags on the workflow.

Needs a secret `CODECOV_ORG_TOKEN` present, which should be provided by the Codecov GH Application when installed.


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To see this working, we need the [Codecov GH application installed in the org,](https://github.com/apps/codecov) and then we will see it working on the next PR opened against the repo.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
