### PR TITLE
fix: linter errors and remove requests defaults.

### DIFF
--- a/controllers/policyserver_controller_test.go
+++ b/controllers/policyserver_controller_test.go
@@ -308,7 +308,7 @@ var _ = Describe("PolicyServer controller", func() {
 				Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Requests).To(Equal(policyServer.Spec.Limits))
 
 				return nil
-			})
+			}).Should(Succeed())
 
 			By("creating a pod with limit and request set")
 			Eventually(func(g Gomega) error {

--- a/controllers/policyserver_controller_test.go
+++ b/controllers/policyserver_controller_test.go
@@ -304,11 +304,9 @@ var _ = Describe("PolicyServer controller", func() {
 				}
 
 				Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Limits).To(Equal(policyServer.Spec.Limits))
-				By("setting the requests to the same value as the limits")
-				Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Requests).To(Equal(policyServer.Spec.Limits))
 
 				return nil
-			}).Should(Succeed())
+			}, timeout, pollInterval).Should(Succeed())
 
 			By("creating a pod with limit and request set")
 			Eventually(func(g Gomega) error {
@@ -318,6 +316,7 @@ var _ = Describe("PolicyServer controller", func() {
 				}
 
 				Expect(pod.Spec.Containers[0].Resources.Limits).To(Equal(policyServer.Spec.Limits))
+				By("setting the requests to the same value as the limits")
 				Expect(pod.Spec.Containers[0].Resources.Requests).To(Equal(policyServer.Spec.Limits))
 
 				return nil

--- a/pkg/apis/policies/v1/policyserver_webhook.go
+++ b/pkg/apis/policies/v1/policyserver_webhook.go
@@ -59,16 +59,6 @@ func (ps *PolicyServer) Default() {
 	if ps.ObjectMeta.DeletionTimestamp == nil {
 		controllerutil.AddFinalizer(ps, constants.KubewardenFinalizer)
 	}
-
-	// Default the requests to the limits if not set
-	for limitName, limitQuantity := range ps.Spec.Limits {
-		if _, found := ps.Spec.Requests[limitName]; !found {
-			if ps.Spec.Requests == nil {
-				ps.Spec.Requests = make(corev1.ResourceList)
-			}
-			ps.Spec.Requests[limitName] = limitQuantity
-		}
-	}
 }
 
 // +kubebuilder:webhook:path=/validate-policies-kubewarden-io-v1-policyserver,mutating=false,failurePolicy=fail,sideEffects=None,groups=policies.kubewarden.io,resources=policyservers,verbs=create;update,versions=v1,name=vpolicyserver.kb.io,admissionReviewVersions=v1

--- a/pkg/apis/policies/v1/policyserver_webhook_test.go
+++ b/pkg/apis/policies/v1/policyserver_webhook_test.go
@@ -45,10 +45,6 @@ func TestDefault(t *testing.T) {
 	policyServer.Default()
 
 	assert.Contains(t, policyServer.Finalizers, constants.KubewardenFinalizer)
-	assert.Equal(t, corev1.ResourceList{
-		"cpu":    resource.MustParse("100m"),
-		"memory": resource.MustParse("1Gi"),
-	}, policyServer.Spec.Requests)
 }
 
 func TestValidatePolicyServerName(t *testing.T) {


### PR DESCRIPTION
## Description

There were some linter errors we did not catch since the Golangci action is acting funny.

For this reason, the PolicyServer controller integration tests were passing even if the expectation was wrong.
I've removed setting requests defaults to limits when the requests are empty to mimic the Kubernetes behavior, which only does this at the Pod level.

