### PR TITLE
feat: certificate rotation

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -9,10 +9,6 @@ kubectl_cmd = "kubectl"
 if str(local("command -v " + kubectl_cmd + " || true", quiet = True)) == "":
     fail("Required command '" + kubectl_cmd + "' not found in PATH")
 
-# Install cert manager
-load('ext://cert_manager', 'deploy_cert_manager')
-deploy_cert_manager()
-
 # Create the kubewarden namespace
 # This is required since the helm() function doesn't support the create_namespace flag
 load('ext://namespace', 'namespace_create')

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -4,15 +4,13 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
 	"math/big"
-	"net"
 	"time"
-
-	"github.com/kubewarden/kubewarden-controller/internal/constants"
 )
 
 const (
@@ -21,9 +19,9 @@ const (
 	exp     = 159
 )
 
-// GenerateCA generates a self-signed CA root certificate and private key
-// The certificate is valid for 10 years.
-func GenerateCA() ([]byte, *rsa.PrivateKey, error) {
+// GenerateCA generates a self-signed CA root certificate and private key in PEM format.
+// It accepts validity bounds as parameters.
+func GenerateCA(notBefore, notAfter time.Time) ([]byte, []byte, error) {
 	serialNumber, err := rand.Int(rand.Reader, (&big.Int{}).Exp(big.NewInt(base), big.NewInt(exp), nil))
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot init serial number: %w", err)
@@ -44,8 +42,8 @@ func GenerateCA() ([]byte, *rsa.PrivateKey, error) {
 			StreetAddress: []string{""},
 			PostalCode:    []string{""},
 		},
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().AddDate(constants.CertExpirationYears, 0, 0),
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
 		IsCA:                  true,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
@@ -62,19 +60,37 @@ func GenerateCA() ([]byte, *rsa.PrivateKey, error) {
 		return nil, nil, fmt.Errorf("cannot create certificate: %w", err)
 	}
 
-	return caCertBytes, privateKey, nil
+	caCertPEM, err := pemEncodeCertificate(caCertBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot encode certificate: %w", err)
+	}
+
+	privateKeyPEM, err := pemEncodePrivateKey(privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot encode private key: %w", err)
+	}
+
+	return caCertPEM, privateKeyPEM, nil
 }
 
-// GenerateCert generates a certificate and private key signed by the provided CA.
-// The certificate is valid for 10 years.
-func GenerateCert(ca []byte,
-	commonName string,
-	extraSANs []string,
-	caPrivateKey *rsa.PrivateKey,
-) ([]byte, *rsa.PrivateKey, error) {
-	caCertificate, err := x509.ParseCertificate(ca)
+// GenerateCert generates a certificate and private key signed by the provided CA in PEM format.
+// It accepts the CA root certificate and private key, validity bounds, and DNS name as parameters.
+func GenerateCert(caCertPEM []byte,
+	caPrivateKeyPEM []byte,
+	notBefore time.Time,
+	notAfter time.Time,
+	dnsName string,
+) ([]byte, []byte, error) {
+	caCertBlock, _ := pem.Decode(caCertPEM)
+	caCert, err := x509.ParseCertificate(caCertBlock.Bytes)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error parsing certificate: %w", err)
+		return nil, nil, fmt.Errorf("error parsing ca root certificate: %w", err)
+	}
+
+	caPrivateKeyBlock, _ := pem.Decode(caPrivateKeyPEM)
+	caPrivateKey, err := x509.ParsePKCS1PrivateKey(caPrivateKeyBlock.Bytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error parsing ca root private key: %w", err)
 	}
 
 	serialNumber, err := rand.Int(rand.Reader, (&big.Int{}).Exp(big.NewInt(base), big.NewInt(exp), nil))
@@ -89,22 +105,10 @@ func GenerateCert(ca []byte,
 		return nil, nil, fmt.Errorf("cannot generate private key: %w", err)
 	}
 
-	sansHosts := []string{}
-	sansIps := []net.IP{}
-
-	for _, san := range extraSANs {
-		sanIP := net.ParseIP(san)
-		if sanIP == nil {
-			sansHosts = append(sansHosts, san)
-		} else {
-			sansIps = append(sansIps, sanIP)
-		}
-	}
-
 	cert := x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
-			CommonName:    commonName,
+			CommonName:    dnsName,
 			Organization:  []string{""},
 			Country:       []string{""},
 			Province:      []string{""},
@@ -112,30 +116,38 @@ func GenerateCert(ca []byte,
 			StreetAddress: []string{""},
 			PostalCode:    []string{""},
 		},
-		DNSNames:     sansHosts,
-		IPAddresses:  sansIps,
-		NotBefore:    time.Now(),
-		NotAfter:     time.Now().AddDate(constants.CertExpirationYears, 0, 0),
-		SubjectKeyId: []byte{1, 2, 3, 4, 6},
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		KeyUsage:     x509.KeyUsageDigitalSignature,
+		DNSNames:    []string{dnsName},
+		NotBefore:   notBefore,
+		NotAfter:    notAfter,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:    x509.KeyUsageDigitalSignature,
 	}
 
 	certBytes, err := x509.CreateCertificate(
 		rand.Reader,
 		&cert,
-		caCertificate,
+		caCert,
 		&privateKey.PublicKey,
 		caPrivateKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot create certificate: %w", err)
 	}
 
-	return certBytes, privateKey, nil
+	certPEM, err := pemEncodeCertificate(certBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot encode certificate: %w", err)
+	}
+
+	privateKeyPEM, err := pemEncodePrivateKey(privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot encode private key: %w", err)
+	}
+
+	return certPEM, privateKeyPEM, nil
 }
 
-// PEMEncodeCertificate encodes a certificate to PEM format.
-func PEMEncodeCertificate(certificate []byte) ([]byte, error) {
+// pemEncodeCertificate encodes a certificate to PEM format.
+func pemEncodeCertificate(certificate []byte) ([]byte, error) {
 	certificatePEM := new(bytes.Buffer)
 
 	err := pem.Encode(certificatePEM, &pem.Block{
@@ -149,8 +161,8 @@ func PEMEncodeCertificate(certificate []byte) ([]byte, error) {
 	return certificatePEM.Bytes(), nil
 }
 
-// PEMEncodePrivateKey encodes a private key to PEM format.
-func PEMEncodePrivateKey(privateKey *rsa.PrivateKey) ([]byte, error) {
+// pemEncodePrivateKey encodes a private key to PEM format.
+func pemEncodePrivateKey(privateKey *rsa.PrivateKey) ([]byte, error) {
 	privateKeyBytes := x509.MarshalPKCS1PrivateKey(privateKey)
 	privateKeyPEM := new(bytes.Buffer)
 
@@ -163,4 +175,73 @@ func PEMEncodePrivateKey(privateKey *rsa.PrivateKey) ([]byte, error) {
 	}
 
 	return privateKeyPEM.Bytes(), nil
+}
+
+// NewCertPool creates a new x509.CertPool from a PEM-encoded certificate that may contain multiple certificates.
+func NewCertPool(certPEM []byte) (*x509.CertPool, error) {
+	certPool := x509.NewCertPool()
+
+	for {
+		var block *pem.Block
+		block, certPEM = pem.Decode(certPEM)
+		if block == nil {
+			break
+		}
+
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing certificate: %w", err)
+		}
+
+		certPool.AddCert(cert)
+	}
+
+	return certPool, nil
+}
+
+func VerifyCA(caCertPEM, caPrivateKeyPEM []byte, at time.Time) error {
+	pool, err := NewCertPool(caCertPEM)
+	if err != nil {
+		return fmt.Errorf("failed to create cert pool: %w", err)
+	}
+
+	if err = VerifyCert(caCertPEM, caPrivateKeyPEM, pool, "", at); err != nil {
+		return fmt.Errorf("failed to verify CA certificate: %w", err)
+	}
+
+	return nil
+}
+
+func VerifyCert(certPEM, privateKeyPEM []byte, certPool *x509.CertPool, dnsName string, at time.Time) error {
+	// Decode and parse the certificate
+	certBlock, _ := pem.Decode(certPEM)
+	cert, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		return fmt.Errorf("error parsing certificate: %w", err)
+	}
+
+	// Verify the private key
+	if privateKeyPEM != nil {
+		if _, err = tls.X509KeyPair(certPEM, privateKeyPEM); err != nil {
+			return fmt.Errorf("key pair is invalid: %w", err)
+		}
+	}
+
+	// Set up the verification options
+	opts := x509.VerifyOptions{
+		Roots:       certPool,
+		DNSName:     dnsName,
+		CurrentTime: at,
+	}
+
+	// Verify the certificate
+	if _, err = cert.Verify(opts); err != nil {
+		return fmt.Errorf("the certificate is invalid: %w", err)
+	}
+
+	return nil
+}
+
+func DNSName(serviceName, namespace string) string {
+	return fmt.Sprintf("%s.%s.svc", serviceName, namespace)
 }

--- a/internal/certs/secrets.go
+++ b/internal/certs/secrets.go
@@ -1,0 +1,50 @@
+package certs
+
+import (
+	"fmt"
+
+	"github.com/kubewarden/kubewarden-controller/internal/constants"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Extract the CA certificate and private key from a secret.
+func ExtractCARootFromSecret(caRootSecret *corev1.Secret) ([]byte, []byte, error) {
+	caCert, ok := caRootSecret.Data[constants.CARootCert]
+	if !ok {
+		return nil, nil, fmt.Errorf("CA could not be extracted from secret: %s", caRootSecret.GetName())
+	}
+	if len(caCert) == 0 {
+		return nil, nil, fmt.Errorf("CA certificate is empty in secret: %s", caRootSecret.GetName())
+	}
+
+	caPrivateKey, ok := caRootSecret.Data[constants.CARootPrivateKey]
+	if !ok {
+		return nil, nil, fmt.Errorf("CA private key bytes could not be extracted from secret: %s", caRootSecret.GetName())
+	}
+	if len(caPrivateKey) == 0 {
+		return nil, nil, fmt.Errorf("CA private key is empty in secret: %s", caRootSecret.GetName())
+	}
+
+	return caCert, caPrivateKey, nil
+}
+
+// Extract the server certificate and private key from a secret.
+func ExtractServerCertFromSecret(serverCertSecret *corev1.Secret) ([]byte, []byte, error) {
+	serverCert, ok := serverCertSecret.Data[constants.ServerCert]
+	if !ok {
+		return nil, nil, fmt.Errorf("server certificate could not be extracted from secret: %s", serverCertSecret.GetName())
+	}
+	if len(serverCert) == 0 {
+		return nil, nil, fmt.Errorf("server certificate is empty in secret: %s", serverCertSecret.GetName())
+	}
+
+	serverPrivateKey, ok := serverCertSecret.Data[constants.ServerPrivateKey]
+	if !ok {
+		return nil, nil, fmt.Errorf("server private key could not be extracted from secret: %s", serverCertSecret.GetName())
+	}
+	if len(serverPrivateKey) == 0 {
+		return nil, nil, fmt.Errorf("server private key is empty in secret: %s", serverCertSecret.GetName())
+	}
+
+	return serverCert, serverPrivateKey, nil
+}

--- a/internal/certs/secrets.go
+++ b/internal/certs/secrets.go
@@ -8,17 +8,18 @@ import (
 )
 
 // Extract the CA certificate and private key from a secret.
+// Both are PEM encoded.
 func ExtractCARootFromSecret(caRootSecret *corev1.Secret) ([]byte, []byte, error) {
-	caCert, ok := caRootSecret.Data[constants.CARootCert]
-	if !ok {
+	caCert, found := caRootSecret.Data[constants.CARootCert]
+	if !found {
 		return nil, nil, fmt.Errorf("CA could not be extracted from secret: %s", caRootSecret.GetName())
 	}
 	if len(caCert) == 0 {
 		return nil, nil, fmt.Errorf("CA certificate is empty in secret: %s", caRootSecret.GetName())
 	}
 
-	caPrivateKey, ok := caRootSecret.Data[constants.CARootPrivateKey]
-	if !ok {
+	caPrivateKey, found := caRootSecret.Data[constants.CARootPrivateKey]
+	if !found {
 		return nil, nil, fmt.Errorf("CA private key bytes could not be extracted from secret: %s", caRootSecret.GetName())
 	}
 	if len(caPrivateKey) == 0 {
@@ -29,17 +30,18 @@ func ExtractCARootFromSecret(caRootSecret *corev1.Secret) ([]byte, []byte, error
 }
 
 // Extract the server certificate and private key from a secret.
+// Both are PEM encoded.
 func ExtractServerCertFromSecret(serverCertSecret *corev1.Secret) ([]byte, []byte, error) {
-	serverCert, ok := serverCertSecret.Data[constants.ServerCert]
-	if !ok {
+	serverCert, found := serverCertSecret.Data[constants.ServerCert]
+	if !found {
 		return nil, nil, fmt.Errorf("server certificate could not be extracted from secret: %s", serverCertSecret.GetName())
 	}
 	if len(serverCert) == 0 {
 		return nil, nil, fmt.Errorf("server certificate is empty in secret: %s", serverCertSecret.GetName())
 	}
 
-	serverPrivateKey, ok := serverCertSecret.Data[constants.ServerPrivateKey]
-	if !ok {
+	serverPrivateKey, found := serverCertSecret.Data[constants.ServerPrivateKey]
+	if !found {
 		return nil, nil, fmt.Errorf("server private key could not be extracted from secret: %s", serverCertSecret.GetName())
 	}
 	if len(serverPrivateKey) == 0 {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -6,13 +6,6 @@ const (
 	// DefaultPolicyServer is the default policy server name to be used when
 	// policies does not have a policy server name defined.
 	DefaultPolicyServer = "default"
-	// PolicyServer CA Secret.
-	PolicyServerTLSCert                  = "policy-server-cert"
-	PolicyServerTLSKey                   = "policy-server-key"
-	PolicyServerCARootSecretName         = "policy-server-root-ca"
-	PolicyServerCARootPemName            = "policy-server-root-ca-pem"
-	PolicyServerCARootCACert             = "policy-server-root-ca-cert"
-	PolicyServerCARootPrivateKeyCertName = "policy-server-root-ca-privatekey-cert"
 
 	// PolicyServer Deployment.
 	PolicyServerEnableMetricsEnvVar                 = "KUBEWARDEN_ENABLE_METRICS"
@@ -65,8 +58,22 @@ const (
 	TimeToRequeuePolicyReconciliation = 2 * time.Second
 	MetricsShutdownTimeout            = 5 * time.Second
 
+	// Server Cert Secrets.
+	WebhookServerCertSecretName = "kubewarden-webhook-server-cert" //nolint:gosec // This is not a credential
+	ServerCert                  = "tls.crt"
+	ServerPrivateKey            = "tls.key"
+
+	// CA Root Secret.
+	CARootSecretName = "kubewarden-ca"
+	CARootCert       = "ca.crt"
+	CARootPrivateKey = "ca.key"
+	OldCARootCert    = "old-ca.crt"
+
 	// Certs.
 	CertExpirationYears = 10
+	CACertExpiration     = 10 * 365 * 24 * time.Hour
+	ServerCertExpiration = 1 * 365 * 24 * time.Hour
+	CertLookahead        = 60 * 24 * time.Hour
 
 	// Feature flags.
 	EnablePolicyGroupsFlag = "KUBEWARDEN_ENABLE_POLICY_GROUPS"

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -27,9 +27,13 @@ const (
 	PolicyServerVerificationConfigEntry         = "verification-config"
 	PolicyServerVerificationConfigContainerPath = "/verification"
 
-	// Label.
-	AppLabelKey          = "app"
-	PolicyServerLabelKey = "kubewarden/policy-server"
+	// Labels.
+	AppLabelKey                     = "app"
+	PolicyServerLabelKey            = "kubewarden/policy-server"
+	PartOfLabelKey                  = "app.kubernetes.io/part-of"
+	PartOfLabelValue                = "kubewarden"
+	ComponentLabelKey               = "app.kubernetes.io/component"
+	ComponentPolicyServerLabelValue = "policy-server"
 
 	// Index.
 	PolicyServerIndexKey = ".spec.policyServer"

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -74,7 +74,7 @@ const (
 	OldCARootCert    = "old-ca.crt"
 
 	// Certs.
-	CertExpirationYears = 10
+	CertExpirationYears  = 10
 	CACertExpiration     = 10 * 365 * 24 * time.Hour
 	ServerCertExpiration = 1 * 365 * 24 * time.Hour
 	CertLookahead        = 60 * 24 * time.Hour

--- a/internal/controller/admissionpolicy_controller_test.go
+++ b/internal/controller/admissionpolicy_controller_test.go
@@ -82,7 +82,7 @@ var _ = Describe("AdmissionPolicy controller", Label("real-cluster"), func() {
 					return err
 				}
 
-				Expect(validatingWebhookConfiguration.Labels["kubewarden"]).To(Equal("true"))
+				Expect(validatingWebhookConfiguration.Labels["app.kubernetes.io/part-of"]).To(Equal("kubewarden"))
 				Expect(validatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey]).To(Equal(constants.NamespacePolicyScope))
 				Expect(validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNameAnnotationKey]).To(Equal(policyName))
 				Expect(validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey]).To(Equal(policyNamespace))
@@ -92,7 +92,7 @@ var _ = Describe("AdmissionPolicy controller", Label("real-cluster"), func() {
 
 				caSecret, err := getTestCASecret(ctx)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(validatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle).To(Equal(caSecret.Data[constants.PolicyServerCARootPemName]))
+				Expect(validatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle).To(Equal(caSecret.Data[constants.CARootCert]))
 
 				return nil
 			}, timeout, pollInterval).Should(Succeed())
@@ -112,7 +112,7 @@ var _ = Describe("AdmissionPolicy controller", Label("real-cluster"), func() {
 			}, timeout, pollInterval).Should(Succeed())
 
 			By("changing the ValidatingWebhookConfiguration")
-			delete(validatingWebhookConfiguration.Labels, "kubewarden")
+			delete(validatingWebhookConfiguration.Labels, "app.kubernetes.io/part-of")
 			validatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey] = newName("scope")
 			delete(validatingWebhookConfiguration.Annotations, constants.WebhookConfigurationPolicyNameAnnotationKey)
 			validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey] = newName("namespace")
@@ -194,7 +194,7 @@ var _ = Describe("AdmissionPolicy controller", Label("real-cluster"), func() {
 					return err
 				}
 
-				Expect(mutatingWebhookConfiguration.Labels["kubewarden"]).To(Equal("true"))
+				Expect(mutatingWebhookConfiguration.Labels["app.kubernetes.io/part-of"]).To(Equal("kubewarden"))
 				Expect(mutatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey]).To(Equal(constants.NamespacePolicyScope))
 				Expect(mutatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNameAnnotationKey]).To(Equal(policyName))
 				Expect(mutatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey]).To(Equal(policyNamespace))
@@ -204,7 +204,7 @@ var _ = Describe("AdmissionPolicy controller", Label("real-cluster"), func() {
 
 				caSecret, err := getTestCASecret(ctx)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(mutatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle).To(Equal(caSecret.Data[constants.PolicyServerCARootPemName]))
+				Expect(mutatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle).To(Equal(caSecret.Data[constants.CARootCert]))
 
 				return nil
 			}, timeout, pollInterval).Should(Succeed())
@@ -224,7 +224,7 @@ var _ = Describe("AdmissionPolicy controller", Label("real-cluster"), func() {
 			}, timeout, pollInterval).Should(Succeed())
 
 			By("changing the MutatingWebhookConfiguration")
-			delete(mutatingWebhookConfiguration.Labels, "kubewarden")
+			delete(mutatingWebhookConfiguration.Labels, "app.kubernetes.io/part-of")
 			mutatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey] = newName("scope")
 			delete(mutatingWebhookConfiguration.Annotations, constants.WebhookConfigurationPolicyNameAnnotationKey)
 			mutatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey] = newName("namespace")

--- a/internal/controller/admissionpolicy_controller_test.go
+++ b/internal/controller/admissionpolicy_controller_test.go
@@ -82,7 +82,7 @@ var _ = Describe("AdmissionPolicy controller", Label("real-cluster"), func() {
 					return err
 				}
 
-				Expect(validatingWebhookConfiguration.Labels["app.kubernetes.io/part-of"]).To(Equal("kubewarden"))
+				Expect(validatingWebhookConfiguration.Labels[constants.PartOfLabelKey]).To(Equal(constants.PartOfLabelValue))
 				Expect(validatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey]).To(Equal(constants.NamespacePolicyScope))
 				Expect(validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNameAnnotationKey]).To(Equal(policyName))
 				Expect(validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey]).To(Equal(policyNamespace))
@@ -112,7 +112,7 @@ var _ = Describe("AdmissionPolicy controller", Label("real-cluster"), func() {
 			}, timeout, pollInterval).Should(Succeed())
 
 			By("changing the ValidatingWebhookConfiguration")
-			delete(validatingWebhookConfiguration.Labels, "app.kubernetes.io/part-of")
+			delete(validatingWebhookConfiguration.Labels, constants.PartOfLabelKey)
 			validatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey] = newName("scope")
 			delete(validatingWebhookConfiguration.Annotations, constants.WebhookConfigurationPolicyNameAnnotationKey)
 			validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey] = newName("namespace")
@@ -194,7 +194,7 @@ var _ = Describe("AdmissionPolicy controller", Label("real-cluster"), func() {
 					return err
 				}
 
-				Expect(mutatingWebhookConfiguration.Labels["app.kubernetes.io/part-of"]).To(Equal("kubewarden"))
+				Expect(mutatingWebhookConfiguration.Labels[constants.PartOfLabelKey]).To(Equal(constants.PartOfLabelValue))
 				Expect(mutatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey]).To(Equal(constants.NamespacePolicyScope))
 				Expect(mutatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNameAnnotationKey]).To(Equal(policyName))
 				Expect(mutatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey]).To(Equal(policyNamespace))
@@ -224,7 +224,7 @@ var _ = Describe("AdmissionPolicy controller", Label("real-cluster"), func() {
 			}, timeout, pollInterval).Should(Succeed())
 
 			By("changing the MutatingWebhookConfiguration")
-			delete(mutatingWebhookConfiguration.Labels, "app.kubernetes.io/part-of")
+			delete(mutatingWebhookConfiguration.Labels, constants.PartOfLabelKey)
 			mutatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey] = newName("scope")
 			delete(mutatingWebhookConfiguration.Annotations, constants.WebhookConfigurationPolicyNameAnnotationKey)
 			mutatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey] = newName("namespace")

--- a/internal/controller/admissionpolicygroup_controller_test.go
+++ b/internal/controller/admissionpolicygroup_controller_test.go
@@ -81,7 +81,7 @@ var _ = Describe("AdmissionPolicyGroup controller", Label("real-cluster"), func(
 					return err
 				}
 
-				Expect(validatingWebhookConfiguration.Labels["kubewarden"]).To(Equal("true"))
+				Expect(validatingWebhookConfiguration.Labels[constants.PartOfLabelKey]).To(Equal(constants.PartOfLabelValue))
 				Expect(validatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey]).To(Equal(constants.NamespacePolicyScope))
 				Expect(validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNameAnnotationKey]).To(Equal(policyName))
 				Expect(validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey]).To(Equal(policyNamespace))
