### PR TITLE
fix: policy server resource deleted before policies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.23
+ENVTEST_K8S_VERSION = 1.29
 # K3S_TESTCONTAINER_VERSION refers to the version of k3s testcontainer to be used by envtest to run integration tests.
-K3S_TESTCONTAINER_VERSION = v1.23.2-k3s1
+K3S_TESTCONTAINER_VERSION = v1.29.1-k3s2
 # POLICY_SERVER_VERSION refers to the version of the policy server to be used by integration tests.
-POLICY_SERVER_VERSION = v1.9.0
+POLICY_SERVER_VERSION = v1.10.0
 # Binary directory
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 BIN_DIR := $(abspath $(ROOT_DIR)/bin)
@@ -115,7 +115,7 @@ unit-tests: manifests generate fmt vet setup-envtest ## Run unit tests.
 
 .PHONY: setup-envtest integration-tests
 integration-tests: manifests generate fmt vet setup-envtest ## Run integration tests.
-	ACK_GINKGO_DEPRECATIONS=2.12.0 K3S_TESTCONTAINER_VERSION="$(K3S_TESTCONTAINER_VERSION)" POLICY_SERVER_VERSION="$(POLICY_SERVER_VERSION)" go test ./controllers/... -ginkgo.v -ginkgo.progress -race -test.v -coverprofile=coverage/integration-tests/coverage-controllers.txt -covermode=atomic
+	ACK_GINKGO_DEPRECATIONS=2.12.0 K3S_TESTCONTAINER_VERSION="$(K3S_TESTCONTAINER_VERSION)" POLICY_SERVER_VERSION="$(POLICY_SERVER_VERSION)" go test -v ./controllers/... -ginkgo.v -ginkgo.progress -race -test.v -coverprofile=coverage/integration-tests/coverage-controllers.txt -covermode=atomic
 
 .PHONY: generate-crds
 generate-crds: $(KUSTOMIZE) manifests kustomize ## generate final crds with kustomize. Normally shipped in Helm charts.

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -32,6 +32,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -147,6 +148,21 @@ func getTestPolicyServer(name string) (*policiesv1.PolicyServer, error) {
 		return nil, errors.Join(errors.New("could not find PolicyServer"), err)
 	}
 	return &policyServer, nil
