### PR TITLE
dev: fix the tilt development file

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -50,7 +50,7 @@ install = helm(
     settings.get('helm_charts_path') + '/charts/kubewarden-controller/', 
     name='kubewarden-controller', 
     namespace='kubewarden', 
-    set=['image.repository=' + settings.get('image'), 'global.cattle.SystemDefaultRegistry=' + settings.get('registry')]
+    set=['image.repository=' + settings.get('image'), 'global.cattle.systemDefaultRegistry=' + settings.get('registry')]
 )
 
 objects = decode_yaml_stream(install)


### PR DESCRIPTION
The name of the variable used by the helm chart to replace the system registry was wrong.

That caused tilt to NOT use its own patched image, making everything useless.