@@ -91,7 +91,7 @@ var _ = Describe("AdmissionPolicyGroup controller", Label("real-cluster"), func(
 
 				caSecret, err := getTestCASecret(ctx)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(validatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle).To(Equal(caSecret.Data[constants.PolicyServerCARootPemName]))
+				Expect(validatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle).To(Equal(caSecret.Data[constants.CARootCert]))
 
 				return nil
 			}, timeout, pollInterval).Should(Succeed())
@@ -111,7 +111,7 @@ var _ = Describe("AdmissionPolicyGroup controller", Label("real-cluster"), func(
 			}, timeout, pollInterval).Should(Succeed())
 
 			By("changing the ValidatingWebhookConfiguration")
-			delete(validatingWebhookConfiguration.Labels, "kubewarden")
+			delete(validatingWebhookConfiguration.Labels, constants.PartOfLabelKey)
 			validatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey] = newName("scope")
 			delete(validatingWebhookConfiguration.Annotations, constants.WebhookConfigurationPolicyNameAnnotationKey)
 			validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey] = newName("namespace")

--- a/internal/controller/cert_controller.go
+++ b/internal/controller/cert_controller.go
@@ -1,0 +1,276 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kubewarden/kubewarden-controller/internal/certs"
+	"github.com/kubewarden/kubewarden-controller/internal/constants"
+)
+
+const tickerDuration = 12 * time.Hour
+
+type CertReconciler struct {
+	client.Client
+	Log                         logr.Logger
+	DeploymentsNamespace        string
+	WebhookServiceName          string
+	CARootSecretName            string
+	WebhookServerCertSecretName string
+}
+
+// Start begins the periodic reconciler.
+// Implements the Runnable inteface, see https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager#Runnable.
+func (r *CertReconciler) Start(ctx context.Context) error {
+	r.Log.Info("Starting CertController ticker")
+
+	ticker := time.NewTicker(tickerDuration)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			r.Log.Info("Stopping CertController")
+			return nil
+		case <-ticker.C:
+			if err := r.reconcile(ctx); err != nil {
+				r.Log.Error(err, "Failed to")
+			}
+		}
+	}
+}
+
+// NeedLeaderElection returns true to ensure that only one instance of the controller is running at a time.
+// Implements the LeaderElectionRunnable interface, see https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager#LeaderElectionRunnable.
+func (r *CertReconciler) NeedLeaderElection() bool {
+	return true
+}
+
+func (r *CertReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.Add(r); err != nil {
+		return fmt.Errorf("failed enrolling controller with manager: %w", err)
+	}
+
+	return nil
+}
+
+// reconcile reconciles the CA root and server certificates by rotating them if they are about to expire.
+func (r *CertReconciler) reconcile(ctx context.Context) error {
+	caCertSecret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Name: r.CARootSecretName, Namespace: r.DeploymentsNamespace}, caCertSecret); err != nil {
+		return fmt.Errorf("failed to get CA cert secret: %w", err)
+	}
+
+	if err := r.reconcileCARoot(ctx, caCertSecret); err != nil {
+		return fmt.Errorf("failed to reconcile CA root: %w", err)
+	}
+	if err := r.reconcileOldCARoot(ctx, caCertSecret); err != nil {
+		return fmt.Errorf("failed to reconcile old CA root: %w", err)
+	}
+	if err := r.reconcileServerCerts(ctx, caCertSecret); err != nil {
+		return fmt.Errorf("failed to reconcile server certs: %w", err)
+	}
+
+	return nil
+}
+
+// reconcileCARoot reconciles the CA root certificate by rotating it if it is about to expire.
+// It saves the old CA root certificate in the secret so that we can remove it after it is no longer valid.
+// Also, it updates the webhook configurations by injecting a bundle containing the new and old CA root certificates.
+func (r *CertReconciler) reconcileCARoot(ctx context.Context, caRootSecret *corev1.Secret) error {
+	caCert, caPrivateKey, err := certs.ExtractCARootFromSecret(caRootSecret)
+	if err != nil {
+		return fmt.Errorf("failed to extract CA root from secret: %w", err)
+	}
+
+	if err = certs.VerifyCA(caCert, caPrivateKey, time.Now().Add(constants.CertLookahead)); err != nil {
+		r.Log.Info("CA root certificate verification failed, rotating CA root the certificate", "verification error", err)
+
+		oldCACert := caCert
+		caCert, caPrivateKey, err = certs.GenerateCA(time.Now(), time.Now().Add(constants.CACertExpiration))
+		if err != nil {
+			return fmt.Errorf("failed to generate CA cert: %w", err)
+		}
+
+		caRootSecret.Data[constants.CARootCert] = caCert
+		caRootSecret.Data[constants.CARootPrivateKey] = caPrivateKey
+		caRootSecret.Data[constants.OldCARootCert] = oldCACert
+		if err = r.Update(ctx, caRootSecret); err != nil {
+			return fmt.Errorf("failed to update CA root secret: %w", err)
+		}
+
+		err = r.reconcileWebhookConfigurations(ctx, append(caCert, oldCACert...))
+		if err != nil {
+			return fmt.Errorf("failed to reconcile webhook configurations: %w", err)
+		}
+
+		r.Log.Info("CA root certificate rotated successfully")
+	}
+
+	return nil
+}
+
+// reconcileOldCARoot reconciles the old CA root certificate by removing it if it is no longer valid.
+// It also updates the webhook configurations by removing the old CA root certificate from the CA bundle.
+func (r *CertReconciler) reconcileOldCARoot(ctx context.Context, caRootSecret *corev1.Secret) error {
+	oldCACert, ok := caRootSecret.Data[constants.OldCARootCert]
+	if !ok {
+		return nil
+	}
+
+	if err := certs.VerifyCA(oldCACert, nil, time.Now()); err != nil {
+		r.Log.Info("Old CA root certificate is not valid anymore, removing the old CA root certificate", "verification error", err)
+
+		var caCert []byte
+		caCert, _, err = certs.ExtractCARootFromSecret(caRootSecret)
+		if err != nil {
+			return fmt.Errorf("failed to extract CA root from secret: %w", err)
+		}
+
+		delete(caRootSecret.Data, constants.OldCARootCert)
+		if err = r.Update(ctx, caRootSecret); err != nil {
+			return fmt.Errorf("failed to update CA root secret: %w", err)
+		}
+
+		err = r.reconcileWebhookConfigurations(ctx, caCert)
+		if err != nil {
+			return fmt.Errorf("failed to reconcile webhook configurations: %w", err)
+		}
+
+		r.Log.Info("Old CA root certificate removed successfully")
+	}
+
+	return nil
+}
+
+// reconcileWebhookConfigurations reconciles the webhook configurations by injecting the CA bundle.
+// Note that we are using RetryOnConflict to handle potential conflicts when updating the webhook configurations.
+// This is necessary because the webhook configurations could be update by the AdmissionPolicy and ClusterAdmissionPolicy controllers.
+func (r *CertReconciler) reconcileWebhookConfigurations(ctx context.Context, caBundle []byte) error {
+	validatingWebhookConfigurationList := &admissionregistrationv1.ValidatingWebhookConfigurationList{}
+	if err := r.List(ctx, validatingWebhookConfigurationList, client.MatchingLabels{
+		"app.kubernetes.io/part-of": "kubewarden",
+	}); err != nil {
+		return fmt.Errorf("failed to list validating webhook configurations: %w", err)
+	}
+
+	for _, validatingWebhookConfiguration := range validatingWebhookConfigurationList.Items {
+		original := validatingWebhookConfiguration.DeepCopy()
+		for i := range validatingWebhookConfiguration.Webhooks {
+			validatingWebhookConfiguration.Webhooks[i].ClientConfig.CABundle = caBundle
+		}
+
+		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			return r.Patch(ctx, &validatingWebhookConfiguration, client.MergeFrom(original))
+		})
+		if err != nil {
+			return fmt.Errorf("failed to patch validating webhook configuration: %w", err)
+		}
+	}
+
+	mutatingWebhookConfigurationList := &admissionregistrationv1.MutatingWebhookConfigurationList{}
+	if err := r.List(ctx, mutatingWebhookConfigurationList, client.MatchingLabels{
+		"app.kubernetes.io/part-of": "kubewarden",
+	}); err != nil {
+		return fmt.Errorf("failed to list mutating webhook configurations: %w", err)
+	}
+
+	for _, mutatingWebhookConfiguration := range mutatingWebhookConfigurationList.Items {
+		original := mutatingWebhookConfiguration.DeepCopy()
+		for i := range mutatingWebhookConfiguration.Webhooks {
+			mutatingWebhookConfiguration.Webhooks[i].ClientConfig.CABundle = caBundle
+		}
+
+		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			return r.Patch(ctx, &mutatingWebhookConfiguration, client.MergeFrom(original))
+		})
+		if err != nil {
+			return fmt.Errorf("failed to patch mutating webhook configuration: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// reconcileServerCerts reconciles the webhook server and policy server certificates by rotating them if they are about to expire.
+func (r *CertReconciler) reconcileServerCerts(ctx context.Context, caRootSecret *corev1.Secret) error {
+	webhookServerCertSecret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Name: r.WebhookServerCertSecretName, Namespace: r.DeploymentsNamespace}, webhookServerCertSecret); err != nil {
+		return fmt.Errorf("failed to get webhook server cert secret: %w", err)
+	}
+	dnsName := certs.DNSName(r.WebhookServiceName, r.DeploymentsNamespace)
+	if err := r.reconcileServerCert(ctx, webhookServerCertSecret, caRootSecret, dnsName); err != nil {
+		return fmt.Errorf("failed to rotate server cert: %w", err)
+	}
+
+	serverCertSecretList := &corev1.SecretList{}
+	err := r.List(ctx,
+		serverCertSecretList,
+		client.InNamespace(r.DeploymentsNamespace),
+		client.MatchingLabels{
+			"app.kubernetes.io/part-of":   "kubewarden",
+			"app.kubernetes.io/component": "policy-server",
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to list policy server cert secrets: %w", err)
+	}
+
+	for _, serverCertSecret := range serverCertSecretList.Items {
+		dnsName = certs.DNSName(serverCertSecret.GetName(), r.DeploymentsNamespace)
+		if err = r.reconcileServerCert(ctx, &serverCertSecret, caRootSecret, dnsName); err != nil {
+			return fmt.Errorf("failed to rotate server cert: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// reconcileServerCert reconciles the server certificate by rotating it if it is about to expire.
+func (r *CertReconciler) reconcileServerCert(ctx context.Context, serverCertSecret *corev1.Secret, caRootSecret *corev1.Secret, dnsName string) error {
+	cert, privateKey, err := certs.ExtractServerCertFromSecret(serverCertSecret)
+	if err != nil {
+		return fmt.Errorf("failed to extract server cert from secret: %w", err)
+	}
+
+	caCert, caPrivateKey, err := certs.ExtractCARootFromSecret(caRootSecret)
+	if err != nil {
+		return fmt.Errorf("failed to extract CA root from secret: %w", err)
+	}
+
+	pool, err := certs.NewCertPool(caCert)
+	if err != nil {
+		return fmt.Errorf("failed to create cert pool: %w", err)
+	}
+
+	if err = certs.VerifyCert(cert, privateKey, pool, dnsName, time.Now().Add(constants.CertLookahead)); err != nil {
+		r.Log.Info("Certificate verification failed, rotating the certificate", "dnsName", dnsName, "verification error", err)
+
+		var newCert, newPrivateKey []byte
+		newCert, newPrivateKey, err = certs.GenerateCert(caCert, caPrivateKey, time.Now(), time.Now().Add(constants.ServerCertExpiration), dnsName)
+		if err != nil {
+			return fmt.Errorf("failed to generate cert: %w", err)
+		}
+
+		serverCertSecret.Data[constants.ServerCert] = newCert
+		serverCertSecret.Data[constants.ServerPrivateKey] = newPrivateKey
+
+		if err = r.Update(ctx, serverCertSecret); err != nil {
+			return fmt.Errorf("failed to update secret: %w", err)
+		}
+
+		r.Log.Info("Certificate rotated successfully", "dnsName", dnsName)
+	}
+
+	return nil
+}

--- a/internal/controller/cert_controller.go
+++ b/internal/controller/cert_controller.go
@@ -159,7 +159,7 @@ func (r *CertReconciler) reconcileOldCARoot(ctx context.Context, caRootSecret *c
 func (r *CertReconciler) reconcileWebhookConfigurations(ctx context.Context, caBundle []byte) error {
 	validatingWebhookConfigurationList := &admissionregistrationv1.ValidatingWebhookConfigurationList{}
 	if err := r.List(ctx, validatingWebhookConfigurationList, client.MatchingLabels{
-		"app.kubernetes.io/part-of": "kubewarden",
+		constants.PartOfLabelKey: constants.PartOfLabelValue,
 	}); err != nil {
 		return fmt.Errorf("failed to list validating webhook configurations: %w", err)
 	}
@@ -180,7 +180,7 @@ func (r *CertReconciler) reconcileWebhookConfigurations(ctx context.Context, caB
 
 	mutatingWebhookConfigurationList := &admissionregistrationv1.MutatingWebhookConfigurationList{}
 	if err := r.List(ctx, mutatingWebhookConfigurationList, client.MatchingLabels{
-		"app.kubernetes.io/part-of": "kubewarden",
+		constants.PartOfLabelKey: constants.PartOfLabelValue,
 	}); err != nil {
 		return fmt.Errorf("failed to list mutating webhook configurations: %w", err)
 	}
@@ -218,8 +218,8 @@ func (r *CertReconciler) reconcileServerCerts(ctx context.Context, caRootSecret 
 		serverCertSecretList,
 		client.InNamespace(r.DeploymentsNamespace),
 		client.MatchingLabels{
-			"app.kubernetes.io/part-of":   "kubewarden",
-			"app.kubernetes.io/component": "policy-server",
+			constants.PartOfLabelKey:    constants.PartOfLabelValue,
+			constants.ComponentLabelKey: constants.ComponentPolicyServerLabelValue,
 		},
 	)
 	if err != nil {

--- a/internal/controller/cert_controller_test.go
+++ b/internal/controller/cert_controller_test.go
@@ -80,8 +80,8 @@ var _ = Describe("Cert controller", func() {
 					Namespace: deploymentsNamespace,
 					Name:      policyServerName,
 					Labels: map[string]string{
-						"app.kubernetes.io/part-of":   "kubewarden",
-						"app.kubernetes.io/component": "policy-server",
+						constants.PartOfLabelKey:    constants.PartOfLabelValue,
+						constants.ComponentLabelKey: constants.ComponentPolicyServerLabelValue,
 					},
 				},
 				Type: corev1.SecretTypeOpaque,
@@ -200,7 +200,7 @@ var _ = Describe("Cert controller", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: validatingWebhookConfigurationName,
 					Labels: map[string]string{
-						"app.kubernetes.io/part-of": "kubewarden",
+						constants.PartOfLabelKey: "kubewarden",
 					},
 				},
 				Webhooks: []admissionregistrationv1.ValidatingWebhook{
@@ -226,7 +226,7 @@ var _ = Describe("Cert controller", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: mutatingWebhookConfigurationName,
 					Labels: map[string]string{
-						"app.kubernetes.io/part-of": "kubewarden",
+						constants.PartOfLabelKey: "kubewarden",
 					},
 				},
 				Webhooks: []admissionregistrationv1.MutatingWebhook{
@@ -255,8 +255,8 @@ var _ = Describe("Cert controller", func() {
 					Namespace: deploymentsNamespace,
 					Name:      policyServerName,
 					Labels: map[string]string{
-						"app.kubernetes.io/part-of":   "kubewarden",
-						"app.kubernetes.io/component": "policy-server",
+						constants.PartOfLabelKey:    constants.PartOfLabelValue,
+						constants.ComponentLabelKey: constants.ComponentPolicyServerLabelValue,
 					},
 				},
 				Type: corev1.SecretTypeOpaque,
@@ -284,8 +284,8 @@ var _ = Describe("Cert controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("checking whether the old CA cert has beeen added to the secret")
-			_, ok := caRootSecret.Data[constants.OldCARootCert]
-			Expect(ok).To(BeTrue())
+			_, found := caRootSecret.Data[constants.OldCARootCert]
+			Expect(found).To(BeTrue())
 		})
 
 		It("should inject the old + new CA bundle in the webhook configurations and rotate the webhook server cert", func() {
@@ -412,7 +412,7 @@ var _ = Describe("Cert controller", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: validatingWebhookConfigurationName,
 					Labels: map[string]string{
-						"app.kubernetes.io/part-of": "kubewarden",
+						constants.PartOfLabelKey: constants.PartOfLabelValue,
 					},
 				},
 				Webhooks: []admissionregistrationv1.ValidatingWebhook{
@@ -442,8 +442,8 @@ var _ = Describe("Cert controller", func() {
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: caRootSecretName, Namespace: deploymentsNamespace}, caRootSecret)
 			Expect(err).ToNot(HaveOccurred())
 
-			_, ok := caRootSecret.Data[constants.OldCARootCert]
-			Expect(ok).To(BeFalse())
+			_, found := caRootSecret.Data[constants.OldCARootCert]
+			Expect(found).To(BeFalse())
 		})
 
 		It("should remove the old CA root from the webhook configurations' CA bundle", func() {

--- a/internal/controller/cert_controller_test.go
+++ b/internal/controller/cert_controller_test.go
@@ -1,0 +1,466 @@
+package controller
+
+import (
+	"context"
+	"time"
+
+	"github.com/kubewarden/kubewarden-controller/internal/certs"
+	"github.com/kubewarden/kubewarden-controller/internal/constants"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+)
+
+var _ = Describe("Cert controller", func() {
+	ctx := context.Background()
+
+	Context("Server certificates rotation", Ordered, func() {
+		const (
+			webhookServerServiceName    = "server-cert-rotation-test-webhook-service"
+			caRootSecretName            = "server-cert-rotation-test-ca-root"
+			webhookServerCertSecretName = "server-cert-rotation-test-webhook-server-cert"
+			policyServerName            = "server-cert-rotation-test-policy-server"
+		)
+
+		BeforeAll(func() {
+			certController := CertReconciler{
+				Client:                      k8sClient,
+				DeploymentsNamespace:        deploymentsNamespace,
+				WebhookServiceName:          webhookServerServiceName,
+				CARootSecretName:            caRootSecretName,
+				WebhookServerCertSecretName: webhookServerCertSecretName,
+			}
+
+			By("generating the CA cert")
+			caCert, caPrivateKey, err := certs.GenerateCA(time.Now(), time.Now().Add(constants.CACertExpiration))
+			Expect(err).ToNot(HaveOccurred())
+			By("creating the CA cert secret")
+			caRootSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: deploymentsNamespace,
+					Name:      caRootSecretName,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					constants.CARootCert:       caCert,
+					constants.CARootPrivateKey: caPrivateKey,
+				},
+			}
+			Expect(k8sClient.Create(ctx, caRootSecret)).To(Succeed())
+
+			By("generating webhook server cert that is about to expire")
+			webhookServiceDNSName := certs.DNSName(webhookServerServiceName, deploymentsNamespace)
+			webhookServerCert, webhookServerPrivateKey, err := certs.GenerateCert(caCert, caPrivateKey, time.Now().Add(-constants.ServerCertExpiration), time.Now().Add(constants.CertLookahead), webhookServiceDNSName)
+			Expect(err).ToNot(HaveOccurred())
+			By("creating the webhook server cert secret")
+			webhookServerCertSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: deploymentsNamespace,
+					Name:      webhookServerCertSecretName,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					constants.ServerCert:       webhookServerCert,
+					constants.ServerPrivateKey: webhookServerPrivateKey,
+				},
+			}
+			Expect(k8sClient.Create(ctx, webhookServerCertSecret)).To(Succeed())
+
+			By("generating a policy server cert that is about to expire")
+			policyServerDNSName := certs.DNSName(policyServerName, deploymentsNamespace)
+			policyServerCert, policyServerPrivateKey, err := certs.GenerateCert(caCert, caPrivateKey, time.Now().Add(-constants.ServerCertExpiration), time.Now().Add(constants.CertLookahead), policyServerDNSName)
+			Expect(err).ToNot(HaveOccurred())
+			policyServerCertSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: deploymentsNamespace,
+					Name:      policyServerName,
+					Labels: map[string]string{
+						"app.kubernetes.io/part-of":   "kubewarden",
+						"app.kubernetes.io/component": "policy-server",
+					},
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					constants.ServerCert:       policyServerCert,
+					constants.ServerPrivateKey: policyServerPrivateKey,
+				},
+			}
+			Expect(k8sClient.Create(ctx, policyServerCertSecret)).To(Succeed())
+
+			By("reconciling")
+			Expect(certController.reconcile(ctx)).To(Succeed())
+		})
+
+		It("should rotate the webhook server certificate", func() {
+			By("fetching the CA cert secret")
+			caRootSecret := &corev1.Secret{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: caRootSecretName, Namespace: deploymentsNamespace}, caRootSecret)
+			Expect(err).ToNot(HaveOccurred())
+
+			caCert, _, err := certs.ExtractCARootFromSecret(caRootSecret)
+			Expect(err).ToNot(HaveOccurred())
+			By("fetching the webhook server cert secret")
+			webhookServerCertSecret := &corev1.Secret{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: webhookServerCertSecretName, Namespace: deploymentsNamespace}, webhookServerCertSecret)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("checking whether the webhook server cert secret has been rotated")
+			pool, err := certs.NewCertPool(caCert)
+			Expect(err).ToNot(HaveOccurred())
+			dnsName := certs.DNSName(webhookServerServiceName, deploymentsNamespace)
+			err = certs.VerifyCert(webhookServerCertSecret.Data[constants.ServerCert], webhookServerCertSecret.Data[constants.ServerPrivateKey], pool, dnsName, time.Now())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should rotate the policy server certificates", func() {
+			By("fetching the CA cert secret")
+			caRootSecret := &corev1.Secret{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: caRootSecretName, Namespace: deploymentsNamespace}, caRootSecret)
+			Expect(err).ToNot(HaveOccurred())
+			caCert, _, err := certs.ExtractCARootFromSecret(caRootSecret)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("fetching the policy server cert secrets")
+			policyServerSecret := &corev1.Secret{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: "server-cert-rotation-test-policy-server", Namespace: deploymentsNamespace}, policyServerSecret)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("checking whether the policy server cert secret has been rotated")
+			pool, err := certs.NewCertPool(caCert)
+			Expect(err).ToNot(HaveOccurred())
+			dnsName := certs.DNSName(policyServerSecret.GetName(), deploymentsNamespace)
+			err = certs.VerifyCert(policyServerSecret.Data[constants.ServerCert], policyServerSecret.Data[constants.ServerPrivateKey], pool, dnsName, time.Now())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("CA root rotation", Ordered, func() {
+		const (
+			webhookServerServiceName           = "ca-root-rotation-test-webhook-service"
+			caRootSecretName                   = "ca-root-rotation-test-ca-root"
+			webhookServerCertSecretName        = "ca-root-rotation-test-webhook-server-cert"
+			policyServerName                   = "ca-root-rotation-test-policy-server"
+			validatingWebhookConfigurationName = "ca-root-rotation-test-validating-webhook-configuration"
+			mutatingWebhookConfigurationName   = "ca-root-rotation-test-mutating-webhook-configuration"
+		)
+
+		var webhookServerCert, webhookServerPrivateKey []byte
+
+		BeforeAll(func() {
+			certController := CertReconciler{
+				Client:                      k8sClient,
+				DeploymentsNamespace:        deploymentsNamespace,
+				WebhookServiceName:          webhookServerServiceName,
+				CARootSecretName:            caRootSecretName,
+				WebhookServerCertSecretName: webhookServerCertSecretName,
+			}
+
+			By("generating a CA cert that is about to expire")
+			caCert, caPrivateKey, err := certs.GenerateCA(time.Now().Add(-constants.CACertExpiration), time.Now().Add(constants.CertLookahead))
+			Expect(err).ToNot(HaveOccurred())
+			By("creating the CA cert secret")
+			caRootSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: deploymentsNamespace,
+					Name:      caRootSecretName,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					constants.CARootCert:       caCert,
+					constants.CARootPrivateKey: caPrivateKey,
+				},
+			}
+			Expect(k8sClient.Create(ctx, caRootSecret)).To(Succeed())
+
+			By("generating a webhook server cert")
+			webhookServiceDNSName := certs.DNSName(webhookServerServiceName, deploymentsNamespace)
+			webhookServerCert, webhookServerPrivateKey, err = certs.GenerateCert(caCert, caPrivateKey, time.Now(), time.Now().Add(constants.ServerCertExpiration), webhookServiceDNSName)
+			Expect(err).ToNot(HaveOccurred())
+			By("creating the webhook server cert secret")
+			webhookServerCertSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: deploymentsNamespace,
+					Name:      webhookServerCertSecretName,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					constants.ServerCert:       webhookServerCert,
+					constants.ServerPrivateKey: webhookServerPrivateKey,
+				},
+			}
+			Expect(k8sClient.Create(ctx, webhookServerCertSecret)).To(Succeed())
+
+			By("creating a validating webhook configuration")
+			validatingWebhookConfiguration := &admissionregistrationv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: validatingWebhookConfigurationName,
+					Labels: map[string]string{
+						"app.kubernetes.io/part-of": "kubewarden",
+					},
+				},
+				Webhooks: []admissionregistrationv1.ValidatingWebhook{
+					{
+						Name: "kubewarden.webhook.test",
+
+						ClientConfig: admissionregistrationv1.WebhookClientConfig{
+							Service: &admissionregistrationv1.ServiceReference{
+								Namespace: deploymentsNamespace,
+								Name:      webhookServerServiceName,
+							},
+							CABundle: caCert,
+						},
+						AdmissionReviewVersions: []string{"v1"},
+						SideEffects:             ptr.To(admissionregistrationv1.SideEffectClassNone),
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, validatingWebhookConfiguration)).To(Succeed())
+
+			By("creating a mutating webhook configuration")
+			mutatingWebhookConfiguration := &admissionregistrationv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: mutatingWebhookConfigurationName,
+					Labels: map[string]string{
+						"app.kubernetes.io/part-of": "kubewarden",
+					},
+				},
+				Webhooks: []admissionregistrationv1.MutatingWebhook{
+					{
+						Name: "kubewarden.webhook.test",
+						ClientConfig: admissionregistrationv1.WebhookClientConfig{
+							Service: &admissionregistrationv1.ServiceReference{
+								Namespace: deploymentsNamespace,
+								Name:      webhookServerServiceName,
+							},
+							CABundle: caCert,
+						},
+						AdmissionReviewVersions: []string{"v1"},
+						SideEffects:             ptr.To(admissionregistrationv1.SideEffectClassNone),
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, mutatingWebhookConfiguration)).To(Succeed())
+
+			By("creating a policy server cert secret")
+			policyServerDNSName := certs.DNSName(policyServerName, deploymentsNamespace)
+			policyServerCert, policyServerPrivateKey, err := certs.GenerateCert(caCert, caPrivateKey, time.Now(), time.Now().Add(constants.ServerCertExpiration), policyServerDNSName)
+			Expect(err).ToNot(HaveOccurred())
+			policyServerCertSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: deploymentsNamespace,
+					Name:      policyServerName,
+					Labels: map[string]string{
+						"app.kubernetes.io/part-of":   "kubewarden",
+						"app.kubernetes.io/component": "policy-server",
+					},
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					constants.ServerCert:       policyServerCert,
+					constants.ServerPrivateKey: policyServerPrivateKey,
+				},
+			}
+			Expect(k8sClient.Create(ctx, policyServerCertSecret)).To(Succeed())
+
+			By("reconciling")
+			Expect(certController.reconcile(ctx)).To(Succeed())
+		})
+
+		It("should rotate the CA cert", func() {
+			By("fetching the CA cert secret")
+			caRootSecret := &corev1.Secret{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: caRootSecretName, Namespace: deploymentsNamespace}, caRootSecret)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("checking whether the CA cert has been rotated")
+			caCert, caPrivateKey, err := certs.ExtractCARootFromSecret(caRootSecret)
+			Expect(err).ToNot(HaveOccurred())
+			err = certs.VerifyCA(caCert, caPrivateKey, time.Now())
+			Expect(err).ToNot(HaveOccurred())
+
+			By("checking whether the old CA cert has beeen added to the secret")
+			_, ok := caRootSecret.Data[constants.OldCARootCert]
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should inject the old + new CA bundle in the webhook configurations and rotate the webhook server cert", func() {
+			By("fetching the CA cert secret")
+			caRootSecret := &corev1.Secret{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: caRootSecretName, Namespace: deploymentsNamespace}, caRootSecret)
+			Expect(err).ToNot(HaveOccurred())
+			expectedCABundle := append(caRootSecret.Data[constants.CARootCert], caRootSecret.Data[constants.OldCARootCert]...)
+
+			By("fetching the validating webhook configuration")
+			validatingWebhookConfiguration := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: validatingWebhookConfigurationName}, validatingWebhookConfiguration)
+			Expect(err).ToNot(HaveOccurred())
+			By("checking whether the validating webhook CA bundle contains the old and new CA certs")
+			caBundle := validatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle
+			Expect(expectedCABundle).To(Equal(caBundle))
+
+			By("fetching the mutating webhook configuration")
+			mutatingWebhookConfiguration := &admissionregistrationv1.MutatingWebhookConfiguration{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: mutatingWebhookConfigurationName}, mutatingWebhookConfiguration)
+			Expect(err).ToNot(HaveOccurred())
+			By("checking whether the mutating webhook CA bundle contains the old and new CA certs")
+			caBundle = mutatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle
+			Expect(expectedCABundle).To(Equal(caBundle))
+
+			By("checking whether the old webhook server cert is still valid against the combined CA bundle")
+			pool, err := certs.NewCertPool(caBundle)
+			Expect(err).ToNot(HaveOccurred())
+			dnsName := certs.DNSName(webhookServerServiceName, deploymentsNamespace)
+			err = certs.VerifyCert(webhookServerCert, webhookServerPrivateKey, pool, dnsName, time.Now())
+			Expect(err).ToNot(HaveOccurred())
+
+			By("fetching the webhook server cert secret")
+			webhookServerCertSecret := &corev1.Secret{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: webhookServerCertSecretName, Namespace: deploymentsNamespace}, webhookServerCertSecret)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("checking whether the webhook server cert secret has been rotated")
+			err = certs.VerifyCert(webhookServerCertSecret.Data[constants.ServerCert], webhookServerCertSecret.Data[constants.ServerPrivateKey], pool, dnsName, time.Now())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should rotate the policy server certificates", func() {
+			By("fetching the CA cert secret")
+			caRootSecret := &corev1.Secret{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: caRootSecretName, Namespace: deploymentsNamespace}, caRootSecret)
+			Expect(err).ToNot(HaveOccurred())
+			caCert, _, err := certs.ExtractCARootFromSecret(caRootSecret)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("fetching the policy server cert secrets")
+			policyServerSecret := &corev1.Secret{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: policyServerName, Namespace: deploymentsNamespace}, policyServerSecret)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("checking whether policy server cert secret has been rotated")
+			pool, err := certs.NewCertPool(caCert)
+			Expect(err).ToNot(HaveOccurred())
+			dnsName := certs.DNSName(policyServerSecret.GetName(), deploymentsNamespace)
+			err = certs.VerifyCert(policyServerSecret.Data[constants.ServerCert], policyServerSecret.Data[constants.ServerPrivateKey], pool, dnsName, time.Now())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("Old CA root cleanup", Ordered, func() {
+		const (
+			webhookServerServiceName           = "old-ca-root-cleanup-test-webhook-service"
+			caRootSecretName                   = "old-ca-root-cleanup-test-ca-root"
+			webhookServerCertSecretName        = "old-ca-root-cleanup-test-webhook-server-cert"
+			policyServerName                   = "old-ca-root-cleanup-test-policy-server"
+			validatingWebhookConfigurationName = "old-ca-root-cleanup-test-validating-webhook-configuration"
+		)
+
+		BeforeAll(func() {
+			certController := CertReconciler{
+				Client:                      k8sClient,
+				DeploymentsNamespace:        deploymentsNamespace,
+				WebhookServiceName:          webhookServerServiceName,
+				CARootSecretName:            caRootSecretName,
+				WebhookServerCertSecretName: webhookServerCertSecretName,
+			}
+
+			By("generating the CA cert")
+			caCert, caPrivateKey, err := certs.GenerateCA(time.Now(), time.Now().Add(constants.CACertExpiration))
+			Expect(err).ToNot(HaveOccurred())
+			By("generating an expired old CA cert")
+			oldCACert, _, err := certs.GenerateCA(time.Now().Add(-constants.CACertExpiration), time.Now().Add(-24*time.Hour))
+			Expect(err).ToNot(HaveOccurred())
+			By("creating the CA cert secret")
+			caRootSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: deploymentsNamespace,
+					Name:      "old-ca-root-cleanup-test-ca-root",
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					constants.CARootCert:       caCert,
+					constants.CARootPrivateKey: caPrivateKey,
+					constants.OldCARootCert:    oldCACert,
+				},
+			}
+			Expect(k8sClient.Create(ctx, caRootSecret)).To(Succeed())
+
+			By("generating a webhook server cert")
+			webhookServiceDNSName := certs.DNSName(webhookServerServiceName, deploymentsNamespace)
+			webhookServerCert, webhookServerPrivateKey, err := certs.GenerateCert(caCert, caPrivateKey, time.Now(), time.Now().Add(constants.ServerCertExpiration), webhookServiceDNSName)
+			Expect(err).ToNot(HaveOccurred())
+			By("creating the webhook server cert secret")
+			webhookServerCertSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: deploymentsNamespace,
+					Name:      webhookServerCertSecretName,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					constants.ServerCert:       webhookServerCert,
+					constants.ServerPrivateKey: webhookServerPrivateKey,
+				},
+			}
+			Expect(k8sClient.Create(ctx, webhookServerCertSecret)).To(Succeed())
+
+			By("creating a validating webhook configuration with the old and new CA certs in the CA bundle")
+			validatingWebhookConfiguration := &admissionregistrationv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: validatingWebhookConfigurationName,
+					Labels: map[string]string{
+						"app.kubernetes.io/part-of": "kubewarden",
+					},
+				},
+				Webhooks: []admissionregistrationv1.ValidatingWebhook{
+					{
+						Name: "kubewarden.webhook.test",
+
+						ClientConfig: admissionregistrationv1.WebhookClientConfig{
+							Service: &admissionregistrationv1.ServiceReference{
+								Namespace: deploymentsNamespace,
+								Name:      webhookServerServiceName,
+							},
+							CABundle: append(caCert, oldCACert...),
+						},
+						AdmissionReviewVersions: []string{"v1"},
+						SideEffects:             ptr.To(admissionregistrationv1.SideEffectClassNone),
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, validatingWebhookConfiguration)).To(Succeed())
+
+			By("reconciling")
+			Expect(certController.reconcile(ctx)).To(Succeed())
+		})
+
+		It("should remove the old CA root from the secret", func() {
+			caRootSecret := &corev1.Secret{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: caRootSecretName, Namespace: deploymentsNamespace}, caRootSecret)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, ok := caRootSecret.Data[constants.OldCARootCert]
+			Expect(ok).To(BeFalse())
+		})
+
+		It("should remove the old CA root from the webhook configurations' CA bundle", func() {
+			By("fetching the CA cert secret")
+			caRootSecret := &corev1.Secret{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: caRootSecretName, Namespace: deploymentsNamespace}, caRootSecret)
+			Expect(err).ToNot(HaveOccurred())
+			expectedCABundle := caRootSecret.Data[constants.CARootCert]
+
+			By("fetching the validating webhook configuration")
+			validatingWebhookConfiguration := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: validatingWebhookConfigurationName}, validatingWebhookConfiguration)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("checking whether the validating webhook CA bundle contains only the new CA cert")
+			caBundle := validatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle
+			Expect(expectedCABundle).To(Equal(caBundle))
+		})
+	})
+})

