### PR TITLE
Remote otel collector configuration

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -39,12 +39,20 @@ for role in roles:
 if len(roles_rules_mapping["ClusterRole"]) == 0 or len(roles_rules_mapping["Role"]) == 0:
     fail("Failed to load cluster and namespace roles")
 
+additional_helm_installation_args = {}
+# If the user provided a values file, use it in the helm installation
+userProvidedValues = settings.get("controller_values_file")
+if userProvidedValues:
+	if not os.path.exists(userProvidedValues):
+		fail("The provided values file does not exist")
+	additional_helm_installation_args["values"] = userProvidedValues
 # Install kubewarden-controller helm chart
 install = helm(
     settings.get('helm_charts_path') + '/charts/kubewarden-controller/', 
     name='kubewarden-controller', 
     namespace='kubewarden', 
     set=['image.repository=' + settings.get('image'), 'global.cattle.systemDefaultRegistry=' + settings.get('registry')]
+    , **additional_helm_installation_args
 )
 
 objects = decode_yaml_stream(install)

--- a/internal/controller/policy_subreconciler.go
+++ b/internal/controller/policy_subreconciler.go
@@ -349,7 +349,6 @@ func findClusterPoliciesForPod(ctx context.Context, k8sClient client.Client, obj
 	return findClusterPoliciesForConfigMap(&configMap)
 }
 
-//nolint:goconst // we don't want to use a constant for "true"
 func hasKubewardenLabel(labels map[string]string) bool {
 	// Pre v1.16.0
 	kubewardenLabel := labels["kubewarden"]

--- a/internal/controller/policyserver_controller.go
+++ b/internal/controller/policyserver_controller.go
@@ -56,12 +56,27 @@ import (
 // PolicyServerReconciler reconciles a PolicyServer object.
 type PolicyServerReconciler struct {
 	client.Client
+	TelemetryConfiguration
 	Log                                                logr.Logger
 	Scheme                                             *runtime.Scheme
 	DeploymentsNamespace                               string
 	AlwaysAcceptAdmissionReviewsInDeploymentsNamespace bool
-	MetricsEnabled                                     bool
-	TracingEnabled                                     bool
+}
+
+// TelemetryConfiguration is a struct that contains the configuration for the
+// Telemetry configuration. Now, it only contains the configuration for the
+// OpenTelemetry.
+type TelemetryConfiguration struct {
+	MetricsEnabled bool
+	TracingEnabled bool
+	// OpenTelemetry configuration.
+	// OtelSidecarEnabled is a flag that enables the OpenTelemetry sidecar.
+	OtelSidecarEnabled bool
+	// OtelCertificateSecret and OtelClientCertificateSecret are the names of the
+	// secrets that contain the certificates used with the communication between
+	// controller and policy server with the remote OpenTelemetry collector.
+	OtelCertificateSecret       string
+	OtelClientCertificateSecret string
 }
 
 func (r *PolicyServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -21,13 +21,13 @@ const (
 	timeBetweenExports             = 2 * time.Second
 )
 
-func New(openTelemetryEndpoint string) (func(context.Context) error, error) {
+func New() (func(context.Context) error, error) {
 	ctx := context.Background()
 
+	// Create the OTLP exporter to export metrics to the specified endpoint.
+	// All the Otel exporter configuration is set by environment variables.
 	exporter, err := otlpmetricgrpc.New(
 		ctx,
-		otlpmetricgrpc.WithInsecure(),
-		otlpmetricgrpc.WithEndpoint(openTelemetryEndpoint),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot start metric exporter: %w", err)

--- a/tilt-settings.yaml.example
+++ b/tilt-settings.yaml.example
@@ -2,3 +2,4 @@ registry: ghcr.io
 image: <your github handle>/kubewarden-controller
 helm_charts_path: ../helm-charts/
 audit_scanner_path: ../audit-scanner/
+controller_values_file: your-kubewarden-controller-helm-chart-values.yaml


### PR DESCRIPTION
## Description

Updates the collector to allow the communication with a remote OpenTelemetry collector. Also updates the policy server reconciler to replicate the same configuration in the policy server deployment enabling it to send data to the same remote Otel collector.

Fix #933 

## Tests

> [!WARNING]  
> This PR was tested together with the changes from [this](https://github.com/kubewarden/helm-charts/pull/581) Helm chart changes

Create a simple cluster with required dependencies:

```
k3d cluster create 

helm repo add jetstack https://charts.jetstack.io --force-update
helm upgrade -i --wait cert-manager jetstack/cert-manager \
        -n cert-manager --create-namespace \
        --set crds.enabled=true

helm repo add --force-update open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
helm upgrade -i --wait my-opentelemetry-operator open-telemetry/opentelemetry-operator \
        --set "manager.collectorImage.repository=otel/opentelemetry-collector-contrib" \
        -n open-telemetry --create-namespace
```

I've tested this changes with this Otel collector configuration

```yaml
# cert-manager resources
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: my-client-certificate
  namespace: kubewarden
spec:
  dnsNames:
  - my-collector-collector.kubewarden.svc
  - my-collector-collector.kubewarden.svc.cluster.local
  issuerRef:
    kind: Issuer
    name: my-client-selfsigned-issuer
  secretName: my-client-cert
---
apiVersion: cert-manager.io/v1
kind: Issuer
metadata:
  name: my-client-selfsigned-issuer
  namespace: kubewarden
spec:
  selfSigned: {}
---
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: my-certificate
  namespace: kubewarden
spec:
  dnsNames:
  - my-collector-collector.kubewarden.svc
  - my-collector-collector.kubewarden.svc.cluster.local
  issuerRef:
    kind: Issuer
    name: my-selfsigned-issuer
  secretName: my-server-cert
---
apiVersion: cert-manager.io/v1
kind: Issuer
metadata:
  name: my-selfsigned-issuer
  namespace: kubewarden
spec:
  selfSigned: {}
---
apiVersion: opentelemetry.io/v1beta1
kind: OpenTelemetryCollector
metadata:
  name: my-collector
  namespace: kubewarden
spec:
  mode: deployment # This configuration is omittable.
  volumes:
    - name: server-certificate
      secret:
        secretName: my-server-cert
    - name: client-certificate
      secret:
        secretName: my-client-cert
  volumeMounts:
    - name: server-certificate
      mountPath: /tmp/etc/ssl/certs/my-server-cert
      readOnly: true
    - name: client-certificate
      mountPath: /tmp/etc/ssl/certs/my-client-cert
      readOnly: true
  config:
    receivers:
      otlp:
        protocols:
          grpc:
            tls:
              cert_file: /tmp/etc/ssl/certs/my-server-cert/tls.crt
              key_file: /tmp/etc/ssl/certs/my-server-cert/tls.key
              client_ca_file: /tmp/etc/ssl/certs/my-client-cert/ca.crt
              # ca_file: /tmp/etc/ssl/certs/my-server-cert/ca.crt
              # client_ca_file_reload: true
    processors: {}
    exporters:
      debug:
        verbosity: normal
      prometheus:
        endpoint: ":8080"
    service:
      pipelines:
        metrics:
          receivers: [otlp]
          processors: []
          exporters: [debug, prometheus]
        traces:
          receivers: [otlp]
          processors: []
          exporters: [debug]

```
