### PR TITLE
build: add ginkgo dep to makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,6 @@ jobs:
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: "1.22"
-      - name: Install gingko
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
       - run: make integration-tests-envtest
       - run: make integration-tests-real-cluster
       - name: Upload integration-tests coverage to Codecov


### PR DESCRIPTION
## Description
Adds the ginkgo cli tool dependency to the Makefile, similarly to what Kubebuilder already scaffolds for other external tools.

I've tried to cache the `bin` directory, but restoring the cache takes about the same time as installing the tools from scratch.