### PR TITLE
fix: rename "url" field into "module".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,10 @@ ENVTEST_K8S_VERSION = 1.30.0
 K3S_TESTCONTAINER_VERSION = v1.30.0-k3s1
 # POLICY_SERVER_VERSION refers to the version of the policy server to be used by integration tests.
 # FIXME This should be updated to the latest stable version when the policy server is updated.
-POLICY_SERVER_VERSION = latest
+POLICY_SERVER_VERSION ?= latest
+# POLICY_SERVER_REPOSITORY refers to the repository where the policy server image is hosted.
+# This is useful when you need to test the controller with a different policy server image.
+POLICY_SERVER_REPOSITORY ?= ghcr.io/kubewarden/policy-server
 
 # Let's use a generous timeout for integration tests because GitHub workers can
 # be slow
@@ -92,9 +95,9 @@ integration-tests-envtest: manifests generate fmt vet ginkgo envtest ## Run inte
 .PHONY: integration-tests-real-cluster
 integration-tests-real-cluster: manifests generate fmt ginkgo vet ## Run integration tests that require a real cluster only.
 	K3S_TESTCONTAINER_VERSION="$(K3S_TESTCONTAINER_VERSION)" POLICY_SERVER_VERSION="$(POLICY_SERVER_VERSION)" \
-	$(GINKGO) -p -v -github-output -timeout=$(TEST_TIMEOUT) -label-filter="real-cluster" \
-	-output-dir=./coverage/integration-tests/ -coverprofile=coverage-real-cluster.txt -covermode=atomic -coverpkg=all \
-	./internal/controller/
+	POLICY_SERVER_REPOSITORY="$(POLICY_SERVER_REPOSITORY)" $(GINKGO) -p -v -github-output -timeout=$(TEST_TIMEOUT) \
+	-label-filter="real-cluster" -output-dir=./coverage/integration-tests/ -coverprofile=coverage-real-cluster.txt \
+	-covermode=atomic -coverpkg=all ./internal/controller/
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter

