### PR TITLE
feat: validate PolicyGroup expressions

### DIFF
--- a/api/policies/v1/admissionpolicy_webhook.go
+++ b/api/policies/v1/admissionpolicy_webhook.go
@@ -19,7 +19,6 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -51,6 +50,7 @@ var _ webhook.Defaulter = &AdmissionPolicy{}
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
 func (r *AdmissionPolicy) Default() {
 	admissionpolicylog.Info("default", "name", r.Name)
+
 	if r.Spec.PolicyServer == "" {
 		r.Spec.PolicyServer = constants.DefaultPolicyServer
 	}
@@ -66,17 +66,12 @@ var _ webhook.Validator = &AdmissionPolicy{}
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *AdmissionPolicy) ValidateCreate() (admission.Warnings, error) {
 	admissionpolicylog.Info("validate create", "name", r.Name)
-	errList := field.ErrorList{}
 
-	if errs := validateRulesField(r); len(errs) != 0 {
-		errList = append(errList, errs...)
+	allErrors := validatePolicyCreate(r)
+	if len(allErrors) != 0 {
+		return nil, prepareInvalidAPIError(r, allErrors)
 	}
-	if errs := validateMatchConditionsField(r); len(errs) != 0 {
-		errList = append(errList, errs...)
-	}
-	if len(errList) != 0 {
-		return nil, prepareInvalidAPIError(r, errList)
-	}
+
 	return nil, nil
 }
 
@@ -89,11 +84,18 @@ func (r *AdmissionPolicy) ValidateUpdate(old runtime.Object) (admission.Warnings
 		return admission.Warnings{}, apierrors.NewInternalError(
 			fmt.Errorf("object is not of type AdmissionPolicy: %#v", old))
 	}
-	return nil, validatePolicyUpdate(oldPolicy, r)
+
+	allErrors := validatePolicyUpdate(oldPolicy, r)
+	if len(allErrors) != 0 {
+		return nil, prepareInvalidAPIError(r, allErrors)
+	}
+
+	return nil, nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *AdmissionPolicy) ValidateDelete() (admission.Warnings, error) {
 	admissionpolicylog.Info("validate delete", "name", r.Name)
+
 	return nil, nil
 }