--- a/internal/controller/clusteradmissionpolicy_controller_test.go
+++ b/internal/controller/clusteradmissionpolicy_controller_test.go
@@ -68,7 +68,7 @@ var _ = Describe("ClusterAdmissionPolicy controller", Label("real-cluster"), fun
 					return err
 				}
 
-				Expect(validatingWebhookConfiguration.Labels["app.kubernetes.io/part-of"]).To(Equal("kubewarden"))
+				Expect(validatingWebhookConfiguration.Labels[constants.PartOfLabelKey]).To(Equal(constants.PartOfLabelValue))
 				Expect(validatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey]).To(Equal(constants.ClusterPolicyScope))
 				Expect(validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNameAnnotationKey]).To(Equal(policyName))
 				Expect(validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey]).To(BeEmpty())
@@ -98,7 +98,7 @@ var _ = Describe("ClusterAdmissionPolicy controller", Label("real-cluster"), fun
 				return nil
 			}, timeout, pollInterval).Should(Succeed())
 
-			delete(validatingWebhookConfiguration.Labels, "app.kubernetes.io/part-of")
+			delete(validatingWebhookConfiguration.Labels, constants.PartOfLabelKey)
 			validatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey] = newName("scope")
 			delete(validatingWebhookConfiguration.Annotations, constants.WebhookConfigurationPolicyNameAnnotationKey)
 			validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey] = newName("namespace")
