### PR TITLE
Revert "feat: add feature flag for policy groups."

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -55,10 +55,6 @@ for o in objects:
         o['spec']['template']['spec']['securityContext']['runAsNonRoot'] = False
         # Disable the leader election to speed up the startup time.
         o['spec']['template']['spec']['containers'][0]['args'].remove('--leader-elect')
-	# Enable policy groups feature
-	envvars = o['spec']['template']['spec']['containers'][0].get('env', [])
-	envvars.append({'name': 'KUBEWARDEN_ENABLE_POLICY_GROUPS', 'value': 'true'})
-	o['spec']['template']['spec']['containers'][0]['env']  = envvars
 
     # Update the cluster and namespace roles used by the controller. This ensures
     # that always we have the latest roles applied to the cluster.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"flag"
 	"os"
-	"strings"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -275,26 +274,24 @@ func setupReconcilers(mgr ctrl.Manager, deploymentsNamespace, webhookServiceName
 		return errors.Join(errors.New("unable to create Cert controller"), err)
 	}
 
-	if isPolicyGroupEnabled() {
-		if err := (&controller.AdmissionPolicyGroupReconciler{
-			Client:               mgr.GetClient(),
-			Scheme:               mgr.GetScheme(),
-			Log:                  ctrl.Log.WithName("admission-policy-group-reconciler"),
-			DeploymentsNamespace: deploymentsNamespace,
-			FeatureGateAdmissionWebhookMatchConditions: featureGateAdmissionWebhookMatchConditions,
-		}).SetupWithManager(mgr); err != nil {
-			return errors.Join(errors.New("unable to create AdmissionPolicyGroup controller"), err)
-		}
+	if err := (&controller.AdmissionPolicyGroupReconciler{
+		Client:               mgr.GetClient(),
+		Scheme:               mgr.GetScheme(),
+		Log:                  ctrl.Log.WithName("admission-policy-group-reconciler"),
+		DeploymentsNamespace: deploymentsNamespace,
+		FeatureGateAdmissionWebhookMatchConditions: featureGateAdmissionWebhookMatchConditions,
+	}).SetupWithManager(mgr); err != nil {
+		return errors.Join(errors.New("unable to create AdmissionPolicyGroup controller"), err)
+	}
 
-		if err := (&controller.ClusterAdmissionPolicyGroupReconciler{
-			Client:               mgr.GetClient(),
-			Scheme:               mgr.GetScheme(),
-			Log:                  ctrl.Log.WithName("cluster-admission-policy-group-reconciler"),
-			DeploymentsNamespace: deploymentsNamespace,
-			FeatureGateAdmissionWebhookMatchConditions: featureGateAdmissionWebhookMatchConditions,
-		}).SetupWithManager(mgr); err != nil {
-			return errors.Join(errors.New("unable to create ClusterAdmissionPolicyGroup controller"), err)
-		}
+	if err := (&controller.ClusterAdmissionPolicyGroupReconciler{
+		Client:               mgr.GetClient(),
+		Scheme:               mgr.GetScheme(),
+		Log:                  ctrl.Log.WithName("cluster-admission-policy-group-reconciler"),
+		DeploymentsNamespace: deploymentsNamespace,
+		FeatureGateAdmissionWebhookMatchConditions: featureGateAdmissionWebhookMatchConditions,
+	}).SetupWithManager(mgr); err != nil {
+		return errors.Join(errors.New("unable to create ClusterAdmissionPolicyGroup controller"), err)
 	}
 	return nil
 }
@@ -309,18 +306,11 @@ func setupWebhooks(mgr ctrl.Manager, deploymentsNamespace string) error {
 	if err := (&policiesv1.AdmissionPolicy{}).SetupWebhookWithManager(mgr); err != nil {
 		return errors.Join(errors.New("unable to create webhook for admission policies"), err)
 	}
-	if isPolicyGroupEnabled() {
-		if err := (&policiesv1.AdmissionPolicyGroup{}).SetupWebhookWithManager(mgr); err != nil {
-			return errors.Join(errors.New("unable to create webhook for admission policies groups"), err)
-		}
-		if err := (&policiesv1.ClusterAdmissionPolicyGroup{}).SetupWebhookWithManager(mgr); err != nil {
-			return errors.Join(errors.New("unable to create webhook for cluster admission policies groups"), err)
-		}
+	if err := (&policiesv1.AdmissionPolicyGroup{}).SetupWebhookWithManager(mgr); err != nil {
+		return errors.Join(errors.New("unable to create webhook for admission policies groups"), err)
+	}
+	if err := (&policiesv1.ClusterAdmissionPolicyGroup{}).SetupWebhookWithManager(mgr); err != nil {
+		return errors.Join(errors.New("unable to create webhook for cluster admission policies groups"), err)
 	}
 	return nil
-}
-
-func isPolicyGroupEnabled() bool {
-	envVarValue := strings.ToLower(os.Getenv(constants.EnablePolicyGroupsFlag))
-	return envVarValue == "true" || envVarValue == "1"
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -78,7 +78,4 @@ const (
 	CACertExpiration     = 10 * 365 * 24 * time.Hour
 	ServerCertExpiration = 1 * 365 * 24 * time.Hour
 	CertLookahead        = 60 * 24 * time.Hour
-
-	// Feature flags.
-	EnablePolicyGroupsFlag = "KUBEWARDEN_ENABLE_POLICY_GROUPS"
 )


### PR DESCRIPTION
## Description

This reverts commit 0a7941173e5c8e6b42c2a3c15a873aba9c10835a. 
It removes the feature flag added in the past to enable policy group types.

Fix #857 