--- a/api/policies/v1/policy_utils_test.go
+++ b/api/policies/v1/policy_utils_test.go
@@ -54,7 +54,7 @@ func admissionPolicyGroupFactory() *AdmissionPolicyGroup {
 				Message:      "This is a test policy",
 				Policies: []PolicyGroupMember{
 					{
-						Name:                  "testing-policy",
+						Name:                  "mypolicy",
 						Module:                "ghcr.io/kubewarden/tests/user-group-psp:v0.4.9",
 						Settings:              runtime.RawExtension{},
 						ContextAwareResources: []ContextAwareResource{},
@@ -101,7 +101,7 @@ func clusterAdmissionPolicyGroupFactory() *ClusterAdmissionPolicyGroup {
 				Message:         "This is a test policy",
 				Policies: []PolicyGroupMember{
 					{
-						Name:                  "testing-policy",
+						Name:                  "mypolicy",
 						Module:                "ghcr.io/kubewarden/tests/user-group-psp:v0.4.9",
 						Settings:              runtime.RawExtension{},
 						ContextAwareResources: []ContextAwareResource{},

--- a/api/policies/v1/policy_validation.go
+++ b/api/policies/v1/policy_validation.go
@@ -134,7 +134,7 @@ func validatePolicyServerField(oldPolicy, newPolicy Policy) *field.Error {
 }
 
 func validatePolicyModeField(oldPolicy, newPolicy Policy) *field.Error {
-	if oldPolicy.GetPolicyMode() != newPolicy.GetPolicyMode() {
+	if oldPolicy.GetPolicyMode() == "protect" && newPolicy.GetPolicyMode() == "monitor" {
 		return field.Forbidden(field.NewPath("spec").Child("mode"), "field cannot transition from protect to monitor. Recreate instead.")
 	}
 

--- a/api/policies/v1/policy_validation_test.go
+++ b/api/policies/v1/policy_validation_test.go
@@ -28,109 +28,152 @@ func TestValidateRulesField(t *testing.T) {
 		policy               Policy
 		expectedErrorMessage string // use empty string when no error is expected
 	}{
-		{"with no operations and API groups and resources", clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{}, nil, "default", "protect"), "spec.rules: Required value: a value must be specified"},
-		{"with empty objects", clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{}}, nil, "default", "protect"), "spec.rules.operations: Required value: a value must be specified"},
-		{"with no operations", clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
-			Operations: []admissionregistrationv1.OperationType{},
-			Rule: admissionregistrationv1.Rule{
-				APIGroups:   []string{"*"},
-				APIVersions: []string{"*"},
-				Resources:   []string{"*/*"},
-			},
-		}}, nil, "default", "protect"), "spec.rules.operations: Required value: a value must be specified"},
-		{"with null operations", clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
-			Operations: nil,
-			Rule: admissionregistrationv1.Rule{
-				APIGroups:   []string{"*"},
-				APIVersions: []string{"*"},
-				Resources:   []string{"*/*"},
-			},
-		}}, nil, "default", "protect"), "spec.rules.operations: Required value: a value must be specified"},
-		{"with empty operations string", clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
-			Operations: []admissionregistrationv1.OperationType{""},
-			Rule: admissionregistrationv1.Rule{
-				APIGroups:   []string{"*"},
-				APIVersions: []string{"*"},
-				Resources:   []string{"*/*"},
-			},
-		}}, nil, "default", "protect"), "spec.rules.operations: Invalid value: \"\": field value cannot contain the empty string"},
-
-		{"with no apiVersion", clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
-			Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-			Rule: admissionregistrationv1.Rule{
-				APIGroups:   []string{"*"},
-				APIVersions: []string{},
-				Resources:   []string{"*/*"},
-			},
-		}}, nil, "default", "protect"), "spec.rules: Required value: apiVersions and resources must have specified values"},
-		{"with no resources", clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
-			Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-			Rule: admissionregistrationv1.Rule{
-				APIGroups:   []string{"*"},
-				APIVersions: []string{"*"},
-				Resources:   []string{},
-			},
-		}}, nil, "default", "protect"), "spec.rules: Required value: apiVersions and resources must have specified values"},
-		{"with empty apiVersion string", clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
-			Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-			Rule: admissionregistrationv1.Rule{
-				APIGroups:   []string{"*"},
-				APIVersions: []string{""},
-				Resources:   []string{"*/*"},
-			},
-		}}, nil, "default", "protect"), "spec.rules.rule.apiVersions: Invalid value: \"\": rule.apiVersions value cannot contain the empty string"},
-		{"with some of the apiVersion are empty string", clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
-			Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-			Rule: admissionregistrationv1.Rule{
-				APIGroups:   []string{"*"},
-				APIVersions: []string{""},
-				Resources:   []string{"*/*"},
-			},
-		}}, nil, "default", "protect"), "spec.rules.rule.apiVersions: Invalid value: \"\": rule.apiVersions value cannot contain the empty string"},
-		{"with empty resources string", clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
-			Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-			Rule: admissionregistrationv1.Rule{
-				APIGroups:   []string{"*"},
-				APIVersions: []string{"*"},
-				Resources:   []string{""},
-			},
-		}}, nil, "default", "protect"), "spec.rules.rule.resources: Invalid value: \"\": rule.resources value cannot contain the empty string"},
-		{"with some of the resources are string", clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
-			Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-			Rule: admissionregistrationv1.Rule{
-				APIGroups:   []string{""},
-				APIVersions: []string{"v1"},
-				Resources:   []string{"", "pods"},
-			},
-		}}, nil, "default", "protect"), "spec.rules.rule.resources: Invalid value: \"\": rule.resources value cannot contain the empty string"},
-		{"with all operations and API groups and resources", clusterAdmissionPolicyFactory(nil, nil, "default", "protect"), ""},
-		{"with valid APIVersion and resources. But with empty APIGroup", clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
-			Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-			Rule: admissionregistrationv1.Rule{
-				APIGroups:   []string{""},
-				APIVersions: []string{"v1"},
-				Resources:   []string{"pods"},
-			},
-		}}, nil, "default", "protect"), ""},
-		{"with valid APIVersion, Resources and APIGroup", clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
-			Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-			Rule: admissionregistrationv1.Rule{
-				APIGroups:   []string{"apps"},
-				APIVersions: []string{"v1"},
-				Resources:   []string{"deployments"},
-			},
-		}}, nil, "default", "protect"), ""},
+		{
+			"with valid APIVersion and resources. But with empty APIGroup", clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{""},
+					APIVersions: []string{"v1"},
+					Resources:   []string{"pods"},
+				},
+			}}, nil, "default", "protect"),
+			"",
+		},
+		{
+			"with valid APIVersion, Resources and APIGroup",
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{"apps"},
+					APIVersions: []string{"v1"},
+					Resources:   []string{"deployments"},
+				},
+			}}, nil, "default", "protect"),
+			"",
+		},
+		{
+			"with no operations and API groups and resources",
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{}, nil, "default", "protect"),
+			"spec.rules: Required value: a value must be specified",
+		},
+		{
+			"with empty objects",
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{}}, nil, "default", "protect"),
+			"spec.rules.operations: Required value: a value must be specified",
+		},
+		{
+			"with no operations",
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{"*"},
+					APIVersions: []string{"*"},
+					Resources:   []string{"*/*"},
+				},
+			}}, nil, "default", "protect"),
+			"spec.rules.operations: Required value: a value must be specified",
+		},
+		{
+			"with null operations",
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: nil,
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{"*"},
+					APIVersions: []string{"*"},
+					Resources:   []string{"*/*"},
+				},
+			}}, nil, "default", "protect"),
+			"spec.rules.operations: Required value: a value must be specified",
+		},
+		{
+			"with empty operations string",
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{""},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{"*"},
+					APIVersions: []string{"*"},
+					Resources:   []string{"*/*"},
+				},
+			}}, nil, "default", "protect"),
+			"spec.rules.operations[0]: Required value: must be non-empty",
+		},
+		{
+			"with no apiVersion",
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{"*"},
+					APIVersions: []string{},
+					Resources:   []string{"*/*"},
+				},
+			}}, nil, "default", "protect"),
+			"spec.rules: Required value: apiVersions and resources must have specified values",
+		},
+		{
+			"with no resources",
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{"*"},
+					APIVersions: []string{"*"},
+					Resources:   []string{},
+				},
+			}}, nil, "default", "protect"),
+			"spec.rules: Required value: apiVersions and resources must have specified values",
+		},
+		{
+			"with empty apiVersion string",
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{"*"},
+					APIVersions: []string{""},
+					Resources:   []string{"*/*"},
+				},
+			}}, nil, "default", "protect"),
+			"spec.rules.rule.apiVersions[0]: Required value: must be non-empty",
+		},
+		{
+			"with empty resources string",
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{"*"},
+					APIVersions: []string{"*"},
+					Resources:   []string{""},
+				},
+			}}, nil, "default", "protect"),
+			"spec.rules.rule.resources[0]: Required value: must be non-empty",
+		},
+		{
+			"with some of the resources are empty strings",
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{""},
+					APIVersions: []string{"v1"},
+					Resources:   []string{"", "pods"},
+				},
+			}}, nil, "default", "protect"),
+			"spec.rules.rule.resources[0]: Required value: must be non-empty",
+		},
+		{
+			"with all operations and API groups and resources",
+			clusterAdmissionPolicyFactory(nil, nil, "default", "protect"),
+			"",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			errList := validateRulesField(test.policy)
+			allErrors := validateRulesField(test.policy)
+
 			if test.expectedErrorMessage != "" {
-				err := prepareInvalidAPIError(test.policy, errList)
+				err := prepareInvalidAPIError(test.policy, allErrors)
 				require.ErrorContains(t, err, test.expectedErrorMessage)
-				return
+			} else {
+				require.Empty(t, allErrors)
 			}
-			require.Empty(t, errList)
 		})
 	}
 }
