### PR TITLE
refactor: remove watches used only by integration tests

### DIFF
--- a/internal/controller/admissionpolicy_controller.go
+++ b/internal/controller/admissionpolicy_controller.go
@@ -81,14 +81,6 @@ func (r *AdmissionPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(r.findAdmissionPoliciesForPod),
 		).
-		// Despite this policy server watch is not strictly necessary, we
-		// include it for the integration tests, so that we identify
-		// policy server creations even when the controller-manager is not
-		// present (so no pods end up being created)
-		Watches(
-			&policiesv1.PolicyServer{},
-			handler.EnqueueRequestsFromMapFunc(r.findAdmissionPoliciesForPolicyServer),
-		).
 		Watches(
 			&admissionregistrationv1.ValidatingWebhookConfiguration{},
 			handler.EnqueueRequestsFromMapFunc(r.findAdmissionPolicyForWebhookConfiguration),
@@ -108,9 +100,7 @@ func (r *AdmissionPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *AdmissionPolicyReconciler) findAdmissionPoliciesForPod(ctx context.Context, object client.Object) []reconcile.Request {
 	return findPoliciesForPod(ctx, r.Client, object)
 }
-func (r *AdmissionPolicyReconciler) findAdmissionPoliciesForPolicyServer(ctx context.Context, object client.Object) []reconcile.Request {
-	return findPoliciesForPolicyServer(ctx, r.Client, object, r.DeploymentsNamespace)
-}
+
 func (r *AdmissionPolicyReconciler) findAdmissionPolicyForWebhookConfiguration(_ context.Context, webhookConfiguration client.Object) []reconcile.Request {
 	return findPolicyForWebhookConfiguration(webhookConfiguration, r.Log)
 }

--- a/internal/controller/admissionpolicygroup_controller.go
+++ b/internal/controller/admissionpolicygroup_controller.go
@@ -81,14 +81,6 @@ func (r *AdmissionPolicyGroupReconciler) SetupWithManager(mgr ctrl.Manager) erro
 			&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(r.findAdmissionPoliciesForPod),
 		).
