### PR TITLE
fix: remove default policy server name CLI flag.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -85,7 +85,6 @@ func main() {
 	flag.BoolVar(&enableTracing, "enable-tracing", false,
 		"Enable tracing collection for all Policy Servers")
 	flag.StringVar(&openTelemetryEndpoint, "opentelemetry-endpoint", "127.0.0.1:4317", "The OpenTelemetry connection endpoint")
-	flag.StringVar(&constants.DefaultPolicyServer, "default-policy-server", "", "The default policy server to set on policies before they are persisted")
 	flag.StringVar(&deploymentsNamespace,
 		"deployments-namespace",
 		"",

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -2,14 +2,10 @@ package constants
 
 import "time"
 
-// DefaultPolicyServer is set to a non empty value if policies that
-// are missing a policy server should be defaulted to this one
-// before being persisted.
-//
-//nolint:gochecknoglobals //Disabling this check here because we have an issue to remove the default policy server configuration.
-var DefaultPolicyServer string
-
 const (
+	// DefaultPolicyServer is the default policy server name to be used when
+	// policies does not have a policy server name defined.
+	DefaultPolicyServer = "default"
 	// PolicyServer CA Secret.
 	PolicyServerTLSCert                  = "policy-server-cert"
 	PolicyServerTLSKey                   = "policy-server-key"


### PR DESCRIPTION
## Description

Updates the CLI flag to allow users to define the default policy server name to be used when users does not define one in policies. Now the default policy server name will be always: "default"

Fix #809 