@@ -141,91 +184,77 @@ func TestValidateMatchConditionsField(t *testing.T) {
 		policy               Policy
 		expectedErrorMessage string // use empty string when no error is expected
 	}{
-		{"with empty MatchConditions", clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
-			Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-			Rule:       admissionregistrationv1.Rule{APIGroups: []string{"apps"}, APIVersions: []string{"v1"}, Resources: []string{"deployments"}},
-		}}, nil, "default", "protect"), ""},
-		{"with valid MatchConditions", clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
-			Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-			Rule:       admissionregistrationv1.Rule{APIGroups: []string{"apps"}, APIVersions: []string{"v1"}, Resources: []string{"deployments"}},
-		}}, []admissionregistrationv1.MatchCondition{
-			{
-				Name:       "foo",
-				Expression: "true",
-			},
-		}, "default", "protect"), ""},
-		{"with non-boolean MatchConditions", clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
-			Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-			Rule:       admissionregistrationv1.Rule{APIGroups: []string{"apps"}, APIVersions: []string{"v1"}, Resources: []string{"deployments"}},
-		}}, []admissionregistrationv1.MatchCondition{
-			{
-				Name:       "foo",
-				Expression: "1 + 1",
-			},
-		}, "default", "protect"), "Invalid value: \"1 + 1\": must evaluate to bool"},
-		{"with invalid expression in MatchConditions", clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
-			Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-			Rule:       admissionregistrationv1.Rule{APIGroups: []string{"apps"}, APIVersions: []string{"v1"}, Resources: []string{"deployments"}},
-		}}, []admissionregistrationv1.MatchCondition{
-			{
-				Name:       "foo",
-				Expression: "invalid expression",
-			},
-		}, "default", "protect"), "Syntax error: extraneous input 'expression'"},
+		{
+			"with empty MatchConditions",
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule:       admissionregistrationv1.Rule{APIGroups: []string{"apps"}, APIVersions: []string{"v1"}, Resources: []string{"deployments"}},
+			}}, nil, "default", "protect"),
+			"",
+		},
+		{
+			"with valid MatchConditions",
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule:       admissionregistrationv1.Rule{APIGroups: []string{"apps"}, APIVersions: []string{"v1"}, Resources: []string{"deployments"}},
+			}}, []admissionregistrationv1.MatchCondition{
+				{
+					Name:       "foo",
+					Expression: "true",
+				},
+			}, "default", "protect"),
+			"",
+		},
+		{
+			"with non-boolean MatchConditions",
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule:       admissionregistrationv1.Rule{APIGroups: []string{"apps"}, APIVersions: []string{"v1"}, Resources: []string{"deployments"}},
+			}}, []admissionregistrationv1.MatchCondition{
+				{
+					Name:       "foo",
+					Expression: "1 + 1",
+				},
+			}, "default", "protect"),
+			"Invalid value: \"1 + 1\": must evaluate to bool",
+		},
+		{
+			"with invalid expression in MatchConditions",
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule:       admissionregistrationv1.Rule{APIGroups: []string{"apps"}, APIVersions: []string{"v1"}, Resources: []string{"deployments"}},
+			}}, []admissionregistrationv1.MatchCondition{
+				{
+					Name:       "foo",
+					Expression: "invalid expression",
+				},
+			}, "default", "protect"), "Syntax error: extraneous input 'expression'",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			errList := validateMatchConditionsField(test.policy)
+			allErrors := validateMatchConditionsField(test.policy)
+
 			if test.expectedErrorMessage != "" {
-				err := prepareInvalidAPIError(test.policy, errList)
+				err := prepareInvalidAPIError(test.policy, allErrors)
 				require.ErrorContains(t, err, test.expectedErrorMessage)
-				return
+			} else {
+				require.Empty(t, allErrors)
 			}
