### PR TITLE
fix: do not overwrite PolicyServer annotations and labels

### DIFF
--- a/internal/pkg/admission/policy-server-deployment.go
+++ b/internal/pkg/admission/policy-server-deployment.go
@@ -130,13 +130,17 @@ func (r *Reconciler) updatePolicyServerDeployment(policyServer *policiesv1.Polic
 
 	r.adaptDeploymentForMetricsAndTracingConfiguration(templateAnnotations, &admissionContainer)
 
-	policyServerDeployment.Annotations = map[string]string{
-		constants.PolicyServerDeploymentConfigVersionAnnotation: configMapVersion,
+	if policyServerDeployment.ObjectMeta.Annotations == nil {
+		policyServerDeployment.ObjectMeta.Annotations = make(map[string]string)
 	}
-	policyServerDeployment.Labels = map[string]string{
-		constants.AppLabelKey:          policyServer.AppLabel(),
-		constants.PolicyServerLabelKey: policyServer.Name,
+	policyServerDeployment.ObjectMeta.Annotations[constants.PolicyServerDeploymentConfigVersionAnnotation] = configMapVersion
+
+	if policyServerDeployment.Labels == nil {
+		policyServerDeployment.Labels = make(map[string]string)
 	}
+	policyServerDeployment.Labels[constants.AppLabelKey] = policyServer.AppLabel()
+	policyServerDeployment.Labels[constants.PolicyServerLabelKey] = policyServer.Name
+
 	policyServerDeployment.Spec = appsv1.DeploymentSpec{
 		Replicas: &policyServer.Spec.Replicas,
 		Selector: &metav1.LabelSelector{


### PR DESCRIPTION
Prior to this commit, our `CreateOrPatch` function overwrote the Deployment annotations and labels.

This is a problem, because Kubernetes internally uses an annotation to keep track of the Deployment revision.

Because of our behaviour, the controller ended up removing the annotation `deployment.kubernetes.io/revision`. But after a while the Kubernetes reconcilers added it back. Leading to a back and forth between our controller and the Kubernetes ones.

This also manifested itself inside of our e2e tests, which sometimes failed with this message:

> error: desired revision (24) is different from the running revision (0)

The `0` revision is a special value which is assigned by kubectl when the annotation field is NOT found.

This commit prevents annotations and labels to be overwritten. Labels are not strictly related with the issue we found inside of the e2e tests, but there are indeed some labels that are added by helm that we should not be messing with.
