### PR TITLE
fix: do not exit when k8s' matchConditions are not available

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -138,8 +138,6 @@ func main() {
 	featureGateAdmissionWebhookMatchConditions, err := featuregates.CheckAdmissionWebhookMatchConditions(ctrl.GetConfigOrDie())
 	if err != nil {
 		setupLog.Error(err, "unable to check for feature gate AdmissionWebhookMatchConditions")
-		retcode = 1
-		return
 	}
 
 	if err = setupReconcilers(mgr, deploymentsNamespace, webhookServiceName, enableMetrics, enableTracing, alwaysAcceptAdmissionReviewsOnDeploymentsNamespace, featureGateAdmissionWebhookMatchConditions); err != nil {


### PR DESCRIPTION
Do not exit with an error when the `matchConditions` field is not available for ValidatingWebhookConfiguration and MutatingWebhookConfiguration.

The code is already structured to work when this feature is not available, hence we don't have to cause the controller to exit with an
error.

Fixes https://github.com/kubewarden/kubewarden-controller/issues/900