-			require.Empty(t, errList)
 		})
 	}
 }
 
-func TestValidatePolicyUpdate(t *testing.T) {
+func TestValidatePolicyServerField(t *testing.T) {
 	tests := []struct {
 		name                 string
 		oldPolicy            Policy
 		newPolicy            Policy
 		expectedErrorMessage string // use empty string when no error is expected
 	}{
-		{"update policy server", clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
-			Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-			Rule: admissionregistrationv1.Rule{
-				APIGroups:   []string{"apps"},
-				APIVersions: []string{"v1"},
-				Resources:   []string{"deployments"},
-			},
-		}}, nil, "old-policy-server", "monitor"), clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
-			Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-			Rule: admissionregistrationv1.Rule{
-				APIGroups:   []string{"apps"},
-				APIVersions: []string{"v1"},
-				Resources:   []string{"deployments"},
-			},
-		}}, nil, "new-policy-server", "monitor"), "spec.policyServer: Forbidden: the field is immutable"},
-		{"change from protect to monitor", clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
-			Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-			Rule: admissionregistrationv1.Rule{
-				APIGroups:   []string{"apps"},
-				APIVersions: []string{"v1"},
-				Resources:   []string{"deployments"},
-			},
-		}}, nil, "default", "protect"), clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
-			Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-			Rule: admissionregistrationv1.Rule{
-				APIGroups:   []string{"apps"},
-				APIVersions: []string{"v1"},
-				Resources:   []string{"deployments"},
-			},
-		}}, nil, "default", "monitor"), "spec.mode: Forbidden: field cannot transition from protect to monitor. Recreate instead."},
 		{
-			"adding more rules",
+			"policy server unchanged",
 			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
 				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
 				Rule: admissionregistrationv1.Rule{
@@ -233,28 +262,19 @@ func TestValidatePolicyUpdate(t *testing.T) {
 					APIVersions: []string{"v1"},
 					Resources:   []string{"deployments"},
 				},
-			}}, nil, "default", "protect"),
-			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{
-				{
-					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-					Rule: admissionregistrationv1.Rule{
-						APIGroups:   []string{"apps"},
-						APIVersions: []string{"v1"},
-						Resources:   []string{"deployments"},
-					},
+			}}, nil, "old-policy-server", "monitor"),
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{"apps"},
+					APIVersions: []string{"v1"},
+					Resources:   []string{"deployments"},
 				},
