### PR TITLE
fix(Tiltfile): remove overriding helm webhooks with kustomize ones

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -39,24 +39,6 @@ for role in roles:
 if len(roles_rules_mapping["ClusterRole"]) == 0 or len(roles_rules_mapping["Role"]) == 0:
     fail("Failed to load cluster and namespace roles")
 
-# Get the webhook configuration with the latest values generated in the 
-# controller repository. 
-mutating_webhooks = []
-validating_webhooks = []
-webhooks_config = decode_yaml_stream(kustomize('config/webhook'))
-for webhook_config in webhooks_config:
- if webhook_config.get('kind') == 'MutatingWebhookConfiguration':
-	 mutating_webhooks = webhook_config.get('webhooks')
-	 for i in range(len(mutating_webhooks)):
-	     mutating_webhooks[i]["clientConfig"]["service"]["name"] = "kubewarden-controller-webhook-service"
-	     mutating_webhooks[i]["clientConfig"]["service"]["namespace"] = "kubewarden"
- if webhook_config.get('kind') == 'ValidatingWebhookConfiguration':
-	 validating_webhooks = webhook_config.get('webhooks')
-	 for i in range(len(validating_webhooks)):
-	     validating_webhooks[i]["clientConfig"]["service"]["name"] = "kubewarden-controller-webhook-service"
-	     validating_webhooks[i]["clientConfig"]["service"]["namespace"] = "kubewarden"
-
-
 # Install kubewarden-controller helm chart
 install = helm(
     settings.get('helm_charts_path') + '/charts/kubewarden-controller/', 
@@ -86,13 +68,6 @@ for o in objects:
 	o['rules'] = roles_rules_mapping["Role"]["manager-role"]
     if o.get('kind') == 'Role' and o.get('metadata').get('name') == 'kubewarden-controller-leader-election-role':
 	o['rules'] = roles_rules_mapping["Role"]["leader-election-role"]
-
-    # Update the webhook configuration with the latest values generated in the 
-    # controller repository. This useful when adding/updating webhooks.
-    if o.get('kind') == 'MutatingWebhookConfiguration':
-	o['webhooks'] = mutating_webhooks
-    if o.get('kind') == 'ValidatingWebhookConfiguration':
-	o['webhooks'] = validating_webhooks
 
 updated_install = encode_yaml_stream(objects)
 k8s_yaml(updated_install)


### PR DESCRIPTION
## Description

Recently we changed the Tiltfile to override the Helm chart's webhooks with the ones provided by the Kustomize folder.
However, this breaks since we now inject initial certificate bundles from the helm chart.
While having the scaffolded webhooks updated automatically can be handy, we don't expect adding webhooks frequently to justify the added complexity of merging the two configurations.

This PR fixes: #854  by removing the Kustomize webhooks logic in the tiltfile