### PR TITLE
fix: use a different name for ClusterAdmissionpolicyGroup unique name

### DIFF
--- a/api/policies/v1/admissionpolicygroup_types.go
+++ b/api/policies/v1/admissionpolicygroup_types.go
@@ -173,7 +173,7 @@ func (r *AdmissionPolicyGroup) GetPolicyServer() string {
 }
 
 func (r *AdmissionPolicyGroup) GetUniqueName() string {
-	return "namespacedpolicygroup-" + r.Namespace + "-" + r.Name
+	return "namespaced-group-" + r.Namespace + "-" + r.Name
 }
 
 func (r *AdmissionPolicyGroup) GetContextAwareResources() []ContextAwareResource {

--- a/api/policies/v1/clusteradmissionpolicygroup_types.go
+++ b/api/policies/v1/clusteradmissionpolicygroup_types.go
@@ -209,7 +209,7 @@ func (r *ClusterAdmissionPolicyGroup) GetPolicyServer() string {
 }
 
 func (r *ClusterAdmissionPolicyGroup) GetUniqueName() string {
-	return "clusterwide-" + r.Name
+	return "clusterwide-group-" + r.Name
 }
 
 func (r *ClusterAdmissionPolicyGroup) GetContextAwareResources() []ContextAwareResource {


### PR DESCRIPTION


## Description
This PR fixes the `ClusterAdmissionPolicyGroup` unique name so that it does not conflict with a `ClusterAdmissionPolicy` with the same name.