### PR TITLE
chore: Kubewarden release issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/kubewarden-release.yml
+++ b/.github/ISSUE_TEMPLATE/kubewarden-release.yml
@@ -1,0 +1,34 @@
+name: Kubewarden Release
+title: "Kubewarden <VERSION> release"
+description: Issue with all the items needed to release a new version of Kubewarden
+projects: ["kubewarden/6"]
+labels: ["kind/chore"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This issue tracks the release of a new version of Kubewarden. 
+
+  - type: textarea
+    attributes:
+      label: Checklist
+      description: Base checklist for the release process. Please, add or remove items as needed.
+      value: |
+        This issue tracks the release of a new version of Kubewarden. Please follow the checklist below to ensure a smooth release process.
+        - [ ] Bump policy server version in the `Cargo.toml`.
+        - [ ] Policy Server CI is green
+        - [ ] Tag policy server
+        - [ ] Bump kwctl version in the `Cargo.toml`
+        - [ ] Kwctl CI is green
+        - [ ] Tag kwctl
+        - [ ] Controller CI is green
+        - [ ] Tag controller
+        - [ ] Audit scanner code is using the correct version of the kubewarden-controller package
+        - [ ] Audit scanner CI is green
+        - [ ] Tag audit scanner
+        - [ ] Check if the Helm chart repository CI open a PR updating the Helm charts with the correct changes.
+          - [ ] Check if the `kubewarden-controller`, `kubewarden-defaults` and `kubewarden-crds` chart versions are correctly bumped
+          - [ ] Check if kubewarden-controller, kubewarden-defaults and kubewarden-crds charts have the same `appVersion`
+          - [ ] Check if CI for the Helm chart PR is green. If so, merge it.
+        - [ ] Write and release the blog post about the release


### PR DESCRIPTION
## Description

Adds an issue template with the base checklist needed to properly release a Kubewarden version.

This is an [example](https://github.com/jvanz/kubewarden-controller/issues/31) of the issue submitted with no change in the form filled by the user.

This is inspired by https://github.com/kubewarden/community/pull/29