-		// Despite this policy server watch is not strictly necessary, we
-		// include it for the integration tests, so that we identify
-		// policy server creations even when the controller-manager is not
-		// present (so no pods end up being created)
-		Watches(
-			&policiesv1.PolicyServer{},
-			handler.EnqueueRequestsFromMapFunc(r.findAdmissionPoliciesForPolicyServer),
-		).
 		Watches(
 			&admissionregistrationv1.ValidatingWebhookConfiguration{},
 			handler.EnqueueRequestsFromMapFunc(r.findAdmissionPolicyForWebhookConfiguration),
@@ -103,10 +95,6 @@ func (r *AdmissionPolicyGroupReconciler) SetupWithManager(mgr ctrl.Manager) erro
 
 func (r *AdmissionPolicyGroupReconciler) findAdmissionPoliciesForPod(ctx context.Context, object client.Object) []reconcile.Request {
 	return findPoliciesForPod(ctx, r.Client, object)
-}
-
-func (r *AdmissionPolicyGroupReconciler) findAdmissionPoliciesForPolicyServer(ctx context.Context, object client.Object) []reconcile.Request {
-	return findPoliciesForPolicyServer(ctx, r.Client, object, r.DeploymentsNamespace)
 }
 
 func (r *AdmissionPolicyGroupReconciler) findAdmissionPolicyForWebhookConfiguration(_ context.Context, webhookConfiguration client.Object) []reconcile.Request {

--- a/internal/controller/clusteradmissionpolicy_controller.go
+++ b/internal/controller/clusteradmissionpolicy_controller.go
@@ -81,14 +81,6 @@ func (r *ClusterAdmissionPolicyReconciler) SetupWithManager(mgr ctrl.Manager) er
 			&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(r.findClusterAdmissionPoliciesForPod),
 		).
-		// Despite this policy server watch is not strictly necessary, we
-		// include it for the integration tests, so that we identify
-		// policy server creations even when the controller-manager is not
-		// present (so no pods end up being created)
-		Watches(
-			&policiesv1.PolicyServer{},
-			handler.EnqueueRequestsFromMapFunc(r.findClusterAdmissionPoliciesForPolicyServer),
-		).
 		Watches(
 			&admissionregistrationv1.ValidatingWebhookConfiguration{},
 			handler.EnqueueRequestsFromMapFunc(r.findClusterAdmissionPolicyForWebhookConfiguration),
@@ -107,9 +99,7 @@ func (r *ClusterAdmissionPolicyReconciler) SetupWithManager(mgr ctrl.Manager) er
 func (r *ClusterAdmissionPolicyReconciler) findClusterAdmissionPoliciesForPod(ctx context.Context, object client.Object) []reconcile.Request {
 	return findClusterPoliciesForPod(ctx, r.Client, object)
 }
-func (r *ClusterAdmissionPolicyReconciler) findClusterAdmissionPoliciesForPolicyServer(ctx context.Context, object client.Object) []reconcile.Request {
-	return findClusterPoliciesForPolicyServer(ctx, r.Client, object, r.DeploymentsNamespace)
-}
+
 func (r *ClusterAdmissionPolicyReconciler) findClusterAdmissionPolicyForWebhookConfiguration(_ context.Context, webhookConfiguration client.Object) []reconcile.Request {
 	return findClusterPolicyForWebhookConfiguration(webhookConfiguration, r.Log)
 }

--- a/internal/controller/clusteradmissionpolicygroup_controller.go
+++ b/internal/controller/clusteradmissionpolicygroup_controller.go
@@ -81,14 +81,6 @@ func (r *ClusterAdmissionPolicyGroupReconciler) SetupWithManager(mgr ctrl.Manage
 			&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(r.findClusterAdmissionPoliciesForPod),
 		).
-		// Despite this policy server watch is not strictly necessary, we
-		// include it for the integration tests, so that we identify
-		// policy server creations even when the controller-manager is not
-		// present (so no pods end up being created)
-		Watches(
-			&policiesv1.PolicyServer{},
-			handler.EnqueueRequestsFromMapFunc(r.findClusterAdmissionPoliciesForPolicyServer),
-		).
 		Watches(
 			&admissionregistrationv1.ValidatingWebhookConfiguration{},
 			handler.EnqueueRequestsFromMapFunc(r.findClusterAdmissionPolicyForWebhookConfiguration),
@@ -103,9 +95,7 @@ func (r *ClusterAdmissionPolicyGroupReconciler) SetupWithManager(mgr ctrl.Manage
 func (r *ClusterAdmissionPolicyGroupReconciler) findClusterAdmissionPoliciesForPod(ctx context.Context, object client.Object) []reconcile.Request {
 	return findClusterPoliciesForPod(ctx, r.Client, object)
 }
-func (r *ClusterAdmissionPolicyGroupReconciler) findClusterAdmissionPoliciesForPolicyServer(ctx context.Context, object client.Object) []reconcile.Request {
-	return findClusterPoliciesForPolicyServer(ctx, r.Client, object, r.DeploymentsNamespace)
-}
+
 func (r *ClusterAdmissionPolicyGroupReconciler) findClusterAdmissionPolicyForWebhookConfiguration(_ context.Context, webhookConfiguration client.Object) []reconcile.Request {
 	return findClusterPolicyForWebhookConfiguration(webhookConfiguration, r.Log)
 }

--- a/internal/controller/policy_subreconciler.go
+++ b/internal/controller/policy_subreconciler.go
@@ -349,23 +349,6 @@ func findClusterPoliciesForPod(ctx context.Context, k8sClient client.Client, obj
 	return findClusterPoliciesForConfigMap(&configMap)
 }
 
-func findClusterPoliciesForPolicyServer(ctx context.Context, k8sClient client.Client, object client.Object, namespace string) []reconcile.Request {
-	policyServer, ok := object.(*policiesv1.PolicyServer)
-	if !ok {
-		return []reconcile.Request{}
-	}
-	policyServerDeploymentName := policyServerDeploymentName(policyServer.Name)
-	configMap := corev1.ConfigMap{}
-	err := k8sClient.Get(ctx, client.ObjectKey{
-		Namespace: namespace,
-		Name:      policyServerDeploymentName, // As the deployment name matches the name of the ConfigMap
-	}, &configMap)
-	if err != nil {
-		return []reconcile.Request{}
-	}
-	return findClusterPoliciesForConfigMap(&configMap)
-}
-
 func findClusterPolicyForWebhookConfiguration(webhookConfiguration client.Object, log logr.Logger) []reconcile.Request {
 	// Pre v1.16.0
 	_, kubwardenLabelExists := webhookConfiguration.GetLabels()["kubewarden"]
@@ -401,23 +384,6 @@ func findClusterPolicyForWebhookConfiguration(webhookConfiguration client.Object
 			},
 		},
 	}
-}
-
-func findPoliciesForPolicyServer(ctx context.Context, k8sClient client.Client, object client.Object, namespace string) []reconcile.Request {
-	policyServer, ok := object.(*policiesv1.PolicyServer)
-	if !ok {
-		return []reconcile.Request{}
-	}
-	policyServerDeploymentName := policyServerDeploymentName(policyServer.Name)
-	configMap := corev1.ConfigMap{}
-	err := k8sClient.Get(ctx, client.ObjectKey{
-		Namespace: namespace,
-		Name:      policyServerDeploymentName, // As the deployment name matches the name of the ConfigMap
-	}, &configMap)
-	if err != nil {
-		return []reconcile.Request{}
-	}
-	return findPoliciesForConfigMap(&configMap)
 }
 
 func findPolicyForWebhookConfiguration(webhookConfiguration client.Object, log logr.Logger) []reconcile.Request {


### PR DESCRIPTION
These watches were used a long time ago by the integration tests, they are not needed anymore.

Their removal redeuces the resource usage when running in production.
