### PR TITLE
fix: rename some consts and functions.

### DIFF
--- a/api/policies/v1/policyserver_types.go
+++ b/api/policies/v1/policyserver_types.go
@@ -132,12 +132,12 @@ const (
 type PolicyServerConditionType string
 
 const (
-	// PolicyServerCASecretReconciled represents the condition of the
+	// PolicyServerCertSecretReconciled represents the condition of the
 	// Policy Server Secret reconciliation
-	PolicyServerCASecretReconciled PolicyServerConditionType = "CASecretReconciled"
-	// PolicyServerCARootSecretReconciled represents the condition of the
+	PolicyServerCertSecretReconciled PolicyServerConditionType = "CertSecretReconciled"
+	// CARootSecretReconciled represents the condition of the
 	// Policy Server CA Root Secret reconciliation
-	PolicyServerCARootSecretReconciled PolicyServerConditionType = "CARootSecretReconciled"
+	CARootSecretReconciled PolicyServerConditionType = "CARootSecretReconciled"
 	// PolicyServerConfigMapReconciled represents the condition of the
 	// Policy Server ConfigMap reconciliation
 	PolicyServerConfigMapReconciled PolicyServerConditionType = "ConfigMapReconciled"

--- a/internal/controller/policyserver_controller.go
+++ b/internal/controller/policyserver_controller.go
@@ -80,12 +80,12 @@ func (r *PolicyServerReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return r.reconcileDeletion(ctx, &policyServer, policies)
 	}
 
-	policyServerCARootSecret, err := r.fetchOrInitializePolicyServerCARootSecret(ctx, &policyServer)
+	caRootSecret, err := r.reconcileInternalCARootSecret(ctx, &policyServer)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	err = r.fetchOrInitializePolicyServerCASecret(ctx, &policyServer, policyServerCARootSecret)
+	err = r.reconcilePolicyServerCertSecret(ctx, &policyServer, caRootSecret)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/policyserver_controller_cert_secret.go
+++ b/internal/controller/policyserver_controller_cert_secret.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kubewarden/kubewarden-controller/internal/constants"
 )
 
-// Reconcile the certificate to be used by the policy server for TLS. The 
+// Reconcile the certificate to be used by the policy server for TLS. The
 // generated certificate is signed by the CA certificate provided in the
 // caSecret. The generated certificate is stored in a secret
 func (r *PolicyServerReconciler) reconcilePolicyServerCertSecret(ctx context.Context, policyServer *policiesv1.PolicyServer, caSecret *corev1.Secret) error {

--- a/internal/controller/policyserver_controller_test.go
+++ b/internal/controller/policyserver_controller_test.go
@@ -454,7 +454,7 @@ var _ = Describe("PolicyServer controller", func() {
 			createPolicyServerAndWaitForItsService(ctx, policyServer)
 
 			Eventually(func() error {
-				secret, err := getTestPolicyServerCASecret(ctx)
+				secret, err := getInternalPolicyServerRootCASecret(ctx)
 				if err != nil {
 					return err
 				}

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -160,7 +160,7 @@ func getTestPolicyServerService(ctx context.Context, policyServerName string) (*
 	return &service, nil
 }
 
-func getTestPolicyServerCASecret(ctx context.Context) (*corev1.Secret, error) {
+func getInternalPolicyServerRootCASecret(ctx context.Context) (*corev1.Secret, error) {
 	secret := corev1.Secret{}
 	if err := k8sClient.Get(ctx, client.ObjectKey{Name: constants.PolicyServerCARootSecretName, Namespace: deploymentsNamespace}, &secret); err != nil {
 		return nil, errors.Join(errors.New("could not find the PolicyServer CA secret"), err)


### PR DESCRIPTION
## Description

Renames some functions and constants in the code related to CA and certificates reconciliation to avoid confusion.


Fix #782 