@@ -157,7 +157,7 @@ var _ = Describe("ClusterAdmissionPolicy controller", Label("real-cluster"), fun
 				if err != nil {
 					return err
 				}
-				Expect(mutatingWebhookConfiguration.Labels["app.kubernetes.io/part-of"]).To(Equal("kubewarden"))
+				Expect(mutatingWebhookConfiguration.Labels[constants.PartOfLabelKey]).To(Equal(constants.PartOfLabelValue))
 				Expect(mutatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey]).To(Equal(constants.ClusterPolicyScope))
 				Expect(mutatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNameAnnotationKey]).To(Equal(policyName))
 				Expect(mutatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey]).To(BeEmpty())
@@ -187,7 +187,7 @@ var _ = Describe("ClusterAdmissionPolicy controller", Label("real-cluster"), fun
 			}, timeout, pollInterval).Should(Succeed())
 			By("changing the MutatingWebhookConfiguration")
 
-			delete(mutatingWebhookConfiguration.Labels, "app.kubernetes.io/part-of")
+			delete(mutatingWebhookConfiguration.Labels, constants.PartOfLabelKey)
 			mutatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey] = newName("scope")
 			delete(mutatingWebhookConfiguration.Annotations, constants.WebhookConfigurationPolicyNameAnnotationKey)
 			mutatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey] = newName("namespace")