-				{
-					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-					Rule: admissionregistrationv1.Rule{
-						APIGroups:   []string{""},
-						APIVersions: []string{"v1"},
-						Resources:   []string{"pods"},
-					},
-				},
-			}, nil, "default", "protect"), "",
+			}}, nil, "old-policy-server", "monitor"),
+			"",
 		},
 		{
-			"adding matchCondtions",
+			"policy server changed",
 			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
 				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
 				Rule: admissionregistrationv1.Rule{
@@ -262,39 +282,90 @@ func TestValidatePolicyUpdate(t *testing.T) {
 					APIVersions: []string{"v1"},
 					Resources:   []string{"deployments"},
 				},
-			}}, nil, "default", "protect"),
-			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{
-				{
-					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-					Rule: admissionregistrationv1.Rule{
-						APIGroups:   []string{"apps"},
-						APIVersions: []string{"v1"},
-						Resources:   []string{"deployments"},
-					},
+			}}, nil, "old-policy-server", "monitor"),
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{"apps"},
+					APIVersions: []string{"v1"},
+					Resources:   []string{"deployments"},
 				},
-				{
-					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-					Rule: admissionregistrationv1.Rule{
-						APIGroups:   []string{""},
-						APIVersions: []string{"v1"},
-						Resources:   []string{"pods"},
-					},
-				},
-			}, []admissionregistrationv1.MatchCondition{{
-				Name:       "foo",
-				Expression: "true",
-			}}, "default", "protect"), "",
+			}}, nil, "new-policy-server", "monitor"),
+			"spec.policyServer: Forbidden: the field is immutable",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := validatePolicyUpdate(test.oldPolicy, test.newPolicy)
+			err := validatePolicyServerField(test.newPolicy, test.oldPolicy)
+
 			if test.expectedErrorMessage != "" {
 				require.ErrorContains(t, err, test.expectedErrorMessage)
-				return
+			} else {
+				require.Nil(t, err)
 			}
