### PR TITLE
test: split envtest/real cluster tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,6 @@ jobs:
         uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
         with:
           version: v1.57.2
-          # Disable caching as a workaround for https://github.com/golangci/golangci-lint-action/issues/135.
-          # The line can be removed once the golangci-lint issue is resolved.
-          skip-pkg-cache: true
 
   shellcheck:
     name: Shellcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,10 @@ jobs:
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: "1.22"
-      - run: make integration-tests
+      - name: Install gingko
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - run: make integration-tests-envtest
+      - run: make integration-tests-real-cluster
       - name: Upload integration-tests coverage to Codecov
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,22 +42,22 @@ You can use [k3d](https://k3d.io/) to create a local cluster for development pur
 ### Settings
 
 The `tilt-settings.yaml.example` acts as a template for the `tilt-settings.yaml`
-file that you need to create in the root of this repository.  Copy the example
-file and edit it to match your environment.  The `tilt-settings.yaml` file is
+file that you need to create in the root of this repository. Copy the example
+file and edit it to match your environment. The `tilt-settings.yaml` file is
 ignored by git, so you can edit it without concern about committing it by
 mistake.
 
 The following settings can be configured:
 
 - `registry`: the container registry to push the controller image to. If you
-don't have a private registry, you can use `ghcr.io` provided your cluster has
-access to it.
+  don't have a private registry, you can use `ghcr.io` provided your cluster has
+  access to it.
 
 - `image`: the name of the controller image. If you are using `ghcr.io` as your
-registry, you need to prefix the image name with your GitHub username.
+  registry, you need to prefix the image name with your GitHub username.
 
 - `helm_charts_path`: the path to the `helm-charts` repository that you cloned
-in the previous step.
+  in the previous step.
 
 Example:
 
@@ -83,6 +83,76 @@ empty cluster:
 ```console
 tilt up --stream
 ```
+
+## Testing
+
+### Run tests
+
+Run all tests:
+
+```console
+make test
+```
+
+Run unit tests only:
+
+```console
+make unit-tests
+```
+
+Run controller integration tests only:
+
+```console
+make integration-tests
+```
+
+Run tests that do not require a Kubernetes cluster only:
+
+```console
+make integration-tests-envtest
+```
+
+Run tests that require a Kubernetes cluster only:
+
+```console
+make integration-tests-real-cluster
+```
+
+### Writing (controller) integration tests
+
+The controller integration tests are written using the [Ginkgo](https://onsi.github.io/ginkgo/)
+and [Gomega](https://onsi.github.io/gomega/) testing frameworks.
+The tests are located in the `internal/controller` package.
+
+By default, the tests are run by using [envtest](https://book.kubebuilder.io/reference/envtest) which
+sets up an instance of etcd and the Kubernetes API server, without kubelet, controller-manager or other components.
+
+However, some tests require a real Kubernetes cluster to run.
+These tests must be marked with the `real-cluster` ginkgo label.
+
+Example:
+
+```
+var _ = Describe("A test that requires a real cluster", Label("real cluster") func() {
+    Context("when running in a real cluster", func() {
+        It("should do something", func() {
+            // test code
+        })
+    })
+})
+```
+
+To run only the tests that require a real cluster, you can use the following command:
+
+```console
+make integration-test-real-cluster
+```
+
+The suite setup will start a [k3s testcontainer](https://testcontainers.com/modules/k3s/) and run the tests against it.
+It will also stop and remove the container when the tests finish.
+
+Note that the `real-cluster` tests are slower than the `envtest` tests, therefore, it is recommended to keep the number of `real-cluster` tests to a minimum.
+An example of a test that requires a real cluster is the `AdmissionPolicy` test suite, since at the time of writing, we wait for the `PolicyServer` Pod to be ready before reconciling the webhook configuration.
 
 ## Tagging a new release
 
@@ -133,24 +203,24 @@ everything works well:
 - [ ] Update audit scanner code
 - [ ] Run audit scanner tests or check if the CI is green in the main branch
 - [ ] Bump policy server version in the `Cargo.toml` and update the `Cargo.lock`
-file. This requires a PR in the repository to update the files in the main
-branch. Update the local code after merging the PR
+      file. This requires a PR in the repository to update the files in the main
+      branch. Update the local code after merging the PR
 - [ ] Run policy server tests or check if the CI is green in the main branch
 - [ ] Bump kwctl version in the `Cargo.toml` and update the `Cargo.lock` file.
-This requires a PR in the repository to update the files in the main branch.
-Update the local code after merging the PR
+      This requires a PR in the repository to update the files in the main branch.
+      Update the local code after merging the PR
 - [ ] Run kwctl tests or check if the CI is green in the main branch
 - [ ] Tag audit scanner
 - [ ] Tag policy server
 - [ ] Tag controller
 - [ ] Tag kwctl
 - [ ] Wait for all CI running in all the major components (audit scanner,
-controller, policy server and kwctl) to finish
+      controller, policy server and kwctl) to finish
 - [ ] Check if the Helm chart repository CI open a PR updating the Helm charts
-with the correct changes.
+      with the correct changes.
   - [ ] Check if the `kubewarden-controller` chart versions are correctly bumped
   - [ ] Check if the `kubewarden-defaults` chart versions are correctly bumped
   - [ ] Check if the `kubewarden-crds` chart versions are correctly bumped
   - [ ] Check if kubewarden-controller, kubewarden-defaults and kubewarden-crds
-  charts have the same `appVersion`
+        charts have the same `appVersion`
 - [ ] Check if CI in the Helm chart PR is green. If so, merge it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,20 @@ It will also stop and remove the container when the tests finish.
 Note that the `real-cluster` tests are slower than the `envtest` tests, therefore, it is recommended to keep the number of `real-cluster` tests to a minimum.
 An example of a test that requires a real cluster is the `AdmissionPolicy` test suite, since at the time of writing, we wait for the `PolicyServer` Pod to be ready before reconciling the webhook configuration.
 
+### Focusing
+
+You can focus on a specific test or spec by using a [Focused Spec](https://onsi.github.io/ginkgo/#focused-specs).
+
+Example:
+
+```go
+var _ = Describe("Controller test", func() {
+    FIt("should do something", func() {
+        // This spec will be the only one executed
+    })
+})
+```
+
 ## Tagging a new release
 
 ### Make sure to update the CRD docs

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ENVTEST_K8S_VERSION = 1.30.0
 # K3S_TESTCONTAINER_VERSION refers to the version of k3s testcontainer to be used by envtest to run integration tests.
 K3S_TESTCONTAINER_VERSION = v1.30.0-k3s1
 # POLICY_SERVER_VERSION refers to the version of the policy server to be used by integration tests.
-POLICY_SERVER_VERSION = v1.13.0
+POLICY_SERVER_VERSION = v1.14.0
 
 # Let's use a generous timeout for integration tests because GitHub workers can
 # be slow

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
-
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.29
+ENVTEST_K8S_VERSION = 1.30.0
 # K3S_TESTCONTAINER_VERSION refers to the version of k3s testcontainer to be used by envtest to run integration tests.
-K3S_TESTCONTAINER_VERSION = v1.29.1-k3s2
+K3S_TESTCONTAINER_VERSION = v1.30.0-k3s1
 # POLICY_SERVER_VERSION refers to the version of the policy server to be used by integration tests.
-POLICY_SERVER_VERSION = v1.11.0
-# Binary directory
-ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-BIN_DIR := $(abspath $(ROOT_DIR)/bin)
+POLICY_SERVER_VERSION = v1.13.0
+
+# Let's use a generous timeout for integration tests because GitHub workers can
+# be slow
+TEST_TIMEOUT := 30m
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -18,40 +18,25 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# CONTAINER_TOOL defines the container tool to be used for building images.
+# Be aware that the target commands are only tested with Docker which is
+# scaffolded by default. However, you might want to replace it to use other
+# tools. (i.e. podman)
+CONTAINER_TOOL ?= docker
+
 # Setting SHELL to bash allows bash commands to be executed by recipes.
-# This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
-# Tools binaries
-CONTROLLER_GEN_VER := v0.15.0
-CONTROLLER_GEN_BIN := controller-gen
-CONTROLLER_GEN := $(BIN_DIR)/$(CONTROLLER_GEN_BIN)
-
-KUSTOMIZE_VER := v5.4.1
-KUSTOMIZE_BIN := kustomize
-KUSTOMIZE := $(BIN_DIR)/$(KUSTOMIZE_BIN)
-
-SETUP_ENVTEST_VER := v0.0.0-20211110210527-619e6b92dab9
-SETUP_ENVTEST_BIN := setup-envtest
-SETUP_ENVTEST := $(abspath $(BIN_DIR)/$(SETUP_ENVTEST_BIN))
-
-GOLANGCI_LINT_VER := v1.57.2
-GOLANGCI_LINT_BIN := golangci-lint
-GOLANGCI_LINT := $(BIN_DIR)/$(GOLANGCI_LINT_BIN)
-
-# Let's use a generous timeout for integration tests because GitHub workers can
-# be slow
-TEST_TIMEOUT := 30m
-
+.PHONY: all
 all: build
 
 ##@ General
 
 # The help target prints out all targets with their descriptions organized
 # beneath their categories. The categories are represented by '##@' and the
-# target descriptions by '##'. The awk commands is responsible for reading the
+# target descriptions by '##'. The awk command is responsible for reading the
 # entire set of makefiles included in this invocation, looking for lines of the
 # file as xyz: ## something, and then pretty-format the target and help. Then,
 # if there's a line with ##@ something, that gets pretty-printed as a category.
@@ -60,74 +45,71 @@ all: build
 # More info on the awk command:
 # http://linuxcommand.org/lc3_adv_awk.php
 
+.PHONY: help
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-## @ Tools
-
-controller-gen: $(CONTROLLER_GEN) ## Install a local copy of controller-gen.
-kustomize: $(KUSTOMIZE) ## Install a local copy of kustomize.
-setup-envtest: $(SETUP_ENVTEST) ## Install a local copy of setup-envtest.
-golangci-lint: $(GOLANGCI_LINT) ## Install a local copy of golang ci-lint.
-
-$(CONTROLLER_GEN): ## Install controller-gen.
-	GOBIN=$(BIN_DIR) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VER)
-
-$(KUSTOMIZE): ## Install kustomize.
-	GOBIN=$(BIN_DIR) go install sigs.k8s.io/kustomize/kustomize/v5@$(KUSTOMIZE_VER)
-
-$(SETUP_ENVTEST): ## Install setup-envtest.
-	GOBIN=$(BIN_DIR) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(SETUP_ENVTEST_VER)
-
-$(GOLANGCI_LINT): ## Install golangci-lint.
-	GOBIN=$(BIN_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VER)
-
 ##@ Development
 
-manifests: $(CONTROLLER_GEN)  ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+.PHONY: manifests
+manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
-generate: $(CONTROLLER_GEN) ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
+.PHONY: generate
+generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
+.PHONY: fmt
 fmt: ## Run go fmt against code.
 	go fmt ./...
 
+.PHONY: vet
 vet: ## Run go vet against code.
 	go vet ./...
-
-lint: $(GOLANGCI_LINT)
-	$(GOLANGCI_LINT) run
 
 .PHONY: test
 test: unit-tests integration-tests ## Run tests.
 
-.PHONY: setup-envtest
-setup-envtest: $(SETUP_ENVTEST) # Build setup-envtest
-	@if [ $(shell go env GOOS) == "darwin" ]; then \
-		$(eval KUBEBUILDER_ASSETS := $(shell $(SETUP_ENVTEST) use --use-env -p path --arch amd64 $(ENVTEST_K8S_VERSION))) \
-		echo "kube-builder assets set using darwin OS"; \
-	else \
-		$(eval KUBEBUILDER_ASSETS := $(shell $(SETUP_ENVTEST) use --use-env -p path $(ENVTEST_K8S_VERSION))) \
-		echo "kube-builder assets set using other OS"; \
-	fi
-
 .PHONY: unit-tests
-unit-tests: manifests generate fmt vet setup-envtest ## Run unit tests.
-	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test $$(go list ./... | grep -v /internal/controller) -race -test.v -coverprofile=coverage/unit-tests/coverage.txt -covermode=atomic
+unit-tests: manifests generate fmt vet ## Run unit tests.
+	go test $$(go list ./... | grep -v /internal/controller) -race -test.v -coverprofile=coverage/unit-tests/coverage.txt -covermode=atomic
 
-.PHONY: setup-envtest integration-tests
-integration-tests: manifests generate fmt vet setup-envtest ## Run integration tests.
-	ACK_GINKGO_DEPRECATIONS=2.12.0 K3S_TESTCONTAINER_VERSION="$(K3S_TESTCONTAINER_VERSION)" POLICY_SERVER_VERSION="$(POLICY_SERVER_VERSION)" \
-	go test -v ./internal/controller/... -ginkgo.v -ginkgo.progress -race -test.v \
-		-ginkgo.randomize-all -ginkgo.timeout=$(TEST_TIMEOUT) \
-		-coverprofile=coverage/integration-tests/coverage-controllers.txt \
-		-covermode=atomic -timeout=$(TEST_TIMEOUT) -coverpkg=all
+# Integration tests are split into two targets to allow for running tests 
+# that require a real cluster to be run separately from those that can be run using envtest.
+.PHONY: integration-tests
+integration-tests: integration-tests-envtest integration-tests-real-cluster ## Run integration tests.
 
-.PHONY: generate-crds
-generate-crds: $(KUSTOMIZE) manifests kustomize ## generate final crds with kustomize. Normally shipped in Helm charts.
-	mkdir -p generated-crds
-	$(KUSTOMIZE) build config/crd -o generated-crds # If -o points to a folder, kustomize saves them as several files instead of 1
+# Note that the label-filter "!real-cluster" is used to exclude tests that require a real cluster, 
+# otherwise ginkgo will try to run ALL tests.
+.PHONY: integration-tests-envtest
+integration-tests-envtest: manifests generate fmt vet envtest ## Run integration tests that do not require a real cluster only (using envtest).
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
+	ginkgo -v -github-output -timeout=$(TEST_TIMEOUT) -label-filter="!real-cluster" \
+	-output-dir=./coverage/integration-tests/ -coverprofile=coverage-envtest.txt -covermode=atomic -coverpkg=all \
+	./internal/controller/ 
+
+.PHONY: integration-tests-real-cluster
+integration-tests-real-cluster: manifests generate fmt vet ## Run integration tests that require a real cluster only.
+	K3S_TESTCONTAINER_VERSION="$(K3S_TESTCONTAINER_VERSION)" POLICY_SERVER_VERSION="$(POLICY_SERVER_VERSION)" \
+	ginkgo -p -v -github-output -timeout=$(TEST_TIMEOUT) -label-filter="real-cluster" \
+	-output-dir=./coverage/integration-tests/ -coverprofile=coverage-real-cluster.txt -covermode=atomic -coverpkg=all \
+	./internal/controller/
+
+.PHONY: lint
+lint: golangci-lint ## Run golangci-lint linter
+	$(GOLANGCI_LINT) run
+
+.PHONY: lint-fix
+lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
+	$(GOLANGCI_LINT) run --fix
+
+.PHONY: tilt-up
+tilt-up: manifests generate fmt vet ## Run a controller using Tilt.
+	tilt up --stream
+
+.PHONY: tilt-down
+tilt-down: ## Stop Tilt.
+	tilt down
 
 ##@ Build
 
@@ -135,44 +117,113 @@ generate-crds: $(KUSTOMIZE) manifests kustomize ## generate final crds with kust
 build: manifests generate fmt vet ## Build manager binary.
 	go build -o bin/manager cmd/main.go
 
-.PHONY: run
-run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./cmd/main.go -deployments-namespace kubewarden --default-policy-server default
+# If you wish to build the manager image targeting other platforms you can use the --platform flag.
+# (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.
+# More info: https://docs.docker.com/develop/develop-images/build_enhancements/
+.PHONY: docker-build
+docker-build: ## Build docker image with the manager.
+	$(CONTAINER_TOOL) build -t ${IMG} .
 
-docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
-
+.PHONY: docker-push
 docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+	$(CONTAINER_TOOL) push ${IMG}
+
+# PLATFORMS defines the target platforms for the manager image be built to provide support to multiple
+# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
+# - be able to use docker buildx. More info: https://docs.docker.com/build/buildx/
+# - have enabled BuildKit. More info: https://docs.docker.com/develop/develop-images/build_enhancements/
+# - be able to push the image to your registry (i.e. if you do not set a valid value via IMG=<myregistry/image:<tag>> then the export will fail)
+# To adequately provide solutions that are compatible with multiple platforms, you should consider using this option.
+PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+.PHONY: docker-buildx
+docker-buildx: ## Build and push docker image for the manager for cross-platform support
+	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
+	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+	- $(CONTAINER_TOOL) buildx create --name kubebuild-builder
+	$(CONTAINER_TOOL) buildx use kubebuild-builder
+	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
+	- $(CONTAINER_TOOL) buildx rm kubebuild-builder
+	rm Dockerfile.cross
+
+.PHONY: build-installer
+build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
+	mkdir -p dist
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/default > dist/install.yaml
 
 ##@ Deployment
 
-install: $(KUSTOMIZE) manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+ifndef ignore-not-found
+  ignore-not-found = false
+endif
 
-uninstall: $(KUSTOMIZE) manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl delete -f -
+.PHONY: install
+install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
+	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
 
-deploy: $(KUSTOMIZE) manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+.PHONY: uninstall
+uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+
+.PHONY: deploy
+deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
 
-undeploy: $(KUSTOMIZE) ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
-	bash -c "./scripts/removeFinalizersFromCRDs.sh"
-	$(KUSTOMIZE) build config/default | kubectl delete -f -
+.PHONY: undeploy
+undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
-##@ Release
+##@ Dependencies
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
-PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-define go-get-tool
+## Location to install dependencies to
+LOCALBIN ?= $(shell pwd)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+## Tool Binaries
+KUBECTL ?= kubectl
+KUSTOMIZE ?= $(LOCALBIN)/kustomize-$(KUSTOMIZE_VERSION)
+CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen-$(CONTROLLER_TOOLS_VERSION)
+ENVTEST ?= $(LOCALBIN)/setup-envtest-$(ENVTEST_VERSION)
+GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
+
+## Tool Versions
+KUSTOMIZE_VERSION ?= v5.4.1
+CONTROLLER_TOOLS_VERSION ?= v0.15.0
+ENVTEST_VERSION ?= release-0.18
+GOLANGCI_LINT_VERSION ?= v1.57.2
+
+.PHONY: kustomize
+kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
+$(KUSTOMIZE): $(LOCALBIN)
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
+
+.PHONY: controller-gen
+controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
+$(CONTROLLER_GEN): $(LOCALBIN)
+	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
+
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
+$(ENVTEST): $(LOCALBIN)
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))
+
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
+$(GOLANGCI_LINT): $(LOCALBIN)
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
+
+# go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
+# $1 - target path with name of binary (ideally with version)
+# $2 - package url which can be installed
+# $3 - specific version of package
+define go-install-tool
 @[ -f $(1) ] || { \
-set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
-rm -rf $$TMP_DIR ;\
+set -e; \
+package=$(2)@$(3) ;\
+echo "Downloading $${package}" ;\
+GOBIN=$(LOCALBIN) go install $${package} ;\
+mv "$$(echo "$(1)" | sed "s/-$(3)$$//")" $(1) ;\
 }
 endef

--- a/internal/controller/admissionpolicy_controller_test.go
+++ b/internal/controller/admissionpolicy_controller_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//nolint:dupl,goconst
+//nolint:dupl
 package controller
 
 import (

--- a/internal/controller/admissionpolicy_controller_test.go
+++ b/internal/controller/admissionpolicy_controller_test.go
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//nolint:dupl
+//nolint:dupl,goconst
 package controller
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive
@@ -31,15 +32,11 @@ import (
 	"github.com/kubewarden/kubewarden-controller/internal/constants"
 )
 
-var _ = Describe("AdmissionPolicy controller", func() {
-	var policyNamespace string
-	var policyServerName string
-	// let's use this constant to avoid linter errors
-	const PolicyServerNamePrefix = "policy-server-"
+var _ = Describe("AdmissionPolicy controller", Label("real-cluster"), func() {
+	ctx := context.Background()
+	policyNamespace := "admission-policy-controller-test"
 
 	BeforeEach(func() {
-		policyNamespace = "admission-policy-controller-test"
-		policyServerName = newName("policy-server")
 		Expect(
 			k8sClient.Create(ctx, &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
@@ -49,13 +46,16 @@ var _ = Describe("AdmissionPolicy controller", func() {
 		).To(haveSucceededOrAlreadyExisted())
 	})
 
-	When("creating a validating AdmissionPolicy", func() {
+	When("creating a validating AdmissionPolicy", Ordered, func() {
+		var policyServerName string
 		var policyName string
 		var policy *policiesv1.AdmissionPolicy
 
-		BeforeEach(func() {
+		BeforeAll(func() {
+			policyServerName = newName("policy-server")
+			createPolicyServerAndWaitForItsService(ctx, policyServerFactory(policyServerName))
+
 			policyName = newName("validating-policy")
-			createPolicyServerAndWaitForItsService(policyServerFactory(policyServerName))
 			policy = admissionPolicyFactory(policyName, policyNamespace, policyServerName, false)
 			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
 		})
@@ -63,14 +63,14 @@ var _ = Describe("AdmissionPolicy controller", func() {
 		It("should set the AdminissionPolicy to active sometime after its creation", func() {
 			By("changing the policy status to pending")
 			Eventually(func() (*policiesv1.AdmissionPolicy, error) {
-				return getTestAdmissionPolicy(policyNamespace, policyName)
+				return getTestAdmissionPolicy(ctx, policyNamespace, policyName)
 			}, timeout, pollInterval).Should(
 				HaveField("Status.PolicyStatus", Equal(policiesv1.PolicyStatusPending)),
 			)
 
 			By("changing the policy status to active")
 			Eventually(func() (*policiesv1.AdmissionPolicy, error) {
-				return getTestAdmissionPolicy(policyNamespace, policyName)
+				return getTestAdmissionPolicy(ctx, policyNamespace, policyName)
 			}, timeout, pollInterval).Should(
 				HaveField("Status.PolicyStatus", Equal(policiesv1.PolicyStatusActive)),
 			)
@@ -78,7 +78,7 @@ var _ = Describe("AdmissionPolicy controller", func() {
 
 		It("should create the ValidatingWebhookConfiguration", func() {
 			Eventually(func() error {
-				validatingWebhookConfiguration, err := getTestValidatingWebhookConfiguration(policy.GetUniqueName())
+				validatingWebhookConfiguration, err := getTestValidatingWebhookConfiguration(ctx, policy.GetUniqueName())
 				if err != nil {
 					return err
 				}
@@ -88,9 +88,9 @@ var _ = Describe("AdmissionPolicy controller", func() {
 				Expect(validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNameAnnotationKey]).To(Equal(policyName))
 				Expect(validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey]).To(Equal(policyNamespace))
 				Expect(validatingWebhookConfiguration.Webhooks).To(HaveLen(1))
-				Expect(validatingWebhookConfiguration.Webhooks[0].ClientConfig.Service.Name).To(Equal(PolicyServerNamePrefix + policyServerName))
+				Expect(validatingWebhookConfiguration.Webhooks[0].ClientConfig.Service.Name).To(Equal("policy-server-" + policyServerName))
 
-				caSecret, err := getTestCASecret()
+				caSecret, err := getTestCASecret(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(validatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle).To(Equal(caSecret.Data[constants.PolicyServerCARootPemName]))
 
@@ -98,12 +98,12 @@ var _ = Describe("AdmissionPolicy controller", func() {
 			}, timeout, pollInterval).Should(Succeed())
 		})
 
-		It("should be reconcile the ValidationWebhookConfiguration to the original state after some change", func() {
+		It("should reconcile the ValidationWebhookConfiguration to the original state after some change", func() {
 			var originalValidatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration
 			var validatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration
 			Eventually(func() error {
 				var err error
-				validatingWebhookConfiguration, err = getTestValidatingWebhookConfiguration(policy.GetUniqueName())
+				validatingWebhookConfiguration, err = getTestValidatingWebhookConfiguration(ctx, policy.GetUniqueName())
 				if err != nil {
 					return err
 				}
@@ -124,7 +124,7 @@ var _ = Describe("AdmissionPolicy controller", func() {
 
 			By("reconciling the ValidatingWebhookConfiguration to its original state")
 			Eventually(func() (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
-				return getTestValidatingWebhookConfiguration(policy.GetUniqueName())
+				return getTestValidatingWebhookConfiguration(ctx, policy.GetUniqueName())
 			}, timeout, pollInterval).Should(
 				And(
 					HaveField("Labels", Equal(originalValidatingWebhookConfiguration.Labels)),
@@ -135,7 +135,7 @@ var _ = Describe("AdmissionPolicy controller", func() {
 
 			// simulate uninitialized labels and annotation maps (behavior of Kubewarden <= 1.9.0), or user change
 			By("setting the ValidatingWebhookConfiguration labels and annotation to nil")
-			validatingWebhookConfiguration, err := getTestValidatingWebhookConfiguration(policy.GetUniqueName())
+			validatingWebhookConfiguration, err := getTestValidatingWebhookConfiguration(ctx, policy.GetUniqueName())
 			Expect(err).ToNot(HaveOccurred())
 			originalValidatingWebhookConfiguration = validatingWebhookConfiguration.DeepCopy()
 			validatingWebhookConfiguration.Labels = nil
@@ -146,7 +146,7 @@ var _ = Describe("AdmissionPolicy controller", func() {
 
 			By("reconciling the ValidatingWebhookConfiguration to its original state")
 			Eventually(func() (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
-				return getTestValidatingWebhookConfiguration(policy.GetUniqueName())
+				return getTestValidatingWebhookConfiguration(ctx, policy.GetUniqueName())
 			}, timeout, pollInterval).Should(
 				And(
 					HaveField("Labels", Equal(originalValidatingWebhookConfiguration.Labels)),
@@ -157,13 +157,16 @@ var _ = Describe("AdmissionPolicy controller", func() {
 		})
 	})
 
-	When("creating a mutating AdmissionPolicy", func() {
+	When("creating a mutating AdmissionPolicy", Ordered, func() {
+		var policyServerName string
 		var policyName string
 		var policy *policiesv1.AdmissionPolicy
 
-		BeforeEach(func() {
+		BeforeAll(func() {
+			policyServerName = newName("policy-server")
+			createPolicyServerAndWaitForItsService(ctx, policyServerFactory(policyServerName))
+
 			policyName = newName("mutating-policy")
-			createPolicyServerAndWaitForItsService(policyServerFactory(policyServerName))
 			policy = admissionPolicyFactory(policyName, policyNamespace, policyServerName, true)
 			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
 		})
@@ -171,14 +174,14 @@ var _ = Describe("AdmissionPolicy controller", func() {
 		It("should set the AdmissionPolicy to active", func() {
 			By("changing the policy status to pending")
 			Eventually(func() (*policiesv1.AdmissionPolicy, error) {
-				return getTestAdmissionPolicy(policyNamespace, policyName)
+				return getTestAdmissionPolicy(ctx, policyNamespace, policyName)
 			}, timeout, pollInterval).Should(
 				HaveField("Status.PolicyStatus", Equal(policiesv1.PolicyStatusPending)),
 			)
 
 			By("changing the policy status to active")
 			Eventually(func() (*policiesv1.AdmissionPolicy, error) {
-				return getTestAdmissionPolicy(policyNamespace, policyName)
+				return getTestAdmissionPolicy(ctx, policyNamespace, policyName)
 			}, timeout, pollInterval).Should(
 				HaveField("Status.PolicyStatus", Equal(policiesv1.PolicyStatusActive)),
 			)
@@ -186,7 +189,7 @@ var _ = Describe("AdmissionPolicy controller", func() {
 
 		It("should create the MutatingWebhookConfiguration", func() {
 			Eventually(func() error {
-				mutatingWebhookConfiguration, err := getTestMutatingWebhookConfiguration(policy.GetUniqueName())
+				mutatingWebhookConfiguration, err := getTestMutatingWebhookConfiguration(ctx, policy.GetUniqueName())
 				if err != nil {
 					return err
 				}
@@ -196,9 +199,9 @@ var _ = Describe("AdmissionPolicy controller", func() {
 				Expect(mutatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNameAnnotationKey]).To(Equal(policyName))
 				Expect(mutatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey]).To(Equal(policyNamespace))
 				Expect(mutatingWebhookConfiguration.Webhooks).To(HaveLen(1))
-				Expect(mutatingWebhookConfiguration.Webhooks[0].ClientConfig.Service.Name).To(Equal(PolicyServerNamePrefix + policyServerName))
+				Expect(mutatingWebhookConfiguration.Webhooks[0].ClientConfig.Service.Name).To(Equal("policy-server-" + policyServerName))
 
-				caSecret, err := getTestCASecret()
+				caSecret, err := getTestCASecret(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(mutatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle).To(Equal(caSecret.Data[constants.PolicyServerCARootPemName]))
 
@@ -211,7 +214,7 @@ var _ = Describe("AdmissionPolicy controller", func() {
 			var mutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration
 			Eventually(func() error {
 				var err error
-				mutatingWebhookConfiguration, err = getTestMutatingWebhookConfiguration(policy.GetUniqueName())
+				mutatingWebhookConfiguration, err = getTestMutatingWebhookConfiguration(ctx, policy.GetUniqueName())
 				if err != nil {
 					return err
 				}
@@ -232,7 +235,7 @@ var _ = Describe("AdmissionPolicy controller", func() {
 
 			By("reconciling the MutatingWebhookConfiguration to its original state")
 			Eventually(func() (*admissionregistrationv1.MutatingWebhookConfiguration, error) {
-				return getTestMutatingWebhookConfiguration(fmt.Sprintf("namespaced-%s-%s", policyNamespace, policyName))
+				return getTestMutatingWebhookConfiguration(ctx, fmt.Sprintf("namespaced-%s-%s", policyNamespace, policyName))
 			}, timeout, pollInterval).Should(
 				And(
 					HaveField("Labels", Equal(originalMutatingWebhookConfiguration.Labels)),
@@ -243,7 +246,7 @@ var _ = Describe("AdmissionPolicy controller", func() {
 
 			// simulate unitialized labels and annotation maps (behaviour of Kubewarden <= 1.9.0), or user change
 			By("by setting the MutatingWebhookConfiguration labels and annotation to nil")
-			mutatingWebhookConfiguration, err := getTestMutatingWebhookConfiguration(fmt.Sprintf("namespaced-%s-%s", policyNamespace, policyName))
+			mutatingWebhookConfiguration, err := getTestMutatingWebhookConfiguration(ctx, fmt.Sprintf("namespaced-%s-%s", policyNamespace, policyName))
 			Expect(err).ToNot(HaveOccurred())
 			originalMutatingWebhookConfiguration = mutatingWebhookConfiguration.DeepCopy()
 			mutatingWebhookConfiguration.Labels = nil
@@ -254,7 +257,7 @@ var _ = Describe("AdmissionPolicy controller", func() {
 
 			By("reconciling the MutatingWebhookConfiguration to its original state")
 			Eventually(func() (*admissionregistrationv1.MutatingWebhookConfiguration, error) {
-				return getTestMutatingWebhookConfiguration(fmt.Sprintf("namespaced-%s-%s", policyNamespace, policyName))
+				return getTestMutatingWebhookConfiguration(ctx, fmt.Sprintf("namespaced-%s-%s", policyNamespace, policyName))
 			}, timeout, pollInterval).Should(
 				And(
 					HaveField("Labels", Equal(originalMutatingWebhookConfiguration.Labels)),
@@ -272,17 +275,17 @@ var _ = Describe("AdmissionPolicy controller", func() {
 		).To(haveSucceededOrAlreadyExisted())
 
 		Eventually(func() (*policiesv1.AdmissionPolicy, error) {
-			return getTestAdmissionPolicy(policyNamespace, policyName)
+			return getTestAdmissionPolicy(ctx, policyNamespace, policyName)
 		}, timeout, pollInterval).Should(
 			HaveField("Status.PolicyStatus", Equal(policiesv1.PolicyStatusUnscheduled)),
 		)
 	})
 
-	When("creating an AdmissionPolicy with a PolicyServer assigned but not running yet", func() {
-		var policyName string
+	When("creating an AdmissionPolicy with a PolicyServer assigned but not running yet", Ordered, func() {
+		policyName := newName("scheduled-policy")
+		policyServerName := newName("policy-server")
 
-		BeforeEach(func() {
-			policyName = newName("scheduled-policy")
+		BeforeAll(func() {
 			Expect(
 				k8sClient.Create(ctx, admissionPolicyFactory(policyName, policyNamespace, policyServerName, false)),
 			).To(haveSucceededOrAlreadyExisted())
@@ -290,7 +293,7 @@ var _ = Describe("AdmissionPolicy controller", func() {
 
 		It("should set the policy status to scheduled", func() {
 			Eventually(func() (*policiesv1.AdmissionPolicy, error) {
-				return getTestAdmissionPolicy(policyNamespace, policyName)
+				return getTestAdmissionPolicy(ctx, policyNamespace, policyName)
 			}, timeout, pollInterval).Should(
 				HaveField("Status.PolicyStatus", Equal(policiesv1.PolicyStatusScheduled)),
 			)
@@ -304,14 +307,14 @@ var _ = Describe("AdmissionPolicy controller", func() {
 
 			By("changing the policy status to pending")
 			Eventually(func() (*policiesv1.AdmissionPolicy, error) {
-				return getTestAdmissionPolicy(policyNamespace, policyName)
+				return getTestAdmissionPolicy(ctx, policyNamespace, policyName)
 			}, timeout, pollInterval).Should(
 				HaveField("Status.PolicyStatus", Equal(policiesv1.PolicyStatusPending)),
 			)
 
 			By("changing the policy status to active")
 			Eventually(func() (*policiesv1.AdmissionPolicy, error) {
-				return getTestAdmissionPolicy(policyNamespace, policyName)
+				return getTestAdmissionPolicy(ctx, policyNamespace, policyName)
 			}, timeout, pollInterval).Should(
 				HaveField("Status.PolicyStatus", Equal(policiesv1.PolicyStatusActive)),
 			)

--- a/internal/controller/policyserver_controller_test.go
+++ b/internal/controller/policyserver_controller_test.go
@@ -388,6 +388,7 @@ var _ = Describe("PolicyServer controller", func() {
 					MatchFields(IgnoreExtras, Fields{
 						"UID":  Equal(policyServer.GetUID()),
 						"Name": Equal(policyServer.GetName()),
+						// FIXME: for some reason GroupVersionKind is not set
 						// "Kind":       Equal(policyServer.GetObjectKind().GroupVersionKind().Kind),
 						// "APIVersion": Equal(policyServer.GetObjectKind().GroupVersionKind().GroupVersion().String()),
 					}),

--- a/internal/controller/policyserver_controller_test.go
+++ b/internal/controller/policyserver_controller_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//nolint:godox,wrapcheck
+//nolint:godox
 package controller
 
 import (

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -21,17 +21,18 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive
 	. "github.com/onsi/gomega"    //nolint:revive
-
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/k3s"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -40,24 +41,20 @@ import (
 
 	policiesv1 "github.com/kubewarden/kubewarden-controller/api/policies/v1"
 	"github.com/kubewarden/kubewarden-controller/internal/admission"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var (
-	cfg          *rest.Config //nolint
-	k8sClient    client.Client
-	testEnv      *envtest.Environment
-	ctx          context.Context
-	cancel       context.CancelFunc
-	reconciler   admission.Reconciler
-	k3sContainer *k3s.K3sContainer
-)
+var k8sClient client.Client
 
 const (
-	DeploymentsNamespace = "kubewarden-integration-tests"
+	timeout              = 180 * time.Second
+	pollInterval         = 250 * time.Millisecond
+	consistencyTimeout   = 5 * time.Second
+	deploymentsNamespace = "kubewarden-integration-tests"
 )
 
 func TestAPIs(t *testing.T) {
@@ -66,60 +63,65 @@ func TestAPIs(t *testing.T) {
 	RunSpecs(t, "Controller Suite")
 }
 
-var _ = BeforeSuite(func() {
+var _ = SynchronizedBeforeSuite(func() []byte {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-	ctx, cancel = context.WithCancel(context.TODO())
+	var ctx context.Context
+	ctx, cancel := context.WithCancel(context.TODO())
 
-	By("bootstrapping test environment")
-	k3sTestcontainerVersion, ok := os.LookupEnv("K3S_TESTCONTAINER_VERSION")
-	if !ok {
-		k3sTestcontainerVersion = "latest"
-	}
-
-	var err error
-	k3sContainer, err = k3s.RunContainer(ctx,
-		testcontainers.WithImage("docker.io/rancher/k3s:"+k3sTestcontainerVersion),
-	)
-	Expect(err).NotTo(HaveOccurred())
-
-	kubeConfigYaml, err := k3sContainer.GetKubeConfig(ctx)
-	Expect(err).NotTo(HaveOccurred())
-
-	restcfg, err := clientcmd.RESTConfigFromKubeConfig(kubeConfigYaml)
-	Expect(err).NotTo(HaveOccurred())
-
-	trueValue := true
-	testEnv = &envtest.Environment{
+	testEnv := &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
-		Config:                restcfg,
-		UseExistingCluster:    &trueValue,
+	}
+	// If the suite is being run with the "real-cluster" label, start a k3s container
+	// and use it as the test environment.
+	// See: https://github.com/onsi/ginkgo/issues/1108#issuecomment-1456637713
+	if Label("real-cluster").MatchesLabelFilter(GinkgoLabelFilter()) {
+		By("starting the k3s test container")
+		k3sTestcontainerVersion, ok := os.LookupEnv("K3S_TESTCONTAINER_VERSION")
+		if !ok {
+			k3sTestcontainerVersion = "latest"
+		}
+
+		k3sContainer, err := k3s.RunContainer(ctx,
+			testcontainers.WithImage("docker.io/rancher/k3s:"+k3sTestcontainerVersion),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		kubeConfigYaml, err := k3sContainer.GetKubeConfig(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		kubeConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeConfigYaml)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("configuting the test environment to use the k3s cluster")
+		testEnv.UseExistingCluster = ptr.To(true)
+		testEnv.Config = kubeConfig
 	}
 
-	cfg, err := testEnv.Start()
+	restConfig, err := testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
+	Expect(restConfig).NotTo(BeNil())
 
 	err = policiesv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	k8sClient, err = client.New(restConfig, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+	k8sManager, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme: scheme.Scheme,
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	reconciler = admission.Reconciler{
+	reconciler := admission.Reconciler{
 		Client:               k8sManager.GetClient(),
 		APIReader:            k8sManager.GetClient(),
 		Log:                  ctrl.Log.WithName("reconciler"),
-		DeploymentsNamespace: DeploymentsNamespace,
+		DeploymentsNamespace: deploymentsNamespace,
 	}
 
 	err = (&AdmissionPolicyReconciler{
@@ -139,14 +141,14 @@ var _ = BeforeSuite(func() {
 	err = (&PolicyServerReconciler{
 		Client:               k8sManager.GetClient(),
 		Scheme:               k8sManager.GetScheme(),
-		DeploymentsNamespace: DeploymentsNamespace,
+		DeploymentsNamespace: deploymentsNamespace,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Create the integration tests deployments namespace
 	err = k8sClient.Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: DeploymentsNamespace,
+			Name: deploymentsNamespace,
 		},
 	})
 	Expect(err).NotTo(HaveOccurred())
@@ -156,19 +158,61 @@ var _ = BeforeSuite(func() {
 		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
-})
 
-var _ = AfterSuite(func() {
-	// When running the suite multiple times, canceling the context
-	// is not enough to stop the container in time. We need to terminate it.
-	// Otherwise, the next run may fail in the container initialization.
-	By("terminate the k3s container")
-	err := k3sContainer.Terminate(ctx)
+	DeferCleanup(func() {
+		By("tearing down the test environment")
+		cancel()
+
+		err = testEnv.Stop()
+		Expect(err).ToNot(HaveOccurred(), "failed to tear down the test environment")
+	})
+
+	// Convert rest.Config in api.Config so we write it to bytes
+	config := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"default": {
+				Server:                   restConfig.Host,
+				CertificateAuthorityData: restConfig.CAData,
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"default": {
+				ClientCertificateData: restConfig.CertData,
+				ClientKeyData:         restConfig.KeyData,
+				Username:              restConfig.Username,
+				Password:              restConfig.Password,
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"default": {
+				Cluster:  "default",
+				AuthInfo: "default",
+			},
+		},
+		CurrentContext: "default",
+	}
+	configBytes, err := clientcmd.Write(config)
 	Expect(err).NotTo(HaveOccurred())
 
-	cancel()
-	By("tearing down the test environment")
+	return configBytes
+}, func(configBytes []byte) {
+	By("connecting to the test environment")
+	if k8sClient != nil {
+		return
+	}
 
-	err = testEnv.Stop()
+	config, err := clientcmd.Load(configBytes)
+	Expect(err).NotTo(HaveOccurred())
+	restConfig, err := clientcmd.NewDefaultClientConfig(*config, &clientcmd.ConfigOverrides{}).ClientConfig()
+	restConfig.QPS = 1000.0
+	restConfig.Burst = 2000.0
+	Expect(err).NotTo(HaveOccurred())
+
+	err = policiesv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient, err = client.New(restConfig, client.Options{
+		Scheme: scheme.Scheme,
+	})
 	Expect(err).NotTo(HaveOccurred())
 })

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -14,14 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:ireturn
 package controller
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/rand"
 	"os"
-	"time"
 
 	. "github.com/onsi/gomega"         //nolint:revive
 	. "github.com/onsi/gomega/gstruct" //nolint:revive
@@ -40,12 +41,7 @@ import (
 	"github.com/kubewarden/kubewarden-controller/internal/constants"
 )
 
-const (
-	timeout                   = 180 * time.Second
-	pollInterval              = 250 * time.Millisecond
-	IntegrationTestsFinalizer = "integration-tests-safety-net-finalizer"
-	consistencyTimeout        = 5 * time.Second
-)
+const integrationTestsFinalizer = "integration-tests-safety-net-finalizer"
 
 var (
 	templatePolicyServer = policiesv1.PolicyServer{
@@ -91,7 +87,7 @@ func policyServerFactory(name string) *policiesv1.PolicyServer {
 		// By adding this finalizer automatically, we ensure that when
 		// testing removal of finalizers on deleted objects, that they will
 		// exist at all times
-		IntegrationTestsFinalizer,
+		integrationTestsFinalizer,
 	}
 	return policyServer
 }
@@ -109,7 +105,7 @@ func admissionPolicyFactory(name, policyNamespace, policyServerName string, muta
 		// By adding this finalizer automatically, we ensure that when
 		// testing removal of finalizers on deleted objects, that they will
 		// exist at all times
-		IntegrationTestsFinalizer,
+		integrationTestsFinalizer,
 	}
 	return admissionPolicy
 }
@@ -126,75 +122,75 @@ func clusterAdmissionPolicyFactory(name, policyServerName string, mutating bool)
 		// By adding this finalizer automatically, we ensure that when
 		// testing removal of finalizers on deleted objects, that they will
 		// exist at all times
-		IntegrationTestsFinalizer,
+		integrationTestsFinalizer,
 	}
 	return clusterAdmissionPolicy
 }
 
-func getTestAdmissionPolicy(namespace, name string) (*policiesv1.AdmissionPolicy, error) {
+func getTestAdmissionPolicy(ctx context.Context, namespace, name string) (*policiesv1.AdmissionPolicy, error) {
 	admissionPolicy := policiesv1.AdmissionPolicy{}
-	if err := reconciler.APIReader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &admissionPolicy); err != nil {
+	if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &admissionPolicy); err != nil {
 		return nil, errors.Join(errors.New("could not find AdmissionPolicy"), err)
 	}
 	return &admissionPolicy, nil
 }
 
-func getTestClusterAdmissionPolicy(name string) (*policiesv1.ClusterAdmissionPolicy, error) {
+func getTestClusterAdmissionPolicy(ctx context.Context, name string) (*policiesv1.ClusterAdmissionPolicy, error) {
 	clusterAdmissionPolicy := policiesv1.ClusterAdmissionPolicy{}
-	if err := reconciler.APIReader.Get(ctx, client.ObjectKey{Name: name}, &clusterAdmissionPolicy); err != nil {
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: name}, &clusterAdmissionPolicy); err != nil {
 		return nil, errors.Join(errors.New("could not find ClusterAdmissionPolicy"), err)
 	}
 	return &clusterAdmissionPolicy, nil
 }
 
-func getTestPolicyServer(name string) (*policiesv1.PolicyServer, error) {
+func getTestPolicyServer(ctx context.Context, name string) (*policiesv1.PolicyServer, error) {
 	policyServer := policiesv1.PolicyServer{}
-	if err := reconciler.APIReader.Get(ctx, client.ObjectKey{Name: name}, &policyServer); err != nil {
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: name}, &policyServer); err != nil {
 		return nil, errors.Join(errors.New("could not find PolicyServer"), err)
 	}
 	return &policyServer, nil
 }
 
-func getTestPolicyServerService(policyServerName string) (*corev1.Service, error) {
+func getTestPolicyServerService(ctx context.Context, policyServerName string) (*corev1.Service, error) {
 	serviceName := getPolicyServerNameWithPrefix(policyServerName)
 	service := corev1.Service{}
-	if err := reconciler.APIReader.Get(ctx, client.ObjectKey{Name: serviceName, Namespace: DeploymentsNamespace}, &service); err != nil {
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: serviceName, Namespace: deploymentsNamespace}, &service); err != nil {
 		return nil, errors.Join(errors.New("could not find Service owned by PolicyServer"), err)
 	}
 	return &service, nil
 }
 
-func getTestPolicyServerCASecret() (*corev1.Secret, error) {
+func getTestPolicyServerCASecret(ctx context.Context) (*corev1.Secret, error) {
 	secret := corev1.Secret{}
-	if err := reconciler.APIReader.Get(ctx, client.ObjectKey{Name: constants.PolicyServerCARootSecretName, Namespace: DeploymentsNamespace}, &secret); err != nil {
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: constants.PolicyServerCARootSecretName, Namespace: deploymentsNamespace}, &secret); err != nil {
 		return nil, errors.Join(errors.New("could not find the PolicyServer CA secret"), err)
 	}
 	return &secret, nil
 }
 
-func getTestPolicyServerSecret(policyServerName string) (*corev1.Secret, error) {
+func getTestPolicyServerSecret(ctx context.Context, policyServerName string) (*corev1.Secret, error) {
 	secretName := getPolicyServerNameWithPrefix(policyServerName)
 	secret := corev1.Secret{}
-	if err := reconciler.APIReader.Get(ctx, client.ObjectKey{Name: secretName, Namespace: DeploymentsNamespace}, &secret); err != nil {
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: secretName, Namespace: deploymentsNamespace}, &secret); err != nil {
 		return nil, errors.Join(errors.New("could not find secret owned by PolicyServer"), err)
 	}
 	return &secret, nil
 }
 
-func getTestPolicyServerDeployment(policyServerName string) (*appsv1.Deployment, error) {
+func getTestPolicyServerDeployment(ctx context.Context, policyServerName string) (*appsv1.Deployment, error) {
 	deploymentName := getPolicyServerNameWithPrefix(policyServerName)
 	deployment := appsv1.Deployment{}
-	if err := reconciler.APIReader.Get(ctx, client.ObjectKey{Name: deploymentName, Namespace: DeploymentsNamespace}, &deployment); err != nil {
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: deploymentName, Namespace: deploymentsNamespace}, &deployment); err != nil {
 		return nil, errors.Join(errors.New("could not find Deployment owned by PolicyServer"), err)
 	}
 	return &deployment, nil
 }
 
-func getTestPolicyServerConfigMap(policyServerName string) (*corev1.ConfigMap, error) {
+func getTestPolicyServerConfigMap(ctx context.Context, policyServerName string) (*corev1.ConfigMap, error) {
 	configMapName := getPolicyServerNameWithPrefix(policyServerName)
 
 	configmap := corev1.ConfigMap{}
-	if err := reconciler.APIReader.Get(ctx, client.ObjectKey{Name: configMapName, Namespace: DeploymentsNamespace}, &configmap); err != nil {
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: configMapName, Namespace: deploymentsNamespace}, &configmap); err != nil {
 		return nil, errors.Join(errors.New("could not find ConfigMap owned by PolicyServer"), err)
 	}
 	return &configmap, nil
@@ -209,47 +205,32 @@ func getPolicyServerNameWithPrefix(policyServerName string) string {
 	return policyServer.NameWithPrefix()
 }
 
-func getTestPolicyServerPod(policyServerName string) (*corev1.Pod, error) {
-	podList := corev1.PodList{}
-	if err := reconciler.APIReader.List(ctx, &podList, client.MatchingLabels{
-		constants.PolicyServerLabelKey: policyServerName,
-	}); err != nil {
-		return nil, errors.Join(errors.New("could not list Pods owned by PolicyServer"), err)
-	}
-
-	if len(podList.Items) == 0 {
-		return nil, errors.New("could not find Pod owned by PolicyServer")
-	}
-
-	return &podList.Items[0], nil
-}
-
-func getTestValidatingWebhookConfiguration(name string) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
+func getTestValidatingWebhookConfiguration(ctx context.Context, name string) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
 	validatingWebhookConfiguration := admissionregistrationv1.ValidatingWebhookConfiguration{}
-	if err := reconciler.APIReader.Get(ctx, client.ObjectKey{Name: name}, &validatingWebhookConfiguration); err != nil {
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: name}, &validatingWebhookConfiguration); err != nil {
 		return nil, errors.Join(errors.New("could not find ValidatingWebhookConfiguration"), err)
 	}
 	return &validatingWebhookConfiguration, nil
 }
 
-func getTestMutatingWebhookConfiguration(name string) (*admissionregistrationv1.MutatingWebhookConfiguration, error) {
+func getTestMutatingWebhookConfiguration(ctx context.Context, name string) (*admissionregistrationv1.MutatingWebhookConfiguration, error) {
 	mutatingWebhookConfiguration := admissionregistrationv1.MutatingWebhookConfiguration{}
-	if err := reconciler.APIReader.Get(ctx, client.ObjectKey{Name: name}, &mutatingWebhookConfiguration); err != nil {
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: name}, &mutatingWebhookConfiguration); err != nil {
 		return nil, errors.Join(errors.New("could not find ValidatingWebhookConfiguration"), err)
 	}
 	return &mutatingWebhookConfiguration, nil
 }
 
-func getTestCASecret() (*corev1.Secret, error) {
+func getTestCASecret(ctx context.Context) (*corev1.Secret, error) {
 	secret := corev1.Secret{}
-	if err := reconciler.APIReader.Get(ctx, client.ObjectKey{Name: constants.PolicyServerCARootSecretName, Namespace: DeploymentsNamespace}, &secret); err != nil {
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: constants.PolicyServerCARootSecretName, Namespace: deploymentsNamespace}, &secret); err != nil {
 		return nil, errors.Join(errors.New("could not find CA secret"), err)
 	}
 
 	return &secret, nil
 }
 
-func getPolicyServerPodDisruptionBudget(policyServerName string) (*k8spoliciesv1.PodDisruptionBudget, error) {
+func getPolicyServerPodDisruptionBudget(ctx context.Context, policyServerName string) (*k8spoliciesv1.PodDisruptionBudget, error) {
 	policyServer := policiesv1.PolicyServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: policyServerName,
@@ -257,7 +238,7 @@ func getPolicyServerPodDisruptionBudget(policyServerName string) (*k8spoliciesv1
 	}
 	podDisruptionBudgetName := policyServer.NameWithPrefix()
 	pdb := &k8spoliciesv1.PodDisruptionBudget{}
-	if err := reconciler.APIReader.Get(ctx, client.ObjectKey{Name: podDisruptionBudgetName, Namespace: DeploymentsNamespace}, pdb); err != nil {
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: podDisruptionBudgetName, Namespace: deploymentsNamespace}, pdb); err != nil {
 		return nil, errors.Join(errors.New("could not find PodDisruptionBudget"), err)
 	}
 	return pdb, nil
@@ -297,7 +278,7 @@ func policyServerPodDisruptionBudgetMatcher(policyServer *policiesv1.PolicyServe
 	)
 }
 
-func alreadyExists() types.GomegaMatcher { //nolint:ireturn
+func alreadyExists() types.GomegaMatcher {
 	return WithTransform(
 		func(err error) bool {
 			return err != nil && apierrors.IsAlreadyExists(err)
@@ -306,7 +287,7 @@ func alreadyExists() types.GomegaMatcher { //nolint:ireturn
 	)
 }
 
-func haveSucceededOrAlreadyExisted() types.GomegaMatcher { //nolint:ireturn
+func haveSucceededOrAlreadyExisted() types.GomegaMatcher {
 	return SatisfyAny(
 		BeNil(),
 		alreadyExists(),
@@ -328,22 +309,13 @@ func newName(prefix string) string {
 	return fmt.Sprintf("%s-%s", prefix, randStringRunes(8))
 }
 
-func createPolicyServerAndWaitForItsService(policyServer *policiesv1.PolicyServer) {
+func createPolicyServerAndWaitForItsService(ctx context.Context, policyServer *policiesv1.PolicyServer) {
 	Expect(
 		k8sClient.Create(ctx, policyServer),
 	).To(haveSucceededOrAlreadyExisted())
 	// Wait for the Service associated with the PolicyServer to be created
 	Eventually(func() error {
-		_, err := getTestPolicyServerService(policyServer.GetName())
+		_, err := getTestPolicyServerService(ctx, policyServer.GetName())
 		return err
 	}, timeout, pollInterval).Should(Succeed())
-}
-
-func notFound() types.GomegaMatcher { //nolint:ireturn
-	return WithTransform(
-		func(err error) bool {
-			return err != nil && apierrors.IsNotFound(err)
-		},
-		BeTrue(),
-	)
 }


### PR DESCRIPTION
## Description
This PR splits the controller tests by using the **fast and slow** testing pattern.
It is now possible to run only certain tests against a real cluster while leveraging the envtest fake 
Tests that need a real cluster to run must now be labeled with `real-cluster`.
See https://onsi.github.io/ginkgo/#spec-labels.

kubernetes API server as the default test environment.
The policy server controller test was refactored to run envtest, which means that some assertions (for instance the ones on the Pod being created) are not possible anymore. However, they are not needed as we are not interested in testing that Kubernetes works.

Also, this PR:
- updates the Makefile to v4, customizing the targets as needed fixing: #786 
- adds `integration-tests-envtest` and `integration-tests-real-cluster` targets to the Makefile, and updates the CI accordingly.
- switches to the `ginkgo` test runner, adding a flag to enable GitHub action format output
- enables parallelism for the real cluster tests. There is still work to be done for the PolicyServer controller test, which is tracked here: #792 
- adds testing developer documentation to CONTRIBUTING.md


Note: the test coverage seems to be dropping by 1/2%, by looking at the codecov report this is because the refactored tests are not causing errors due to conflicts so we are not passing through the error handling lines.

With these changes, the CI is taking ~6 minutes instead of ~28 minutes.