### PR TITLE
ci: Fix container-build workflow, no need to set permissions

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -12,9 +12,6 @@ on:
       - "main"
       - "feat-**"
 
-permissions:
-  contents: read
-
 jobs:
   build:
     uses: ./.github/workflows/container-image.yml


### PR DESCRIPTION

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Introduced with CLOMonitor changes.
See
https://github.com/kubewarden/kubewarden-controller/actions/runs/10352202900/workflow
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI once in main.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
