### PR TITLE
fix: add group annotation to WebhookConfiguration and filter watch requests 

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -53,6 +53,7 @@ const (
 	WebhookConfigurationPolicyNameAnnotationKey      = "kubewardenPolicyName"
 	WebhookConfigurationPolicyNamespaceAnnotationKey = "kubewardenPolicyNamespace"
 	WebhookConfigurationPolicyGroupAnnotationKey     = "kubewardenPolicyGroup"
+	True                                             = "true"
 
 	// Scope.
 	NamespacePolicyScope = "namespace"

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -52,6 +52,7 @@ const (
 	WebhookConfigurationPolicyScopeLabelKey          = "kubewardenPolicyScope"
 	WebhookConfigurationPolicyNameAnnotationKey      = "kubewardenPolicyName"
 	WebhookConfigurationPolicyNamespaceAnnotationKey = "kubewardenPolicyNamespace"
+	WebhookConfigurationPolicyGroupAnnotationKey     = "kubewardenPolicyGroup"
 
 	// Scope.
 	NamespacePolicyScope = "namespace"

--- a/internal/controller/admissionpolicy_controller.go
+++ b/internal/controller/admissionpolicy_controller.go
@@ -102,5 +102,5 @@ func (r *AdmissionPolicyReconciler) findAdmissionPoliciesForPod(ctx context.Cont
 }
 
 func (r *AdmissionPolicyReconciler) findAdmissionPolicyForWebhookConfiguration(_ context.Context, webhookConfiguration client.Object) []reconcile.Request {
-	return findPolicyForWebhookConfiguration(webhookConfiguration, r.Log)
+	return findPolicyForWebhookConfiguration(webhookConfiguration, false, r.Log)
 }

--- a/internal/controller/admissionpolicygroup_controller.go
+++ b/internal/controller/admissionpolicygroup_controller.go
@@ -98,5 +98,5 @@ func (r *AdmissionPolicyGroupReconciler) findAdmissionPoliciesForPod(ctx context
 }
 
 func (r *AdmissionPolicyGroupReconciler) findAdmissionPolicyForWebhookConfiguration(_ context.Context, webhookConfiguration client.Object) []reconcile.Request {
-	return findPolicyForWebhookConfiguration(webhookConfiguration, r.Log)
+	return findPolicyForWebhookConfiguration(webhookConfiguration, true, r.Log)
 }

--- a/internal/controller/admissionpolicygroup_controller_test.go
+++ b/internal/controller/admissionpolicygroup_controller_test.go
@@ -84,6 +84,7 @@ var _ = Describe("AdmissionPolicyGroup controller", Label("real-cluster"), func(
 
 				Expect(validatingWebhookConfiguration.Labels[constants.PartOfLabelKey]).To(Equal(constants.PartOfLabelValue))
 				Expect(validatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey]).To(Equal(constants.NamespacePolicyScope))
+				Expect(validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyGroupAnnotationKey]).To(Equal(constants.True))
 				Expect(validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNameAnnotationKey]).To(Equal(policyName))
 				Expect(validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey]).To(Equal(policyNamespace))
 				Expect(validatingWebhookConfiguration.Webhooks).To(HaveLen(1))
@@ -114,6 +115,7 @@ var _ = Describe("AdmissionPolicyGroup controller", Label("real-cluster"), func(
 			By("changing the ValidatingWebhookConfiguration")
 			delete(validatingWebhookConfiguration.Labels, constants.PartOfLabelKey)
 			validatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey] = newName("scope")
+			validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyGroupAnnotationKey] = "false"
 			delete(validatingWebhookConfiguration.Annotations, constants.WebhookConfigurationPolicyNameAnnotationKey)
 			validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey] = newName("namespace")
 			validatingWebhookConfiguration.Webhooks[0].ClientConfig.Service.Name = newName("service")

--- a/internal/controller/clusteradmissionpolicy_controller.go
+++ b/internal/controller/clusteradmissionpolicy_controller.go
@@ -101,5 +101,5 @@ func (r *ClusterAdmissionPolicyReconciler) findClusterAdmissionPoliciesForPod(ct
 }
 
 func (r *ClusterAdmissionPolicyReconciler) findClusterAdmissionPolicyForWebhookConfiguration(_ context.Context, webhookConfiguration client.Object) []reconcile.Request {
-	return findClusterPolicyForWebhookConfiguration(webhookConfiguration, r.Log)
+	return findClusterPolicyForWebhookConfiguration(webhookConfiguration, false, r.Log)
 }

--- a/internal/controller/clusteradmissionpolicygroup_controller.go
+++ b/internal/controller/clusteradmissionpolicygroup_controller.go
@@ -97,5 +97,5 @@ func (r *ClusterAdmissionPolicyGroupReconciler) findClusterAdmissionPoliciesForP
 }
 
 func (r *ClusterAdmissionPolicyGroupReconciler) findClusterAdmissionPolicyForWebhookConfiguration(_ context.Context, webhookConfiguration client.Object) []reconcile.Request {
-	return findClusterPolicyForWebhookConfiguration(webhookConfiguration, r.Log)
+	return findClusterPolicyForWebhookConfiguration(webhookConfiguration, true, r.Log)
 }

