### PR TITLE
fix: handle enable monitoring boolean flag

### DIFF
--- a/internal/pkg/admission/policy-server-deployment.go
+++ b/internal/pkg/admission/policy-server-deployment.go
@@ -334,7 +334,7 @@ func (r *Reconciler) deployment(configMapVersion string, policyServer *policiesv
 	if r.MetricsEnabled {
 		templateAnnotations[constants.OptelInjectAnnotation] = "true" //nolint:goconst
 
-		envvar := corev1.EnvVar{Name: constants.PolicyServerEnableMetricsEnvVar, Value: "1"}
+		envvar := corev1.EnvVar{Name: constants.PolicyServerEnableMetricsEnvVar, Value: "true"}
 		if index := envVarsContainVariable(admissionContainer.Env, constants.PolicyServerEnableMetricsEnvVar); index >= 0 {
 			admissionContainer.Env[index] = envvar
 		} else {

--- a/internal/pkg/admission/policy-server-deployment_test.go
+++ b/internal/pkg/admission/policy-server-deployment_test.go
@@ -469,7 +469,7 @@ func TestPolicyServerDeploymentMetricConfigurationWithValueDefinedByUser(t *test
 	policyServer := &policiesv1.PolicyServer{
 		Spec: policiesv1.PolicyServerSpec{
 			Image: "image",
-			Env:   []corev1.EnvVar{{Name: constants.PolicyServerEnableMetricsEnvVar, Value: "0"}, {Name: constants.PolicyServerLogFmtEnvVar, Value: "invalid"}},
+			Env:   []corev1.EnvVar{{Name: constants.PolicyServerEnableMetricsEnvVar, Value: "false"}, {Name: constants.PolicyServerLogFmtEnvVar, Value: "invalid"}},
 		},
 	}
 	deployment := reconciler.deployment("v1", policyServer)
@@ -477,7 +477,7 @@ func TestPolicyServerDeploymentMetricConfigurationWithValueDefinedByUser(t *test
 	for _, envvar := range deployment.Spec.Template.Spec.Containers[0].Env {
 		if envvar.Name == constants.PolicyServerEnableMetricsEnvVar {
 			hasMetricEnvvar = true
-			if envvar.Value != "1" {
+			if envvar.Value != "true" {
 				t.Error("Present but not reconciled {} value", constants.PolicyServerEnableMetricsEnvVar)
 			}
 		}
@@ -504,7 +504,7 @@ func TestPolicyServerDeploymentTracingConfigurationWithValueDefinedByUser(t *tes
 	policyServer := &policiesv1.PolicyServer{
 		Spec: policiesv1.PolicyServerSpec{
 			Image: "image",
-			Env:   []corev1.EnvVar{{Name: constants.PolicyServerEnableMetricsEnvVar, Value: "0"}, {Name: constants.PolicyServerLogFmtEnvVar, Value: "invalid"}},
+			Env:   []corev1.EnvVar{{Name: constants.PolicyServerEnableMetricsEnvVar, Value: "false"}, {Name: constants.PolicyServerLogFmtEnvVar, Value: "invalid"}},
 		},
 	}
 	deployment := reconciler.deployment("v1", policyServer)


### PR DESCRIPTION
A change has been done to policy-server. Starting from the v1.11 release, the boolean flags must take either `true` or `false` as values when they are toggled via environment variables.
Prior to that, any kind of value was fine.