--- a/internal/controller/policyserver_controller_configmap.go
+++ b/internal/controller/policyserver_controller_configmap.go
@@ -23,14 +23,14 @@ import (
 const dataType string = "Data" // only data type is supported
 
 type policyGroupMember struct {
-	URL                   string                            `json:"url"`
+	Module                string                            `json:"module"`
 	Settings              runtime.RawExtension              `json:"settings,omitempty"`
 	ContextAwareResources []policiesv1.ContextAwareResource `json:"contextAwareResources,omitempty"`
 }
 
 type policyServerConfigEntry struct {
 	NamespacedName        types.NamespacedName              `json:"namespacedName"`
-	URL                   string                            `json:"url,omitempty"`
+	Module                string                            `json:"module,omitempty"`
 	PolicyMode            string                            `json:"policyMode"`
 	AllowedToMutate       bool                              `json:"allowedToMutate,omitempty"`
 	ContextAwareResources []policiesv1.ContextAwareResource `json:"contextAwareResources,omitempty"`
@@ -52,10 +52,10 @@ func (p *policyServerConfigEntry) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, entry); err != nil {
 		return errors.Join(errors.New("failed to unmarshal policy server config entry"), err)
 	}
-	if len(p.Policies) == 0 && len(p.URL) == 0 {
+	if len(p.Policies) == 0 && len(p.Module) == 0 {
 		return errors.New("policies JSON should have an URL or a list of policies to be evaluated")
 	}
-	if len(p.Policies) != 0 && len(p.URL) != 0 {
+	if len(p.Policies) != 0 && len(p.Module) != 0 {
 		return errors.New("policies JSON should not have an URL and a list of policies to be evaluated at the same time")
 	}
 	return nil
@@ -80,14 +80,14 @@ func (p policyServerConfigEntry) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(struct {
 		NamespacedName        types.NamespacedName              `json:"namespacedName"`
-		URL                   string                            `json:"url"`
+		Module                string                            `json:"module"`
 		PolicyMode            string                            `json:"policyMode"`
 		AllowedToMutate       bool                              `json:"allowedToMutate"`
 		ContextAwareResources []policiesv1.ContextAwareResource `json:"contextAwareResources,omitempty"`
 		Settings              runtime.RawExtension              `json:"settings,omitempty"`
 	}{
 		NamespacedName:        p.NamespacedName,
-		URL:                   p.URL,
+		Module:                p.Module,
 		PolicyMode:            p.PolicyMode,
 		AllowedToMutate:       p.AllowedToMutate,
 		ContextAwareResources: p.ContextAwareResources,
@@ -178,7 +178,7 @@ func buildPolicyGroupMembers(policies policiesv1.PolicyGroupMembers) map[string]
 	policyGroupMembers := map[string]policyGroupMember{}
 	for name, policy := range policies {
 		policyGroupMembers[name] = policyGroupMember{
-			URL:                   policy.Module,
+			Module:                policy.Module,
 			Settings:              policy.Settings,
 			ContextAwareResources: policy.ContextAwareResources,
 		}
@@ -194,7 +194,7 @@ func buildPoliciesMap(admissionPolicies []policiesv1.Policy) policyConfigEntryMa
 				Namespace: admissionPolicy.GetNamespace(),
 				Name:      admissionPolicy.GetName(),
 			},
-			URL:                   admissionPolicy.GetModule(),
+			Module:                admissionPolicy.GetModule(),
 			PolicyMode:            string(admissionPolicy.GetPolicyMode()),
 			AllowedToMutate:       admissionPolicy.IsMutating(),
 			Settings:              admissionPolicy.GetSettings(),

--- a/internal/controller/policyserver_controller_test.go
+++ b/internal/controller/policyserver_controller_test.go
@@ -293,7 +293,7 @@ var _ = Describe("PolicyServer controller", func() {
 					Namespace: admissionPolicy.GetNamespace(),
 					Name:      admissionPolicy.GetName(),
 				},
-				URL:                   admissionPolicy.GetModule(),
+				Module:                admissionPolicy.GetModule(),
 				PolicyMode:            string(admissionPolicy.GetPolicyMode()),
 				AllowedToMutate:       admissionPolicy.IsMutating(),
 				Settings:              admissionPolicy.GetSettings(),
@@ -304,7 +304,7 @@ var _ = Describe("PolicyServer controller", func() {
 					Namespace: clusterAdmissionPolicy.GetNamespace(),
 					Name:      clusterAdmissionPolicy.GetName(),
 				},
-				URL:                   clusterAdmissionPolicy.GetModule(),
+				Module:                clusterAdmissionPolicy.GetModule(),
 				PolicyMode:            string(clusterAdmissionPolicy.GetPolicyMode()),
 				AllowedToMutate:       clusterAdmissionPolicy.IsMutating(),
 				Settings:              clusterAdmissionPolicy.GetSettings(),
@@ -315,7 +315,7 @@ var _ = Describe("PolicyServer controller", func() {
 					Namespace: admissionPolicyGroup.GetNamespace(),
 					Name:      admissionPolicyGroup.GetName(),
 				},
-				URL:                   admissionPolicyGroup.GetModule(),
+				Module:                admissionPolicyGroup.GetModule(),
 				PolicyMode:            string(admissionPolicyGroup.GetPolicyMode()),
 				AllowedToMutate:       admissionPolicyGroup.IsMutating(),
 				Settings:              admissionPolicyGroup.GetSettings(),
@@ -329,7 +329,7 @@ var _ = Describe("PolicyServer controller", func() {
 					Namespace: clusterPolicyGroup.GetNamespace(),
 					Name:      clusterPolicyGroup.GetName(),
 				},
-				URL:                   clusterPolicyGroup.GetModule(),
+				Module:                clusterPolicyGroup.GetModule(),
 				AllowedToMutate:       clusterPolicyGroup.IsMutating(),
 				Settings:              clusterPolicyGroup.GetSettings(),
 				ContextAwareResources: clusterPolicyGroup.GetContextAwareResources(),
@@ -363,7 +363,7 @@ var _ = Describe("PolicyServer controller", func() {
 									"Namespace": Equal(admissionPolicy.GetNamespace()),
 									"Name":      Equal(admissionPolicy.GetName()),
 								}),
-								"url":        Equal(admissionPolicy.GetModule()),
+								"module":     Equal(admissionPolicy.GetModule()),
 								"policyMode": Equal(string(admissionPolicy.GetPolicyMode())),
 							}),
 							clusterAdmissionPolicy.GetUniqueName(): And(MatchAllKeys(Keys{
@@ -371,7 +371,7 @@ var _ = Describe("PolicyServer controller", func() {
 									"Namespace": Equal(clusterAdmissionPolicy.GetNamespace()),
 									"Name":      Equal(clusterAdmissionPolicy.GetName()),
 								}),
-								"url":             Equal(clusterAdmissionPolicy.GetModule()),
+								"module":          Equal(clusterAdmissionPolicy.GetModule()),
 								"policyMode":      Equal(string(clusterAdmissionPolicy.GetPolicyMode())),
 								"allowedToMutate": Equal(clusterAdmissionPolicy.IsMutating()),
 								"settings":        BeNil(),
@@ -394,7 +394,7 @@ var _ = Describe("PolicyServer controller", func() {
 								}),
 								"policies": MatchKeys(IgnoreExtras, Keys{
 									"pod-privileged": MatchKeys(IgnoreExtras, Keys{
-										"url": Equal(admissionPolicyGroup.GetPolicyGroupMembers()["pod-privileged"].Module),
+										"module": Equal(admissionPolicyGroup.GetPolicyGroupMembers()["pod-privileged"].Module),
 									}),
 								}),
 								"policyMode": Equal(string(admissionPolicyGroup.GetPolicyMode())),
@@ -408,7 +408,7 @@ var _ = Describe("PolicyServer controller", func() {
 								}),
 								"policies": MatchKeys(IgnoreExtras, Keys{
 									"pod-privileged": MatchAllKeys(Keys{
-										"url":      Equal(clusterPolicyGroup.GetPolicyGroupMembers()["pod-privileged"].Module),
+										"module":   Equal(clusterPolicyGroup.GetPolicyGroupMembers()["pod-privileged"].Module),
 										"settings": Ignore(),
 										"contextAwareResources": And(ContainElement(MatchAllKeys(Keys{
 											"apiVersion": Equal("v1"),
@@ -416,7 +416,7 @@ var _ = Describe("PolicyServer controller", func() {
 										})), HaveLen(1)),
 									}),
 									"user-group-psp": MatchAllKeys(Keys{
-										"url":      Equal(clusterPolicyGroup.GetPolicyGroupMembers()["user-group-psp"].Module),
+										"module":   Equal(clusterPolicyGroup.GetPolicyGroupMembers()["user-group-psp"].Module),
 										"settings": Ignore(),
 										"contextAwareResources": And(ContainElement(MatchAllKeys(Keys{
 											"apiVersion": Equal("v1"),

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -40,12 +40,15 @@ import (
 	"github.com/kubewarden/kubewarden-controller/internal/constants"
 )
 
-const integrationTestsFinalizer = "integration-tests-safety-net-finalizer"
+const (
+	integrationTestsFinalizer   = "integration-tests-safety-net-finalizer"
+	defaultKubewardenRepository = "ghcr.io/kubewarden/policy-server"
+)
 
 var (
 	templatePolicyServer = policiesv1.PolicyServer{
 		Spec: policiesv1.PolicyServerSpec{
-			Image:    "ghcr.io/kubewarden/policy-server:" + policyServerVersion(),
+			Image:    policyServerRepository() + ":" + policyServerVersion(),
 			Replicas: 1,
 		},
 	}
@@ -80,6 +83,14 @@ var (
 		},
 	}
 )
+
+func policyServerRepository() string {
+	repository, ok := os.LookupEnv("POLICY_SERVER_REPOSITORY")
+	if !ok {
+		return defaultKubewardenRepository
+	}
+	return repository
+}
 
 func policyServerVersion() string {
 	version, ok := os.LookupEnv("POLICY_SERVER_VERSION")


### PR DESCRIPTION
## Description

The "url" field used in the policy server configuration configmap has been renamed to "module". This ensures that the name used in the configmap follow the same name used in the CRDs.

Fix https://github.com/kubewarden/policy-server/issues/906

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

```shell
make POLICY_SERVER_VERSION=issue906 POLICY_SERVER_REPOSITORY=ghcr.io/jvanz/policy-server test e2e-tests
```

## Additional Information

Needs to be tested together with https://github.com/kubewarden/policy-server/pull/1016