--- a/internal/controller/clusteradmissionpolicygroup_controller_test.go
+++ b/internal/controller/clusteradmissionpolicygroup_controller_test.go
@@ -72,6 +72,7 @@ var _ = Describe("ClusterAdmissionPolicyGroup controller", Label("real-cluster")
 
 				Expect(validatingWebhookConfiguration.Labels[constants.PartOfLabelKey]).To(Equal(constants.PartOfLabelValue))
 				Expect(validatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey]).To(Equal(constants.ClusterPolicyScope))
+				Expect(validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyGroupAnnotationKey]).To(Equal(constants.True))
 				Expect(validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNameAnnotationKey]).To(Equal(policyName))
 				Expect(validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey]).To(BeEmpty())
 				Expect(validatingWebhookConfiguration.Webhooks).To(HaveLen(1))
@@ -108,6 +109,7 @@ var _ = Describe("ClusterAdmissionPolicyGroup controller", Label("real-cluster")
 
 			delete(validatingWebhookConfiguration.Labels, constants.PartOfLabelKey)
 			validatingWebhookConfiguration.Labels[constants.WebhookConfigurationPolicyScopeLabelKey] = newName("scope")
+			validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyGroupAnnotationKey] = "false"
 			delete(validatingWebhookConfiguration.Annotations, constants.WebhookConfigurationPolicyNameAnnotationKey)
 			validatingWebhookConfiguration.Annotations[constants.WebhookConfigurationPolicyNamespaceAnnotationKey] = newName("namespace")
 			validatingWebhookConfiguration.Webhooks[0].ClientConfig.Service.Name = newName("service")

--- a/internal/controller/policy_subreconciler.go
+++ b/internal/controller/policy_subreconciler.go
@@ -434,11 +434,11 @@ func hasKubewardenLabel(labels map[string]string) bool {
 	// From v1.16.0 on we are using the recommended label "app.kubernetes.io/part-of"
 	partOfLabel := labels[constants.PartOfLabelKey]
 
-	return kubewardenLabel == "true" || partOfLabel == constants.PartOfLabelValue
+	return kubewardenLabel == constants.True || partOfLabel == constants.PartOfLabelValue
 }
 
 func hasGroupAnnotation(annotations map[string]string) bool {
-	return annotations[constants.WebhookConfigurationPolicyGroupAnnotationKey] == "true"
+	return annotations[constants.WebhookConfigurationPolicyGroupAnnotationKey] == constants.True
 }
 
 func getPolicyMapFromConfigMap(configMap *corev1.ConfigMap) (policyConfigEntryMap, error) {

--- a/internal/controller/policy_subreconciler_webhook.go
+++ b/internal/controller/policy_subreconciler_webhook.go
@@ -18,7 +18,6 @@ import (
 
 //+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=create;delete;list;patch;watch
 
-//nolint:dupl // This function is similar to the other reconcileMutatingWebhookConfiguration
 func (r *policySubReconciler) reconcileValidatingWebhookConfiguration(
 	ctx context.Context,
 	policy policiesv1.Policy,
@@ -111,7 +110,6 @@ func (r *policySubReconciler) reconcileValidatingWebhookConfigurationDeletion(ct
 
 //+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,verbs=create;delete;list;patch;watch
 
-//nolint:dupl // This function is similar to the other reconcileValidatingWebhookConfiguration
 func (r *policySubReconciler) reconcileMutatingWebhookConfiguration(
 	ctx context.Context,
 	policy policiesv1.Policy,

--- a/internal/controller/policy_subreconciler_webhook.go
+++ b/internal/controller/policy_subreconciler_webhook.go
@@ -60,7 +60,7 @@ func (r *policySubReconciler) reconcileValidatingWebhookConfiguration(
 			constants.WebhookConfigurationPolicyNamespaceAnnotationKey: policy.GetNamespace(),
 		}
 		if _, ok := policy.(policiesv1.PolicyGroup); ok {
-			webhook.Annotations[constants.WebhookConfigurationPolicyGroupAnnotationKey] = "true"
+			webhook.Annotations[constants.WebhookConfigurationPolicyGroupAnnotationKey] = constants.True
 		}
 		webhook.Webhooks = []admissionregistrationv1.ValidatingWebhook{
 			{

--- a/internal/controller/policy_subreconciler_webhook.go
+++ b/internal/controller/policy_subreconciler_webhook.go
@@ -60,6 +60,9 @@ func (r *policySubReconciler) reconcileValidatingWebhookConfiguration(
 			constants.WebhookConfigurationPolicyNameAnnotationKey:      policy.GetName(),
 			constants.WebhookConfigurationPolicyNamespaceAnnotationKey: policy.GetNamespace(),
 		}
+		if _, ok := policy.(policiesv1.PolicyGroup); ok {
+			webhook.Annotations[constants.WebhookConfigurationPolicyGroupAnnotationKey] = "true"
+		}
 		webhook.Webhooks = []admissionregistrationv1.ValidatingWebhook{
 			{
 				Name: policy.GetUniqueName() + ".kubewarden.admission",


### PR DESCRIPTION
## Description

This PR adds a group annotation to ValidatingWebhookConfiguration and MutatingWebhookConfiguration for policy groups, enabling us to filter watch requests sent to the respective reconcilers.