### PR TITLE
fix: increase controllers integration test timeout

### DIFF
--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	timeout                   = 120 * time.Second
+	timeout                   = 180 * time.Second
 	pollInterval              = 250 * time.Millisecond
 	IntegrationTestsFinalizer = "integration-tests-safety-net-finalizer"
 )


### PR DESCRIPTION
## Description

Increases the integration test timeout that was causing flaky tests

Fixes: #628 