--- a/internal/controller/clusteradmissionpolicy_controller_test.go
+++ b/internal/controller/clusteradmissionpolicy_controller_test.go
@@ -68,7 +68,7 @@ var _ = Describe("ClusterAdmissionPolicy controller", Label("real-cluster"), fun
 					return err
 				}
 
-				Expect(validatingWebhookConfiguration.Labels["kubewarden"]).To(Equal("true"))
+				Expect(validatingWebhookConfiguration.Labels["app.kubernetes.io/part-of"]).To(Equal("kubewarden"))
 				Expect(validatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey]).To(Equal(constants.ClusterPolicyScope))
 				Expect(validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNameAnnotationKey]).To(Equal(policyName))
 				Expect(validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey]).To(BeEmpty())
@@ -78,7 +78,7 @@ var _ = Describe("ClusterAdmissionPolicy controller", Label("real-cluster"), fun
 
 				caSecret, err := getTestCASecret(ctx)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(validatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle).To(Equal(caSecret.Data[constants.PolicyServerCARootPemName]))
+				Expect(validatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle).To(Equal(caSecret.Data[constants.CARootCert]))
 
 				return nil
 			}, timeout, pollInterval).Should(Succeed())
@@ -98,7 +98,7 @@ var _ = Describe("ClusterAdmissionPolicy controller", Label("real-cluster"), fun
 				return nil
 			}, timeout, pollInterval).Should(Succeed())
 
