### PR TITLE
fix: bump cert NotAfter to 10 years

### DIFF
--- a/internal/pkg/admissionregistration/cert.go
+++ b/internal/pkg/admissionregistration/cert.go
@@ -61,7 +61,7 @@ func GenerateCert(ca []byte,
 		DNSNames:     sansHosts,
 		IPAddresses:  sansIps,
 		NotBefore:    time.Now(),
-		NotAfter:     time.Now().AddDate(1, 0, 0),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
 		SubjectKeyId: []byte{1, 2, 3, 4, 6},
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:     x509.KeyUsageDigitalSignature,
@@ -105,7 +105,6 @@ func pemEncodePrivateKey(privateKey []byte) ([]byte, error) {
 		Type:  "RSA PRIVATE KEY",
 		Bytes: privateKey,
 	})
-
 	if err != nil {
 		return []byte{}, fmt.Errorf("PEM encode failure: %w", err)
 	}


### PR DESCRIPTION
## Description

Bumps policy server TLS cert expiration to 10 years.