-			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidatePolicyModeField(t *testing.T) {
+	tests := []struct {
+		name                 string
+		oldPolicy            Policy
+		newPolicy            Policy
+		expectedErrorMessage string // use empty string when no error is expected
+	}{
+		{
+			"policy mode unchanged",
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{"apps"},
+					APIVersions: []string{"v1"},
+					Resources:   []string{"deployments"},
+				},
+			}}, nil, "default", "protect"),
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{"apps"},
+					APIVersions: []string{"v1"},
+					Resources:   []string{"deployments"},
+				},
+			}}, nil, "default", "protect"),
+			"",
+		},
+		{
+			"policy mode changed from protect to monitor",
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{"apps"},
+					APIVersions: []string{"v1"},
+					Resources:   []string{"deployments"},
+				},
+			}}, nil, "default", "protect"),
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{"apps"},
+					APIVersions: []string{"v1"},
+					Resources:   []string{"deployments"},
+				},
+			}}, nil, "default", "monitor"),
+			"spec.mode: Forbidden: field cannot transition from protect to monitor. Recreate instead.",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validatePolicyModeField(test.newPolicy, test.oldPolicy)
+
+			if test.expectedErrorMessage != "" {
+				require.ErrorContains(t, err, test.expectedErrorMessage)
+			} else {
+				require.Nil(t, err)
+			}
 		})
 	}
 }

