### PR TITLE
refactor: use only `CreateOrPatch`

### DIFF
--- a/internal/pkg/admission/policy-server-ca-secret.go
+++ b/internal/pkg/admission/policy-server-ca-secret.go
@@ -27,7 +27,7 @@ func (r *Reconciler) fetchOrInitializePolicyServerCASecret(ctx context.Context, 
 			Name:      policyServer.NameWithPrefix(),
 		},
 	}
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, policyServerSecret, func() error {
+	_, err := controllerutil.CreateOrPatch(ctx, r.Client, policyServerSecret, func() error {
 		if err := controllerutil.SetOwnerReference(policyServer, policyServerSecret, r.Client.Scheme()); err != nil {
 			return errors.Join(errors.New("failed to set policy server secret owner reference"), err)
 		}
@@ -97,7 +97,7 @@ func (r *Reconciler) fetchOrInitializePolicyServerCARootSecret(ctx context.Conte
 			Name:      constants.PolicyServerCARootSecretName,
 		},
 	}
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, policyServerSecret, func() error {
+	_, err := controllerutil.CreateOrPatch(ctx, r.Client, policyServerSecret, func() error {
 		_, hasCARootCert := policyServerSecret.Data[constants.PolicyServerCARootCACert]
 		_, hasCARootPem := policyServerSecret.Data[constants.PolicyServerCARootPemName]
 		_, hasCARootPrivateKey := policyServerSecret.Data[constants.PolicyServerCARootPrivateKeyCertName]

--- a/internal/pkg/admission/policy-server-pod-disruption-budget.go
+++ b/internal/pkg/admission/policy-server-pod-disruption-budget.go
@@ -41,7 +41,7 @@ func reconcilePodDisruptionBudget(ctx context.Context, policyServer *policiesv1.
 			Namespace: namespace,
 		},
 	}
-	_, err := controllerutil.CreateOrUpdate(ctx, k8s, pdb, func() error {
+	_, err := controllerutil.CreateOrPatch(ctx, k8s, pdb, func() error {
 		pdb.Name = policyServer.NameWithPrefix()
 		pdb.Namespace = namespace
 		if err := controllerutil.SetOwnerReference(policyServer, pdb, k8s.Scheme()); err != nil {

--- a/internal/pkg/admission/policy-server-service.go
+++ b/internal/pkg/admission/policy-server-service.go
@@ -42,7 +42,7 @@ func (r *Reconciler) reconcilePolicyServerService(ctx context.Context, policySer
 			Namespace: r.DeploymentsNamespace,
 		},
 	}
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, &svc, func() error {
+	_, err := controllerutil.CreateOrPatch(ctx, r.Client, &svc, func() error {
 		return r.updateService(&svc, policyServer)
 	})
 


### PR DESCRIPTION
Consolidate the code to use only `CreateOrPatch` instead of a mix of that and `CreateOrUpdate`

Somehow related with https://github.com/kubewarden/helm-charts/issues/457
