### PR TITLE
fix: its not necessary add the finalizer in the reconciliation loop.

### DIFF
--- a/controllers/admissionpolicy_controller_test.go
+++ b/controllers/admissionpolicy_controller_test.go
@@ -22,7 +22,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive
 	. "github.com/onsi/gomega"    //nolint:revive
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/kubewarden/kubewarden-controller/internal/pkg/constants"
 	policiesv1 "github.com/kubewarden/kubewarden-controller/pkg/apis/policies/v1"
@@ -318,17 +317,5 @@ var _ = Describe("AdmissionPolicy controller", func() {
 				HaveField("Status.PolicyStatus", Equal(policiesv1.PolicyStatusActive)),
 			)
 		})
-	})
-
-	It("should adds policy's missing finalizer", func() {
-		policyName := newName("missing-finalizer-policy")
-		policy := admissionPolicyFactory(policyName, policyNamespace, "", false)
-		controllerutil.RemoveFinalizer(policy, constants.KubewardenFinalizer)
-		Expect(k8sClient.Create(ctx, policy)).To(haveSucceededOrAlreadyExisted())
-		Eventually(func() (*policiesv1.AdmissionPolicy, error) {
-			return getTestAdmissionPolicy(policyNamespace, policyName)
-		}, timeout, pollInterval).Should(
-			HaveField("Finalizers", ContainElement(constants.KubewardenFinalizer)),
-		)
 	})
 })

--- a/controllers/clusteradmissionpolicy_controller_test.go
+++ b/controllers/clusteradmissionpolicy_controller_test.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive
 	. "github.com/onsi/gomega"    //nolint:revive
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/kubewarden/kubewarden-controller/internal/pkg/constants"
 	policiesv1 "github.com/kubewarden/kubewarden-controller/pkg/apis/policies/v1"
@@ -218,18 +217,6 @@ var _ = Describe("ClusterAdmissionPolicy controller", func() {
 			return getTestClusterAdmissionPolicy(policyName)
 		}, timeout, pollInterval).Should(
 			HaveField("Status.PolicyStatus", Equal(policiesv1.PolicyStatusUnscheduled)),
-		)
-	})
-
-	It("should adds policy's missing finalizer", func() {
-		policyName := newName("missing-finalizer-policy")
-		policy := clusterAdmissionPolicyFactory(policyName, "", false)
-		controllerutil.RemoveFinalizer(policy, constants.KubewardenFinalizer)
-		Expect(k8sClient.Create(ctx, policy)).To(haveSucceededOrAlreadyExisted())
-		Eventually(func() (*policiesv1.ClusterAdmissionPolicy, error) {
-			return getTestClusterAdmissionPolicy(policyName)
-		}, timeout, pollInterval).Should(
-			HaveField("Finalizers", ContainElement(constants.KubewardenFinalizer)),
 		)
 	})
 

--- a/controllers/policy_utils.go
+++ b/controllers/policy_utils.go
@@ -72,13 +72,6 @@ func startReconciling(ctx context.Context, client client.Client, reconciler admi
 		return reconcilePolicyDeletion(ctx, client, policy)
 	}
 
-	if !controllerutil.ContainsFinalizer(policy, constants.KubewardenFinalizer) {
-		controllerutil.AddFinalizer(policy, constants.KubewardenFinalizer)
-		if err := client.Update(ctx, policy); err != nil {
-			return ctrl.Result{}, fmt.Errorf("cannot update policy finalizer: %w", err)
-		}
-	}
-
 	reconcileResult, reconcileErr := reconcilePolicy(ctx, client, reconciler, policy)
 
 	_ = setPolicyStatus(ctx, reconciler.DeploymentsNamespace, reconciler.APIReader, policy)

--- a/controllers/policyserver_controller.go
+++ b/controllers/policyserver_controller.go
@@ -75,13 +75,6 @@ func (r *PolicyServerReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return r.reconcileDeletion(ctx, &policyServer, policies)
 	}
 
-	if !controllerutil.ContainsFinalizer(&policyServer, constants.KubewardenFinalizer) {
-		controllerutil.AddFinalizer(&policyServer, constants.KubewardenFinalizer)
-		if err := r.Client.Update(ctx, &policyServer); err != nil {
-			return ctrl.Result{}, fmt.Errorf("cannot update policy server finalizer: %w", err)
-		}
-	}
-
 	reconcileResult, reconcileErr := r.reconcile(ctx, &policyServer, policies)
 
 	if err := r.Client.Status().Update(ctx, &policyServer); err != nil {

--- a/controllers/policyserver_controller_test.go
+++ b/controllers/policyserver_controller_test.go
@@ -693,17 +693,6 @@ var _ = Describe("PolicyServer controller", func() {
 
 		})
 
-		It("should add missing finalizer", func() {
-			policyServer := policyServerFactory(policyServerName)
-			controllerutil.RemoveFinalizer(policyServer, constants.KubewardenFinalizer)
-			createPolicyServerAndWaitForItsService(policyServer)
-			Eventually(func() (*policiesv1.PolicyServer, error) {
-				return getTestPolicyServer(policyServerName)
-			}, timeout, pollInterval).Should(
-				HaveField("Finalizers", ContainElement(constants.KubewardenFinalizer)),
-			)
-		})
-
 	})
 
 	When("updating the PolicyServer", func() {


### PR DESCRIPTION
## Description

The finalizer used by the Kubewarden controller is added in the webhook for the policy server and policies types. Therefore, it not needed to add it in the reconciliation loop. Furthermore, the deletion reconciliation is able to handle old finalizer as well. So, this change will not cause issues when deleting resources.