+}
+
+func getTestPolicyServerService(policyServerName string) (*corev1.Service, error) {
+	policyServer := policiesv1.PolicyServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: policyServerName,
+		},
+	}
+	serviceName := policyServer.NameWithPrefix()
+
+	service := corev1.Service{}
+	if err := reconciler.APIReader.Get(ctx, client.ObjectKey{Name: serviceName, Namespace: DeploymentsNamespace}, &service); err != nil {
+		return nil, errors.Join(errors.New("could not find Service owned by PolicyServer"), err)
+	}
+	return &service, nil
 }
 
 func getTestValidatingWebhookConfiguration(name string) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -36,8 +36,9 @@ import (
 )
 
 const (
-	timeout      = 120 * time.Second
-	pollInterval = 250 * time.Millisecond
+	timeout                   = 120 * time.Second
+	pollInterval              = 250 * time.Millisecond
+	IntegrationTestsFinalizer = "integration-tests-safety-net-finalizer"
 )
 
 var (
@@ -77,11 +78,15 @@ func policyServerVersion() string {
 func policyServerFactory(name string) *policiesv1.PolicyServer {
 	policyServer := templatePolicyServer.DeepCopy()
 	policyServer.Name = name
-
-	// By adding this finalizer automatically, we ensure that when
-	// testing removal of finalizers on deleted objects, that they will
-	// exist at all times
-	policyServer.Finalizers = []string{"integration-tests-safety-net-finalizer"}
+	policyServer.Finalizers = []string{
+		// On a real cluster the Kubewarden finalizer is added by our mutating
+		// webhook. This is not running now, hence we have to manually add the finalizer
+		constants.KubewardenFinalizer,
+		// By adding this finalizer automatically, we ensure that when
+		// testing removal of finalizers on deleted objects, that they will
+		// exist at all times
+		IntegrationTestsFinalizer,
+	}
 	return policyServer
 }
 
@@ -91,10 +96,15 @@ func admissionPolicyFactory(name, policyNamespace, policyServerName string, muta
 	admissionPolicy.Namespace = policyNamespace
 	admissionPolicy.Spec.PolicyServer = policyServerName
 	admissionPolicy.Spec.PolicySpec.Mutating = mutating
-	// By adding this finalizer automatically, we ensure that when
-	// testing removal of finalizers on deleted objects, that they will
-	// exist at all times
-	admissionPolicy.Finalizers = []string{"integration-tests-safety-net-finalizer"}
+	admissionPolicy.Finalizers = []string{
+		// On a real cluster the Kubewarden finalizer is added by our mutating
+		// webhook. This is not running now, hence we have to manually add the finalizer
+		constants.KubewardenFinalizer,
+		// By adding this finalizer automatically, we ensure that when
+		// testing removal of finalizers on deleted objects, that they will
+		// exist at all times
+		IntegrationTestsFinalizer,
+	}
 	return admissionPolicy
 }
 
@@ -103,10 +113,15 @@ func clusterAdmissionPolicyFactory(name, policyServerName string, mutating bool)
 	clusterAdmissionPolicy.Name = name
 	clusterAdmissionPolicy.Spec.PolicyServer = policyServerName
 	clusterAdmissionPolicy.Spec.PolicySpec.Mutating = mutating
-	// By adding this finalizer automatically, we ensure that when
-	// testing removal of finalizers on deleted objects, that they will
-	// exist at all times
-	clusterAdmissionPolicy.Finalizers = []string{"integration-tests-safety-net-finalizer"}
+	clusterAdmissionPolicy.Finalizers = []string{
+		// On a real cluster the Kubewarden finalizer is added by our mutating
+		// webhook. This is not running now, hence we have to manually add the finalizer
+		constants.KubewardenFinalizer,
+		// By adding this finalizer automatically, we ensure that when
+		// testing removal of finalizers on deleted objects, that they will
+		// exist at all times
+		IntegrationTestsFinalizer,
+	}
 	return clusterAdmissionPolicy
 }
 

--- a/internal/pkg/admission/reconciler.go
+++ b/internal/pkg/admission/reconciler.go
@@ -248,16 +248,9 @@ func (r *Reconciler) Reconcile(
 	return nil
 }
 
-type GetPoliciesBehavior int
-
-const (
-	SkipDeleted GetPoliciesBehavior = iota
-	IncludeDeleted
-)
-
 // GetPolicies returns all admission policies and cluster admission
 // policies bound to the given policyServer
-func (r *Reconciler) GetPolicies(ctx context.Context, policyServer *policiesv1.PolicyServer, getPoliciesBehavior GetPoliciesBehavior) ([]policiesv1.Policy, error) {
+func (r *Reconciler) GetPolicies(ctx context.Context, policyServer *policiesv1.PolicyServer) ([]policiesv1.Policy, error) {
 	var clusterAdmissionPolicies policiesv1.ClusterAdmissionPolicyList
 	err := r.Client.List(ctx, &clusterAdmissionPolicies, client.MatchingFields{constants.PolicyServerIndexKey: policyServer.Name})
 	if err != nil && apierrors.IsNotFound(err) {
@@ -274,16 +267,10 @@ func (r *Reconciler) GetPolicies(ctx context.Context, policyServer *policiesv1.P
 	policies := make([]policiesv1.Policy, 0)
 	for _, clusterAdmissionPolicy := range clusterAdmissionPolicies.Items {
 		clusterAdmissionPolicy := clusterAdmissionPolicy
-		if getPoliciesBehavior == SkipDeleted && clusterAdmissionPolicy.DeletionTimestamp != nil {
-			continue
-		}
 		policies = append(policies, &clusterAdmissionPolicy)
 	}
 	for _, admissionPolicy := range admissionPolicies.Items {
 		admissionPolicy := admissionPolicy
-		if getPoliciesBehavior == SkipDeleted && admissionPolicy.DeletionTimestamp != nil {
-			continue
-		}
 		policies = append(policies, &admissionPolicy)
 	}
 

--- a/internal/pkg/admission/reconciler_test.go
+++ b/internal/pkg/admission/reconciler_test.go
@@ -78,7 +78,7 @@ func TestGetPolicies(t *testing.T) {
 			reconciler := newReconciler(ttest.policies, false)
 			policies, err := reconciler.GetPolicies(context.Background(), &policiesv1.PolicyServer{
 				ObjectMeta: metav1.ObjectMeta{Name: policyServer},
-			}, IncludeDeleted)
+			})
 			if err != nil {
 				t.Errorf("received unexpected error %s", err.Error())
 			}


### PR DESCRIPTION
## Description

There is an issue in the policy server controller which is causing inconsistencies when the policy server is deleted. It's possible, due the concurrent nature of events and controllers loops, where the policies ended in a inconsistent state. Where the policy and its webhooks are register in the cluster. But the policy server which should run it is gone. Causing an issue when the control plane tries to contact the policy server.

This is caused because when the policy server controller deletes all the policy server policies, it filters out policies which have the deletion timestamp field. Once no policies are found, in other words, when no policies without deletion timestamp are found, the policy server resources are deleted. However, the deletion timestamp does not ensure that the resource is not register in the cluster. It tells that the resource is marked to be deleted by the control plane. Which means that we can reach a state where the policy server is deleted before the policies. Causing issue when the control plane tries to send request to the webhooks.This commit fixes that by removing the filter used to get the policies in the deletion reconciliation loop.


Fix #650 

Thanks @flavio for the directions!