--- a/api/policies/v1/policy_validation_test.go
+++ b/api/policies/v1/policy_validation_test.go
@@ -297,7 +297,7 @@ func TestValidatePolicyServerField(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := validatePolicyServerField(test.newPolicy, test.oldPolicy)
+			err := validatePolicyServerField(test.oldPolicy, test.newPolicy)
 
 			if test.expectedErrorMessage != "" {
 				require.ErrorContains(t, err, test.expectedErrorMessage)
@@ -336,6 +336,26 @@ func TestValidatePolicyModeField(t *testing.T) {
 			"",
 		},
 		{
+			"policy mode changed from monitor to protect",
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{"apps"},
+					APIVersions: []string{"v1"},
+					Resources:   []string{"deployments"},
+				},
+			}}, nil, "default", "monitor"),
+			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{"apps"},
+					APIVersions: []string{"v1"},
+					Resources:   []string{"deployments"},
+				},
+			}}, nil, "default", "protect"),
+			"",
+		},
+		{
 			"policy mode changed from protect to monitor",
 			clusterAdmissionPolicyFactory([]admissionregistrationv1.RuleWithOperations{{
 				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
@@ -359,7 +379,7 @@ func TestValidatePolicyModeField(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := validatePolicyModeField(test.newPolicy, test.oldPolicy)
+			err := validatePolicyModeField(test.oldPolicy, test.newPolicy)
 
 			if test.expectedErrorMessage != "" {
 				require.ErrorContains(t, err, test.expectedErrorMessage)

--- a/api/policies/v1/policygroup_validation.go
+++ b/api/policies/v1/policygroup_validation.go
@@ -1,0 +1,104 @@
+package v1
+
+import (
+	"fmt"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/decls"
+	"github.com/google/cel-go/common/operators"
+	"github.com/google/cel-go/common/stdlib"
+	"github.com/google/cel-go/common/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func validatePolicyGroupCreate(policy Policy) field.ErrorList {
+	var allErrors field.ErrorList
+
+	allErrors = append(allErrors, validatePolicyCreate(policy)...)
+	if err := validatePolicyGroupMembers(policy); err != nil {
+		allErrors = append(allErrors, err)
+	}
+	if err := validatePolicyGroupExpressionField(policy); err != nil {
+		allErrors = append(allErrors, err)
+	}
+
+	return allErrors
+}
+
+func validatePolicyGroupUpdate(oldPolicy, newPolicy Policy) field.ErrorList {
+	var allErrors field.ErrorList
+
+	allErrors = append(allErrors, validatePolicyUpdate(oldPolicy, newPolicy)...)
+	if err := validatePolicyGroupMembers(newPolicy); err != nil {
+		allErrors = append(allErrors, err)
+	}
+	if err := validatePolicyGroupExpressionField(newPolicy); err != nil {
+		allErrors = append(allErrors, err)
+	}
+
+	return allErrors
+}
+
+// validatePolicyGroupMembers validates that a policy group has at least one policy member.
+func validatePolicyGroupMembers(policy Policy) *field.Error {
+	if len(policy.GetPolicyMembers()) == 0 {
+		return field.Required(field.NewPath("spec").Child("policies"), "policy groups must have at least one policy member")
+	}
+
+	return nil
+}
+
+// validatePolicyGroupExpressionField validates that the expression is a valid CEL expression that evaluates to a boolean.
+// Only the following operators are allowed: equals, not equals, logical or, logical and, and logical not.
+// Policy members are imported as custom functions that take no arguments and return a boolean.
+func validatePolicyGroupExpressionField(policy Policy) *field.Error {
+	expressionField := field.NewPath("spec").Child("expression")
+
+	if policy.GetExpression() == "" {
+		return field.Required(expressionField, "must be non-empty")
+	}
+
+	// Create a CEL environment with custom functions for each policy member
+	var opts []cel.EnvOption
+	for _, p := range policy.GetPolicyMembers() {
+		fn := cel.Function(p.Name, cel.Overload(p.Name, []*cel.Type{}, types.BoolType))
+		opts = append(opts, fn)
+	}
+
+	// Import only equals, not equals, logical or, logical and, and logical not operators
+	// from the standard library
+	allowedOperators := map[string]bool{
+		operators.Equals:     true,
+		operators.NotEquals:  true,
+		operators.LogicalOr:  true,
+		operators.LogicalAnd: true,
+		operators.LogicalNot: true,
+	}
+	for _, fn := range stdlib.Functions() {
+		if !allowedOperators[fn.Name()] {
+			continue
+		}
+
+		opts = append(opts, cel.Function(fn.Name(),
+			func(*decls.FunctionDecl) (*decls.FunctionDecl, error) {
+				return fn, nil
+			}))
+	}
+
+	env, err := cel.NewCustomEnv(
+		opts...,
+	)
+	if err != nil {
+		return field.InternalError(expressionField, fmt.Errorf("error creating CEL environment: %w", err))
+	}
+
+	ast, issues := env.Compile(policy.GetExpression())
+	if issues != nil && issues.Err() != nil {
+		return field.Invalid(expressionField, policy.GetExpression(), fmt.Sprintf("compilation failed: %v", issues.Err()))
+	}
+	if ast.OutputType() != types.BoolType {
+		return field.Invalid(expressionField, policy.GetExpression(), "must evaluate to bool")
+	}
+
+	return nil
+}

--- a/api/policies/v1/policygroup_validation_test.go
+++ b/api/policies/v1/policygroup_validation_test.go
@@ -1,0 +1,189 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestValidatePolicyGroupExpressionField(t *testing.T) {
+	tests := []struct {
+		name                 string
+		policy               Policy
+		expectedErrorMessage string
+	}{
+		{
+			"with valid expression",
+			&ClusterAdmissionPolicyGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testing-cluster-policy-group",
+				},
+				Spec: ClusterAdmissionPolicyGroupSpec{
+					PolicyGroupSpec: PolicyGroupSpec{
+						Expression: "policy1() && policy2()",
+						Message:    "This is a test policy",
+						Policies: []PolicyGroupMember{
+							{
+								Name:   "policy1",
+								Module: "ghcr.io/kubewarden/tests/user-group-psp:v0.4.9",
+							},
+							{
+								Name:   "policy2",
+								Module: "ghcr.io/kubewarden/tests/safe-labels:v1.0.0",
+							},
+						},
+					},
+				},
+			},
+			"",
+		},
+		{
+			"with empty expression",
+			&ClusterAdmissionPolicyGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testing-cluster-policy-group",
+				},
+				Spec: ClusterAdmissionPolicyGroupSpec{
+					PolicyGroupSpec: PolicyGroupSpec{
+						Expression: "",
+						Message:    "This is a test policy",
+						Policies: []PolicyGroupMember{
+							{
+								Name:   "policy1",
+								Module: "ghcr.io/kubewarden/tests/user-group-psp:v0.4.9",
+							},
+							{
+								Name:   "policy2",
+								Module: "ghcr.io/kubewarden/tests/safe-labels:v1.0.0",
+							},
+						},
+					},
+				},
+			},
+			`spec.expression: Required value: must be non-empty`,
+		},
+		{
+			"with non-boolean expression",
+			&ClusterAdmissionPolicyGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testing-cluster-policy-group",
+				},
+				Spec: ClusterAdmissionPolicyGroupSpec{
+					PolicyGroupSpec: PolicyGroupSpec{
+						Expression: "123",
+						Message:    "This is a test policy",
+						Policies: []PolicyGroupMember{
+							{
+								Name:   "policy1",
+								Module: "ghcr.io/kubewarden/tests/user-group-psp:v0.4.9",
+							},
+							{
+								Name:   "policy2",
+								Module: "ghcr.io/kubewarden/tests/safe-labels:v1.0.0",
+							},
+						},
+					},
+				},
+			},
+			`spec.expression: Invalid value: "123": must evaluate to bool`,
+		},
+		{
+			"with invalid expression",
+			&ClusterAdmissionPolicyGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testing-cluster-policy-group",
+				},
+				Spec: ClusterAdmissionPolicyGroupSpec{
+					PolicyGroupSpec: PolicyGroupSpec{
+						Expression: "2 > 1",
+						Message:    "This is a test policy",
+						Policies: []PolicyGroupMember{
+							{
+								Name:   "policy1",
+								Module: "ghcr.io/kubewarden/tests/user-group-psp:v0.4.9",
+							},
+							{
+								Name:   "policy2",
+								Module: "ghcr.io/kubewarden/tests/safe-labels:v1.0.0",
+							},
+						},
+					},
+				},
+			},
+			`spec.expression: Invalid value: "2 > 1": compilation failed`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validatePolicyGroupExpressionField(test.policy)
+
+			if test.expectedErrorMessage != "" {
+				require.ErrorContains(t, err, test.expectedErrorMessage)
+			} else {
+				require.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestValidatePolicyGroupMembers(t *testing.T) {
+	tests := []struct {
+		name                 string
+		policy               Policy
+		expectedErrorMessage string
+	}{
+		{
+			"with valid policy members",
+			&ClusterAdmissionPolicyGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testing-cluster-policy-group",
+				},
+				Spec: ClusterAdmissionPolicyGroupSpec{
+					PolicyGroupSpec: PolicyGroupSpec{
+						Expression: "policy1() && policy2()",
+						Message:    "This is a test policy",
+						Policies: []PolicyGroupMember{
+							{
+								Name:   "policy1",
+								Module: "ghcr.io/kubewarden/tests/user-group-psp:v0.4.9",
+							},
+							{
+								Name:   "policy2",
+								Module: "ghcr.io/kubewarden/tests/safe-labels:v1.0.0",
+							},
+						},
+					},
+				},
+			},
+			"",
+		},
+		{
+			"with no policy members",
+			&ClusterAdmissionPolicyGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testing-cluster-policy-group",
+				},
+				Spec: ClusterAdmissionPolicyGroupSpec{
+					PolicyGroupSpec: PolicyGroupSpec{
+						Policies: []PolicyGroupMember{},
+					},
+				},
+			},
+			`spec.policies: Required value: policy groups must have at least one policy member`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validatePolicyGroupMembers(test.policy)
+
+			if test.expectedErrorMessage != "" {
+				require.ErrorContains(t, err, test.expectedErrorMessage)
+			} else {
+				require.Nil(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
This PR adds a validation step for the `expression` field of the policy group spec.
An expression must be a valid CEL expression that evaluates to `bool`. Only logic and equality operators are allowed, and policy members are available as functions with zero arity.

It also refactors the policy validation utility functions, cleaning up the existing tests.
Additional cleanup will be needed, which is tracked by: https://github.com/kubewarden/kubewarden-controller/issues/824

Fixes #859 