### PR TITLE
feat: shortName for the CRDs.

### DIFF
--- a/api/policies/v1/admissionpolicy_types.go
+++ b/api/policies/v1/admissionpolicy_types.go
@@ -30,7 +30,7 @@ type AdmissionPolicySpec struct {
 // AdmissionPolicy is the Schema for the admissionpolicies API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:resource:scope=Namespaced,shortName=ap
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Policy Server",type=string,JSONPath=`.spec.policyServer`,description="Bound to Policy Server"
 // +kubebuilder:printcolumn:name="Mutating",type=boolean,JSONPath=`.spec.mutating`,description="Whether the policy is mutating"

--- a/api/policies/v1/admissionpolicygroup_types.go
+++ b/api/policies/v1/admissionpolicygroup_types.go
@@ -30,7 +30,7 @@ type AdmissionPolicyGroupSpec struct {
 // AdmissionPolicyGroup is the Schema for the AdmissionPolicyGroups API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:resource:scope=Namespaced,shortName=apg
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Policy Server",type=string,JSONPath=`.spec.policyServer`,description="Bound to Policy Server"
 // +kubebuilder:printcolumn:name="Mutating",type=boolean,JSONPath=`.spec.mutating`,description="Whether the policy is mutating"

--- a/api/policies/v1/clusteradmissionpolicy_types.go
+++ b/api/policies/v1/clusteradmissionpolicy_types.go
@@ -93,7 +93,7 @@ type ClusterAdmissionPolicySpec struct {
 // ClusterAdmissionPolicy is the Schema for the clusteradmissionpolicies API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName=cap
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Policy Server",type=string,JSONPath=`.spec.policyServer`,description="Bound to Policy Server"
 // +kubebuilder:printcolumn:name="Mutating",type=boolean,JSONPath=`.spec.mutating`,description="Whether the policy is mutating"

--- a/api/policies/v1/clusteradmissionpolicygroup_types.go
+++ b/api/policies/v1/clusteradmissionpolicygroup_types.go
@@ -78,7 +78,7 @@ type ClusterAdmissionPolicyGroupSpec struct {
 // ClusterAdmissionPolicyGroup is the Schema for the clusteradmissionpolicies API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName=capg
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Policy Server",type=string,JSONPath=`.spec.policyServer`,description="Bound to Policy Server"
 // +kubebuilder:printcolumn:name="Mutating",type=boolean,JSONPath=`.spec.mutating`,description="Whether the policy is mutating"

--- a/api/policies/v1/policyserver_types.go
+++ b/api/policies/v1/policyserver_types.go
@@ -168,7 +168,7 @@ type PolicyServerStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
+//+kubebuilder:resource:scope=Cluster,shortName=ps
 //+kubebuilder:printcolumn:name="Replicas",type=string,JSONPath=`.spec.replicas`,description="Policy Server replicas"
 //+kubebuilder:printcolumn:name="Image",type=string,JSONPath=`.spec.image`,description="Policy Server image"
 //+kubebuilder:storageversion

--- a/api/policies/v1alpha2/admissionpolicy_types.go
+++ b/api/policies/v1alpha2/admissionpolicy_types.go
@@ -30,12 +30,13 @@ type AdmissionPolicySpec struct {
 // AdmissionPolicy is the Schema for the admissionpolicies API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:resource:scope=Namespaced,shortName=ap
 // +kubebuilder:printcolumn:name="Policy Server",type=string,JSONPath=`.spec.policyServer`,description="Bound to Policy Server"
 // +kubebuilder:printcolumn:name="Mutating",type=boolean,JSONPath=`.spec.mutating`,description="Whether the policy is mutating"
 // +kubebuilder:printcolumn:name="Mode",type=string,JSONPath=`.spec.mode`,description="Policy deployment mode"
 // +kubebuilder:printcolumn:name="Observed mode",type=string,JSONPath=`.status.mode`,description="Policy deployment mode observed on the assigned Policy Server"
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.policyStatus`,description="Status of the policy"
+// +kubebuilder:deprecatedversion:warning="This version is deprecated. Please, consider using v1"
 type AdmissionPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/policies/v1alpha2/clusteradmissionpolicy_types.go
+++ b/api/policies/v1alpha2/clusteradmissionpolicy_types.go
@@ -77,12 +77,13 @@ type ClusterAdmissionPolicySpec struct {
 // ClusterAdmissionPolicy is the Schema for the clusteradmissionpolicies API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName=cap
 // +kubebuilder:printcolumn:name="Policy Server",type=string,JSONPath=`.spec.policyServer`,description="Bound to Policy Server"
 // +kubebuilder:printcolumn:name="Mutating",type=boolean,JSONPath=`.spec.mutating`,description="Whether the policy is mutating"
 // +kubebuilder:printcolumn:name="Mode",type=string,JSONPath=`.spec.mode`,description="Policy deployment mode"
 // +kubebuilder:printcolumn:name="Observed mode",type=string,JSONPath=`.status.mode`,description="Policy deployment mode observed on the assigned Policy Server"
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.policyStatus`,description="Status of the policy"
+// +kubebuilder:deprecatedversion:warning="This version is deprecated. Please, consider using v1"
 type ClusterAdmissionPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/policies/v1alpha2/policyserver_types.go
+++ b/api/policies/v1alpha2/policyserver_types.go
@@ -118,9 +118,10 @@ type PolicyServerStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
+//+kubebuilder:resource:scope=Cluster,shortName=ps
 //+kubebuilder:printcolumn:name="Replicas",type=string,JSONPath=`.spec.replicas`,description="Policy Server replicas"
 //+kubebuilder:printcolumn:name="Image",type=string,JSONPath=`.spec.image`,description="Policy Server image"
+// +kubebuilder:deprecatedversion:warning="This version is deprecated. Please, consider using v1"
 
 // PolicyServer is the Schema for the policyservers API.
 type PolicyServer struct {

--- a/config/crd/bases/policies.kubewarden.io_admissionpolicies.yaml
+++ b/config/crd/bases/policies.kubewarden.io_admissionpolicies.yaml
@@ -11,6 +11,8 @@ spec:
     kind: AdmissionPolicy
     listKind: AdmissionPolicyList
     plural: admissionpolicies
+    shortNames:
+    - ap
     singular: admissionpolicy
   scope: Namespaced
   versions:
@@ -474,6 +476,8 @@ spec:
       jsonPath: .status.policyStatus
       name: Status
       type: string
+    deprecated: true
+    deprecationWarning: This version is deprecated. Please, consider using v1
     name: v1alpha2
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/policies.kubewarden.io_admissionpolicygroups.yaml
+++ b/config/crd/bases/policies.kubewarden.io_admissionpolicygroups.yaml
@@ -11,6 +11,8 @@ spec:
     kind: AdmissionPolicyGroup
     listKind: AdmissionPolicyGroupList
     plural: admissionpolicygroups
+    shortNames:
+    - apg
     singular: admissionpolicygroup
   scope: Namespaced
   versions:

--- a/config/crd/bases/policies.kubewarden.io_clusteradmissionpolicies.yaml
+++ b/config/crd/bases/policies.kubewarden.io_clusteradmissionpolicies.yaml
@@ -11,6 +11,8 @@ spec:
     kind: ClusterAdmissionPolicy
     listKind: ClusterAdmissionPolicyList
     plural: clusteradmissionpolicies
+    shortNames:
+    - cap
     singular: clusteradmissionpolicy
   scope: Cluster
   versions:
@@ -586,6 +588,8 @@ spec:
       jsonPath: .status.policyStatus
       name: Status
       type: string
+    deprecated: true
+    deprecationWarning: This version is deprecated. Please, consider using v1
     name: v1alpha2
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/policies.kubewarden.io_clusteradmissionpolicygroups.yaml
+++ b/config/crd/bases/policies.kubewarden.io_clusteradmissionpolicygroups.yaml
@@ -11,6 +11,8 @@ spec:
     kind: ClusterAdmissionPolicyGroup
     listKind: ClusterAdmissionPolicyGroupList
     plural: clusteradmissionpolicygroups
+    shortNames:
+    - capg
     singular: clusteradmissionpolicygroup
   scope: Cluster
   versions:

--- a/config/crd/bases/policies.kubewarden.io_policyservers.yaml
+++ b/config/crd/bases/policies.kubewarden.io_policyservers.yaml
@@ -11,6 +11,8 @@ spec:
     kind: PolicyServer
     listKind: PolicyServerList
     plural: policyservers
+    shortNames:
+    - ps
     singular: policyserver
   scope: Cluster
   versions:
@@ -1719,6 +1721,8 @@ spec:
       jsonPath: .spec.image
       name: Image
       type: string
+    deprecated: true
+    deprecationWarning: This version is deprecated. Please, consider using v1
     name: v1alpha2
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
## Description

Adds shortName for the Kubewarden CRDs. This allows users to get Kubewarden types using acronymous and making the commands smaller to type.

@kubewarden/kubewarden-developers I'm creating this PR as draft because I would like to investigate why `controller-gen` is not updating the CRDs with the `shortNames` for some CRDs. However, I would like to know if you are fine with the proposed `shortNames`. I've prefixed all of them with `k` to flag this is a `kubewarden` resource.  