-			delete(validatingWebhookConfiguration.Labels, "kubewarden")
+			delete(validatingWebhookConfiguration.Labels, "app.kubernetes.io/part-of")
 			validatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey] = newName("scope")
 			delete(validatingWebhookConfiguration.Annotations, constants.WebhookConfigurationPolicyNameAnnotationKey)
 			validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey] = newName("namespace")
@@ -157,7 +157,7 @@ var _ = Describe("ClusterAdmissionPolicy controller", Label("real-cluster"), fun
 				if err != nil {
 					return err
 				}
-				Expect(mutatingWebhookConfiguration.Labels["kubewarden"]).To(Equal("true"))
+				Expect(mutatingWebhookConfiguration.Labels["app.kubernetes.io/part-of"]).To(Equal("kubewarden"))
 				Expect(mutatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey]).To(Equal(constants.ClusterPolicyScope))
 				Expect(mutatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNameAnnotationKey]).To(Equal(policyName))
 				Expect(mutatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey]).To(BeEmpty())
@@ -167,7 +167,7 @@ var _ = Describe("ClusterAdmissionPolicy controller", Label("real-cluster"), fun
 
 				caSecret, err := getTestCASecret(ctx)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(mutatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle).To(Equal(caSecret.Data[constants.PolicyServerCARootPemName]))
+				Expect(mutatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle).To(Equal(caSecret.Data[constants.CARootCert]))
 
 				return nil
 			}, timeout, pollInterval).Should(Succeed())
@@ -187,7 +187,7 @@ var _ = Describe("ClusterAdmissionPolicy controller", Label("real-cluster"), fun
 			}, timeout, pollInterval).Should(Succeed())
 			By("changing the MutatingWebhookConfiguration")
 
-			delete(mutatingWebhookConfiguration.Labels, "kubewarden")
+			delete(mutatingWebhookConfiguration.Labels, "app.kubernetes.io/part-of")
 			mutatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey] = newName("scope")
 			delete(mutatingWebhookConfiguration.Annotations, constants.WebhookConfigurationPolicyNameAnnotationKey)
 			mutatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey] = newName("namespace")

--- a/internal/controller/clusteradmissionpolicygroup_controller_test.go
+++ b/internal/controller/clusteradmissionpolicygroup_controller_test.go
@@ -68,7 +68,7 @@ var _ = Describe("ClusterAdmissionPolicyGroup controller", Label("real-cluster")
 					return err
 				}
 
-				Expect(validatingWebhookConfiguration.Labels["kubewarden"]).To(Equal("true"))
+				Expect(validatingWebhookConfiguration.Labels[constants.PartOfLabelKey]).To(Equal(constants.PartOfLabelValue))
 				Expect(validatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey]).To(Equal(constants.ClusterPolicyScope))
 				Expect(validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNameAnnotationKey]).To(Equal(policyName))
 				Expect(validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey]).To(BeEmpty())
