### PR TITLE
fix: use patch verb to update configmaps and deployments.

### DIFF
--- a/internal/pkg/admission/policy-server-configmap.go
+++ b/internal/pkg/admission/policy-server-configmap.go
@@ -58,7 +58,7 @@ func (r *Reconciler) reconcilePolicyServerConfigMap(
 			Namespace: r.DeploymentsNamespace,
 		},
 	}
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, cfg, func() error {
+	_, err := controllerutil.CreateOrPatch(ctx, r.Client, cfg, func() error {
 		return r.updateConfigMapData(cfg, policyServer, policies)
 	})
 	if err != nil {

--- a/internal/pkg/admission/policy-server-deployment.go
+++ b/internal/pkg/admission/policy-server-deployment.go
@@ -56,7 +56,7 @@ func (r *Reconciler) reconcilePolicyServerDeployment(ctx context.Context, policy
 			Namespace: r.DeploymentsNamespace,
 		},
 	}
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, policyServerDeployment, func() error {
+	_, err = controllerutil.CreateOrPatch(ctx, r.Client, policyServerDeployment, func() error {
 		return r.updatePolicyServerDeployment(policyServer, policyServerDeployment, configMapVersion)
 	})
 	if err != nil {


### PR DESCRIPTION
## Description

In a recent change to use controller-runtime helper function we accidentally change the verb used to update configmaps and deployments resources from patch to update. This commit fixes that by using the CreateOrPatch helper function.

