### PR TITLE
chore: configure codecov ignore directive and threshold

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,8 +110,8 @@ setup-envtest: $(SETUP_ENVTEST) # Build setup-envtest
 
 .PHONY: unit-tests
 unit-tests: manifests generate fmt vet setup-envtest ## Run unit tests.
-	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./internal/... -race -test.v -coverprofile=coverage/unit-tests/coverage-internal.txt -covermode=atomic
-	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./pkg/... -race -test.v -coverprofile=coverage/unit-tests/coverage-pkg.txt -covermode=atomic
+	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./internal/... -race -test.v -coverprofile=coverage/unit-tests/coverage-internal.txt -covermode=atomic -coverpkg=all
+	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./pkg/... -race -test.v -coverprofile=coverage/unit-tests/coverage-pkg.txt -covermode=atomic -coverpkg=all
 
 .PHONY: setup-envtest integration-tests
 integration-tests: manifests generate fmt vet setup-envtest ## Run integration tests.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%
+ignore:
+  - pkg/apis/policies/v1/zz_generated.deepcopy.go
+  - pkg/apis/policies/v1alpha2


### PR DESCRIPTION
Configure codecov to ignore:

  - pkg/apis/policies/v1/zz_generated.deepcopy.go
  - pkg/apis/policies/v1alpha2
  - internal/pkg/constants
  
 Also, sets the project threshold to 1%, meaning that we tolerate a 1% coverage drift comparing the current PR to head.


 
Fixes: #661 