@@ -78,7 +78,7 @@ var _ = Describe("ClusterAdmissionPolicyGroup controller", Label("real-cluster")
 
 				caSecret, err := getTestCASecret(ctx)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(validatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle).To(Equal(caSecret.Data[constants.PolicyServerCARootPemName]))
+				Expect(validatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle).To(Equal(caSecret.Data[constants.CARootCert]))
 
 				return nil
 			}, timeout, pollInterval).Should(Succeed())
@@ -98,7 +98,7 @@ var _ = Describe("ClusterAdmissionPolicyGroup controller", Label("real-cluster")
 				return nil
 			}, timeout, pollInterval).Should(Succeed())
 
-			delete(validatingWebhookConfiguration.Labels, "kubewarden")
+			delete(validatingWebhookConfiguration.Labels, constants.PartOfLabelKey)
 			validatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey] = newName("scope")
 			delete(validatingWebhookConfiguration.Annotations, constants.WebhookConfigurationPolicyNameAnnotationKey)
 			validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey] = newName("namespace")

--- a/internal/controller/policy_subreconciler.go
+++ b/internal/controller/policy_subreconciler.go
@@ -126,7 +126,7 @@ func (r *policySubReconciler) reconcilePolicy(ctx context.Context, policy polici
 	)
 
 	secret := corev1.Secret{}
-	if err = r.Get(ctx, types.NamespacedName{Namespace: r.deploymentsNamespace, Name: constants.PolicyServerCARootSecretName}, &secret); err != nil {
+	if err = r.Get(ctx, types.NamespacedName{Namespace: r.deploymentsNamespace, Name: constants.CARootSecretName}, &secret); err != nil {
 		return ctrl.Result{}, errors.Join(errors.New("cannot find policy server secret"), err)
 	}
 

--- a/internal/controller/policy_subreconciler.go
+++ b/internal/controller/policy_subreconciler.go
@@ -374,9 +374,6 @@ func findClusterPolicyForWebhookConfiguration(webhookConfiguration client.Object
 	if !kubwardenLabelExists && partOfLabel != "kubewarden" {
 		return []reconcile.Request{}
 	}
-	if _, found := webhookConfiguration.GetLabels()["kubewarden"]; !found {
-		return []reconcile.Request{}
-	}
 
 	policyScope, found := webhookConfiguration.GetLabels()[constants.WebhookConfigurationPolicyScopeLabelKey]
 	if !found {
@@ -424,7 +421,11 @@ func findPoliciesForPolicyServer(ctx context.Context, k8sClient client.Client, o
 }
 
 func findPolicyForWebhookConfiguration(webhookConfiguration client.Object, log logr.Logger) []reconcile.Request {
-	if _, found := webhookConfiguration.GetLabels()["kubewarden"]; !found {
+	// Pre v1.16.0
+	_, kubwardenLabelExists := webhookConfiguration.GetLabels()["kubewarden"]
+	// From v1.16.0 on we are using the recommended label "app.kubernetes.io/part-of"
+	partOfLabel := webhookConfiguration.GetLabels()[constants.PartOfLabelKey]
+	if !kubwardenLabelExists && partOfLabel != constants.PartOfLabelValue {
 		return []reconcile.Request{}
 	}
 

--- a/internal/controller/policy_subreconciler.go
+++ b/internal/controller/policy_subreconciler.go
@@ -367,6 +367,13 @@ func findClusterPoliciesForPolicyServer(ctx context.Context, k8sClient client.Cl
 }
 
 func findClusterPolicyForWebhookConfiguration(webhookConfiguration client.Object, log logr.Logger) []reconcile.Request {
+	// Pre v1.16.0
+	_, kubwardenLabelExists := webhookConfiguration.GetLabels()["kubewarden"]
+	// From v1.16.0 on we are using the recommended label "app.kubernetes.io/part-of"
+	partOfLabel := webhookConfiguration.GetLabels()["app.kubernetes.io/part-of"]
+	if !kubwardenLabelExists && partOfLabel != "kubewarden" {
+		return []reconcile.Request{}
+	}
 	if _, found := webhookConfiguration.GetLabels()["kubewarden"]; !found {
 		return []reconcile.Request{}
 	}

--- a/internal/controller/policy_subreconciler_webhook.go
+++ b/internal/controller/policy_subreconciler_webhook.go
@@ -53,7 +53,7 @@ func (r *policySubReconciler) reconcileValidatingWebhookConfiguration(
 		}
 		webhook.Name = policy.GetUniqueName()
 		webhook.Labels = map[string]string{
-			"app.kubernetes.io/part-of":                       "kubewarden",
+			constants.PartOfLabelKey:                          constants.PartOfLabelValue,
 			constants.WebhookConfigurationPolicyScopeLabelKey: policyScope,
 		}
 		webhook.Annotations = map[string]string{
@@ -144,7 +144,7 @@ func (r *policySubReconciler) reconcileMutatingWebhookConfiguration(
 
 		webhook.Name = policy.GetUniqueName()
 		webhook.Labels = map[string]string{
-			"app.kubernetes.io/part-of":                       "kubewarden",
+			constants.PartOfLabelKey:                          constants.PartOfLabelValue,
 			constants.WebhookConfigurationPolicyScopeLabelKey: policyScope,
 		}
 		webhook.Annotations = map[string]string{

--- a/internal/controller/policy_subreconciler_webhook.go
+++ b/internal/controller/policy_subreconciler_webhook.go
@@ -53,7 +53,7 @@ func (r *policySubReconciler) reconcileValidatingWebhookConfiguration(
 		}
 		webhook.Name = policy.GetUniqueName()
 		webhook.Labels = map[string]string{
-			"kubewarden": "true",
+			"app.kubernetes.io/part-of":                       "kubewarden",
 			constants.WebhookConfigurationPolicyScopeLabelKey: policyScope,
 		}
 		webhook.Annotations = map[string]string{
@@ -65,7 +65,7 @@ func (r *policySubReconciler) reconcileValidatingWebhookConfiguration(
 				Name: policy.GetUniqueName() + ".kubewarden.admission",
 				ClientConfig: admissionregistrationv1.WebhookClientConfig{
 					Service:  &service,
-					CABundle: admissionSecret.Data[constants.PolicyServerCARootPemName],
+					CABundle: admissionSecret.Data[constants.CARootCert],
 				},
 				Rules:                   policy.GetRules(),
 				FailurePolicy:           policy.GetFailurePolicy(),
@@ -144,7 +144,7 @@ func (r *policySubReconciler) reconcileMutatingWebhookConfiguration(
 
 		webhook.Name = policy.GetUniqueName()
 		webhook.Labels = map[string]string{
-			"kubewarden": "true",
+			"app.kubernetes.io/part-of":                       "kubewarden",
 			constants.WebhookConfigurationPolicyScopeLabelKey: policyScope,
 		}
 		webhook.Annotations = map[string]string{
@@ -156,7 +156,7 @@ func (r *policySubReconciler) reconcileMutatingWebhookConfiguration(
 				Name: policy.GetUniqueName() + ".kubewarden.admission",
 				ClientConfig: admissionregistrationv1.WebhookClientConfig{
 					Service:  &service,
-					CABundle: admissionSecret.Data[constants.PolicyServerCARootPemName],
+					CABundle: admissionSecret.Data[constants.CARootCert],
 				},
 				Rules:                   policy.GetRules(),
 				FailurePolicy:           policy.GetFailurePolicy(),

--- a/internal/controller/policyserver_controller.go
+++ b/internal/controller/policyserver_controller.go
@@ -79,12 +79,7 @@ func (r *PolicyServerReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return r.reconcileDeletion(ctx, &policyServer, policies)
 	}
 
-	caRootSecret, err := r.reconcileInternalCARootSecret(ctx, &policyServer)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	err = r.reconcilePolicyServerCertSecret(ctx, &policyServer, caRootSecret)
+	err = r.reconcilePolicyServerCertSecret(ctx, &policyServer)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/policyserver_controller_cert_secret.go
+++ b/internal/controller/policyserver_controller_cert_secret.go
@@ -39,6 +39,11 @@ func (r *PolicyServerReconciler) reconcilePolicyServerCertSecret(ctx context.Con
 			return errors.Join(errors.New("failed to set policy server secret owner reference"), err)
 		}
 
+		policyServerSecret.ObjectMeta.Labels = map[string]string{
+			constants.PartOfLabelKey:    constants.PartOfLabelValue,
+			constants.ComponentLabelKey: constants.ComponentPolicyServerLabelValue,
+		}
+
 		// check if secret has the required data
 		_, hasTLSCert := policyServerSecret.Data[constants.ServerCert]
 		_, hasTLSKey := policyServerSecret.Data[constants.ServerPrivateKey]

--- a/internal/controller/policyserver_controller_cert_secret.go
+++ b/internal/controller/policyserver_controller_cert_secret.go
@@ -2,13 +2,13 @@ package controller
 
 import (
 	"context"
-	"crypto/rsa"
-	"crypto/x509"
 	"errors"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	policiesv1 "github.com/kubewarden/kubewarden-controller/api/policies/v1"
@@ -19,7 +19,14 @@ import (
 // Reconcile the certificate to be used by the policy server for TLS. The
 // generated certificate is signed by the CA certificate provided in the
 // caSecret. The generated certificate is stored in a secret.
-func (r *PolicyServerReconciler) reconcilePolicyServerCertSecret(ctx context.Context, policyServer *policiesv1.PolicyServer, caSecret *corev1.Secret) error {
+func (r *PolicyServerReconciler) reconcilePolicyServerCertSecret(ctx context.Context, policyServer *policiesv1.PolicyServer) error {
+	caSecret := &corev1.Secret{}
+
+	err := r.Client.Get(ctx, types.NamespacedName{Name: constants.CARootSecretName, Namespace: r.DeploymentsNamespace}, caSecret)
+	if err != nil {
+		return fmt.Errorf("failed to fetch CA secret: %w", err)
+	}
+
 	policyServerSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: r.DeploymentsNamespace,
@@ -27,43 +34,37 @@ func (r *PolicyServerReconciler) reconcilePolicyServerCertSecret(ctx context.Con
 		},
 	}
 
-	_, err := controllerutil.CreateOrPatch(ctx, r.Client, policyServerSecret, func() error {
-		if err := controllerutil.SetOwnerReference(policyServer, policyServerSecret, r.Client.Scheme()); err != nil {
+	_, err = controllerutil.CreateOrPatch(ctx, r.Client, policyServerSecret, func() error {
+		if err = controllerutil.SetOwnerReference(policyServer, policyServerSecret, r.Client.Scheme()); err != nil {
 			return errors.Join(errors.New("failed to set policy server secret owner reference"), err)
 		}
 
 		// check if secret has the required data
-		_, hasTLSCert := policyServerSecret.Data[constants.PolicyServerTLSCert]
-		_, hasTLSKey := policyServerSecret.Data[constants.PolicyServerTLSKey]
+		_, hasTLSCert := policyServerSecret.Data[constants.ServerCert]
+		_, hasTLSKey := policyServerSecret.Data[constants.ServerPrivateKey]
 		if !hasTLSCert || !hasTLSKey {
-			caCert, caPrivateKey, err := extractCAFromSecret(caSecret)
+			var caCert, caPrivateKey []byte
+			caCert, caPrivateKey, err = certs.ExtractCARootFromSecret(caSecret)
 			if err != nil {
 				return err
 			}
 
-			cert, privateKey, err := certs.GenerateCert(
+			var cert, privateKey []byte
+			cert, privateKey, err = certs.GenerateCert(
 				caCert,
+				caPrivateKey,
+				time.Now(),
+				time.Now().Add(constants.ServerCertExpiration),
 				fmt.Sprintf("%s.%s.svc", policyServer.NameWithPrefix(), r.DeploymentsNamespace),
-				[]string{fmt.Sprintf("%s.%s.svc", policyServer.NameWithPrefix(), r.DeploymentsNamespace)},
-				caPrivateKey)
+			)
 			if err != nil {
 				return fmt.Errorf("cannot generate policy-server %s certificate: %w", policyServer.NameWithPrefix(), err)
 			}
 
-			certPEM, err := certs.PEMEncodeCertificate(cert)
-			if err != nil {
-				return fmt.Errorf("cannot PEM encode policy-server %s certificate: %w", policyServer.NameWithPrefix(), err)
-			}
-
-			privateKeyPEM, err := certs.PEMEncodePrivateKey(privateKey)
-			if err != nil {
-				return fmt.Errorf("cannot PEM encode policy-server %s private key: %w", policyServer.NameWithPrefix(), err)
-			}
-
 			policyServerSecret.Type = corev1.SecretTypeOpaque
 			policyServerSecret.StringData = map[string]string{
-				constants.PolicyServerTLSCert: string(certPEM),
-				constants.PolicyServerTLSKey:  string(privateKeyPEM),
+				constants.ServerCert:       string(cert),
+				constants.ServerPrivateKey: string(privateKey),
 			}
 		}
 
@@ -82,90 +83,6 @@ func (r *PolicyServerReconciler) reconcilePolicyServerCertSecret(ctx context.Con
 		&policyServer.Status.Conditions,
 		string(policiesv1.PolicyServerCertSecretReconciled),
 	)
-
-	return nil
-}
-
-// Reconcile the internal CA root secret used by the controller to sign
-// the policy server certificate.
-func (r *PolicyServerReconciler) reconcileInternalCARootSecret(ctx context.Context, policyServer *policiesv1.PolicyServer) (*corev1.Secret, error) {
-	policyServerSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: r.DeploymentsNamespace,
-			Name:      constants.PolicyServerCARootSecretName,
-		},
-	}
-
-	_, err := controllerutil.CreateOrPatch(ctx, r.Client, policyServerSecret, func() error {
-		_, hasCARootCert := policyServerSecret.Data[constants.PolicyServerCARootCACert]
-		_, hasCARootPem := policyServerSecret.Data[constants.PolicyServerCARootPemName]
-		_, hasCARootPrivateKey := policyServerSecret.Data[constants.PolicyServerCARootPrivateKeyCertName]
-
-		if !hasCARootCert || !hasCARootPem || !hasCARootPrivateKey {
-			return createInternalCASecret(policyServerSecret)
-		}
-		return nil
-	})
-	if err != nil {
-		setFalseConditionType(
-			&policyServer.Status.Conditions,
-			string(policiesv1.CARootSecretReconciled),
-			fmt.Sprintf("error reconciling secret: %v", err),
-		)
-		return nil, errors.Join(errors.New("cannot fetch or initialize Policy Server CA secret"), err)
-	}
-
-	setTrueConditionType(
-		&policyServer.Status.Conditions,
-		string(policiesv1.CARootSecretReconciled),
-	)
-
-	return policyServerSecret, nil
-}
-
-// Extract the CA certificate and private key from the secret storing the CA data
-// used in the policy server certificate generation.
-func extractCAFromSecret(caSecret *corev1.Secret) ([]byte, *rsa.PrivateKey, error) {
-	caCert, ok := caSecret.Data[constants.PolicyServerCARootCACert]
-	if !ok {
-		return nil, nil, fmt.Errorf("CA could not be extracted from secret %s", caSecret.Kind)
-	}
-
-	privateKeyBytes, ok := caSecret.Data[constants.PolicyServerCARootPrivateKeyCertName]
-	if !ok {
-		return nil, nil, fmt.Errorf("CA private key bytes could not be extracted from secret %s", caSecret.Kind)
-	}
-
-	privateKey, err := x509.ParsePKCS1PrivateKey(privateKeyBytes)
-	if err != nil {
-		return nil, nil, fmt.Errorf("CA private key could not be extracted from secret %s", caSecret.Kind)
-	}
-
-	return caCert, privateKey, nil
-}
-
-// Create the internal CA root secret used by the controller to sign
-// the policy server certificates. The created CA is stored in the secret
-// provided as argument.
-func createInternalCASecret(policyServerSecret *corev1.Secret) error {
-	caCert, privateKey, err := certs.GenerateCA()
-	if err != nil {
-		return fmt.Errorf("cannot generate policy-server secret CA: %w", err)
-	}
-
-	caCertPEM, err := certs.PEMEncodeCertificate(caCert)
-	if err != nil {
-		return fmt.Errorf("cannot PEM encode policy-server secret CA certificate: %w", err)
-	}
-
-	privateKeyBytes := x509.MarshalPKCS1PrivateKey(privateKey)
-	secretContents := map[string][]byte{
-		constants.PolicyServerCARootCACert:             caCert,
-		constants.PolicyServerCARootPemName:            caCertPEM,
-		constants.PolicyServerCARootPrivateKeyCertName: privateKeyBytes,
-	}
-	policyServerSecret.Type = corev1.SecretTypeOpaque
-	policyServerSecret.Data = secretContents
 
 	return nil
 }

--- a/internal/controller/policyserver_controller_deployment.go
+++ b/internal/controller/policyserver_controller_deployment.go
@@ -355,11 +355,11 @@ func getPolicyServerContainer(policyServer *policiesv1.PolicyServer) corev1.Cont
 		Env: append([]corev1.EnvVar{
 			{
 				Name:  "KUBEWARDEN_CERT_FILE",
-				Value: filepath.Join(secretsContainerPath, constants.PolicyServerTLSCert),
+				Value: filepath.Join(secretsContainerPath, constants.ServerCert),
 			},
 			{
 				Name:  "KUBEWARDEN_KEY_FILE",
-				Value: filepath.Join(secretsContainerPath, constants.PolicyServerTLSKey),
+				Value: filepath.Join(secretsContainerPath, constants.ServerPrivateKey),
 			},
 			{
 				Name:  "KUBEWARDEN_PORT",

--- a/internal/controller/policyserver_controller_test.go
+++ b/internal/controller/policyserver_controller_test.go
@@ -617,20 +617,6 @@ var _ = Describe("PolicyServer controller", func() {
 			createPolicyServerAndWaitForItsService(ctx, policyServer)
 
 			Eventually(func() error {
-				secret, err := getInternalPolicyServerRootCASecret(ctx)
-				if err != nil {
-					return err
-				}
-
-				By("creating a secret containing the CA certificate and key")
-				Expect(secret.Data).To(HaveKey(constants.PolicyServerCARootCACert))
-				Expect(secret.Data).To(HaveKey(constants.PolicyServerCARootPemName))
-				Expect(secret.Data).To(HaveKey(constants.PolicyServerCARootPrivateKeyCertName))
-
-				return nil
-			}).Should(Succeed())
-
-			Eventually(func() error {
 				secret, err := getTestPolicyServerSecret(ctx, policyServerName)
 				if err != nil {
 					return err
@@ -641,8 +627,8 @@ var _ = Describe("PolicyServer controller", func() {
 				}
 
 				By("creating a secret containing the TLS certificate and key")
-				Expect(secret.Data).To(HaveKey(constants.PolicyServerTLSCert))
-				Expect(secret.Data).To(HaveKey(constants.PolicyServerTLSKey))
+				Expect(secret.Data).To(HaveKey(constants.ServerCert))
+				Expect(secret.Data).To(HaveKey(constants.ServerPrivateKey))
 
 				By("setting the secret owner reference")
 				Expect(secret.OwnerReferences).To(ContainElement(

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -260,14 +260,6 @@ func getTestPolicyServerService(ctx context.Context, policyServerName string) (*
 	return &service, nil
 }
 
-func getInternalPolicyServerRootCASecret(ctx context.Context) (*corev1.Secret, error) {
-	secret := corev1.Secret{}
-	if err := k8sClient.Get(ctx, client.ObjectKey{Name: constants.PolicyServerCARootSecretName, Namespace: deploymentsNamespace}, &secret); err != nil {
-		return nil, errors.Join(errors.New("could not find the PolicyServer CA secret"), err)
-	}
-	return &secret, nil
-}
-
 func getTestPolicyServerSecret(ctx context.Context, policyServerName string) (*corev1.Secret, error) {
 	secretName := getPolicyServerNameWithPrefix(policyServerName)
 	secret := corev1.Secret{}
@@ -323,7 +315,7 @@ func getTestMutatingWebhookConfiguration(ctx context.Context, name string) (*adm
 
 func getTestCASecret(ctx context.Context) (*corev1.Secret, error) {
 	secret := corev1.Secret{}
-	if err := k8sClient.Get(ctx, client.ObjectKey{Name: constants.PolicyServerCARootSecretName, Namespace: deploymentsNamespace}, &secret); err != nil {
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: constants.CARootSecretName, Namespace: deploymentsNamespace}, &secret); err != nil {
 		return nil, errors.Join(errors.New("could not find CA secret"), err)
 	}
 


### PR DESCRIPTION
## Description

This PR introduces a new runnable (`CertController`) that rotates CA root and leaf certificates:
- CA root rotation: see #818
- Server certificate rotation: see #819

It removes the `cert-manager` dependency.

NOTE: this PR requires helm chart changes, see: https://github.com/kubewarden/helm-charts/pull/488

TODO:
- [ ] remove cert-manager from the kustomize configurations.
- [ ] use some certificate generation settings as helm (see: https://github.com/Masterminds/sprig/blob/master/crypto.go, sprig is the library used by helm to add `genCA` and `genSignedCert` to the templates)

## Testing

The cert controller has been tested by using gingko/envtest.

## Additional information

### Part-of label

Before these changes, we used the `kubewarden: true` label in the webhook configuration, to filter kubewarden resources.
However, using the recommended label `app.kubernetes is better.io/part-of` is more idiomatic.
Also, the label is already set by the helm chart on the controller's webhook configurations.
Unfortunately, we need to support both labels to be compatible with the older versions.

### Injecting the CA bundle

There was the need to use the `retry.RetryOnConflict` utility when injecting the `caBundle` in the validating/mutating webhook configuration since there could be a chance to have a conflict with the neighbor controllers (namely the policy controllers).
`(Cluster)AdmissionPolicyController` will eventually converge to the new bundle, since it reads the secret (from the cache) every time it restores the webhook configuration.
Instead, the `CertController` reconciliation loop is ticker-based, so we cannot wait for the next tick to reconcile again. Therefore retrying with a certain backoff is a good strategy in this situation. See: https://github.com/kubernetes-sigs/controller-runtime/issues/1748

Fixes #819, fixes #818
