### PR TITLE
feat(test): use builder to build test objects.

### DIFF
--- a/internal/controller/admissionpolicy_controller_test.go
+++ b/internal/controller/admissionpolicy_controller_test.go
@@ -53,10 +53,16 @@ var _ = Describe("AdmissionPolicy controller", Label("real-cluster"), func() {
 
 		BeforeAll(func() {
 			policyServerName = newName("policy-server")
-			createPolicyServerAndWaitForItsService(ctx, policyServerFactory(policyServerName))
+			policyServer := newPolicyServerFactory().withName(policyServerName).build()
+			createPolicyServerAndWaitForItsService(ctx, policyServer)
 
 			policyName = newName("validating-policy")
-			policy = admissionPolicyFactory(policyName, policyNamespace, policyServerName, false)
+			policy = newAdmissionPolicyFactory().
+				withName(policyName).
+				withNamespace(policyNamespace).
+				withPolicyServer(policyServerName).
+				withMutating(false).
+				build()
 			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
 		})
 
@@ -177,10 +183,16 @@ var _ = Describe("AdmissionPolicy controller", Label("real-cluster"), func() {
 
 		BeforeAll(func() {
 			policyServerName = newName("policy-server")
-			createPolicyServerAndWaitForItsService(ctx, policyServerFactory(policyServerName))
+			policyServer := newPolicyServerFactory().withName(policyServerName).build()
+			createPolicyServerAndWaitForItsService(ctx, policyServer)
 
 			policyName = newName("mutating-policy")
-			policy = admissionPolicyFactory(policyName, policyNamespace, policyServerName, true)
+			policy = newAdmissionPolicyFactory().
+				withName(policyName).
+				withNamespace(policyNamespace).
+				withPolicyServer(policyServerName).
+				withMutating(true).
+				build()
 			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
 		})
 
@@ -297,7 +309,7 @@ var _ = Describe("AdmissionPolicy controller", Label("real-cluster"), func() {
 	It("should set policy status to unscheduled when creating an AdmissionPolicy without a PolicyServer assigned", func() {
 		policyName := newName("unscheduled-policy")
 		Expect(
-			k8sClient.Create(ctx, admissionPolicyFactory(policyName, policyNamespace, "", false)),
+			k8sClient.Create(ctx, newAdmissionPolicyFactory().withName(policyName).withNamespace(policyNamespace).build()),
 		).To(haveSucceededOrAlreadyExisted())
 
 		Eventually(func() (*policiesv1.AdmissionPolicy, error) {
@@ -313,7 +325,7 @@ var _ = Describe("AdmissionPolicy controller", Label("real-cluster"), func() {
 
 		BeforeAll(func() {
 			Expect(
-				k8sClient.Create(ctx, admissionPolicyFactory(policyName, policyNamespace, policyServerName, false)),
+				k8sClient.Create(ctx, newAdmissionPolicyFactory().withName(policyName).withNamespace(policyNamespace).withPolicyServer(policyServerName).build()),
 			).To(haveSucceededOrAlreadyExisted())
 		})
 
@@ -328,7 +340,7 @@ var _ = Describe("AdmissionPolicy controller", Label("real-cluster"), func() {
 		It("should set the policy status to active when the PolicyServer is created", func() {
 			By("creating the PolicyServer")
 			Expect(
-				k8sClient.Create(ctx, policyServerFactory(policyServerName)),
+				k8sClient.Create(ctx, newPolicyServerFactory().withName(policyServerName).build()),
 			).To(haveSucceededOrAlreadyExisted())
 
 			By("changing the policy status to pending")

--- a/internal/controller/admissionpolicygroup_controller_test.go
+++ b/internal/controller/admissionpolicygroup_controller_test.go
@@ -52,10 +52,10 @@ var _ = Describe("AdmissionPolicyGroup controller", Label("real-cluster"), func(
 
 		BeforeAll(func() {
 			policyServerName = newName("policy-server")
-			createPolicyServerAndWaitForItsService(ctx, policyServerFactory(policyServerName))
+			createPolicyServerAndWaitForItsService(ctx, newPolicyServerFactory().withName(policyServerName).build())
 
 			policyName = newName("validating-policy")
-			policy = admissionPolicyGroupFactory(policyName, policyNamespace, policyServerName)
+			policy = newAdmissionPolicyGroupFactory().withName(policyName).withNamespace(policyNamespace).withPolicyServer(policyServerName).build()
 			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
 		})
 
@@ -172,7 +172,7 @@ var _ = Describe("AdmissionPolicyGroup controller", Label("real-cluster"), func(
 	It("should set policy status to unscheduled when creating an AdmissionPolicyGroup without a PolicyServer assigned", func() {
 		policyName := newName("unscheduled-policy")
 		Expect(
-			k8sClient.Create(ctx, admissionPolicyGroupFactory(policyName, policyNamespace, "")),
+			k8sClient.Create(ctx, newAdmissionPolicyGroupFactory().withName(policyName).withNamespace(policyNamespace).withPolicyServer("").build()),
 		).To(haveSucceededOrAlreadyExisted())
 
 		Eventually(func() (*policiesv1.AdmissionPolicyGroup, error) {
@@ -188,7 +188,7 @@ var _ = Describe("AdmissionPolicyGroup controller", Label("real-cluster"), func(
 
 		BeforeAll(func() {
 			Expect(
-				k8sClient.Create(ctx, admissionPolicyGroupFactory(policyName, policyNamespace, policyServerName)),
+				k8sClient.Create(ctx, newAdmissionPolicyGroupFactory().withName(policyName).withNamespace(policyNamespace).withPolicyServer(policyServerName).build()),
 			).To(haveSucceededOrAlreadyExisted())
 		})
 
@@ -203,7 +203,7 @@ var _ = Describe("AdmissionPolicyGroup controller", Label("real-cluster"), func(
 		It("should set the policy status to active when the PolicyServer is created", func() {
 			By("creating the PolicyServer")
 			Expect(
-				k8sClient.Create(ctx, policyServerFactory(policyServerName)),
+				k8sClient.Create(ctx, newPolicyServerFactory().withName(policyServerName).build()),
 			).To(haveSucceededOrAlreadyExisted())
 
 			By("changing the policy status to pending")

--- a/internal/controller/clusteradmissionpolicy_controller_test.go
+++ b/internal/controller/clusteradmissionpolicy_controller_test.go
@@ -40,10 +40,10 @@ var _ = Describe("ClusterAdmissionPolicy controller", Label("real-cluster"), fun
 
 		BeforeAll(func() {
 			policyServerName = newName("policy-server")
-			createPolicyServerAndWaitForItsService(ctx, policyServerFactory(policyServerName))
+			createPolicyServerAndWaitForItsService(ctx, newPolicyServerFactory().withName(policyServerName).build())
 
 			policyName = newName("validating-policy")
-			policy = clusterAdmissionPolicyFactory(policyName, policyServerName, false)
+			policy = newClusterAdmissionPolicyFactory().withName(policyName).withPolicyServer(policyServerName).withMutating(false).build()
 			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
 		})
 
@@ -148,10 +148,10 @@ var _ = Describe("ClusterAdmissionPolicy controller", Label("real-cluster"), fun
 
 		BeforeAll(func() {
 			policyServerName = newName("policy-server")
-			createPolicyServerAndWaitForItsService(ctx, policyServerFactory(policyServerName))
+			createPolicyServerAndWaitForItsService(ctx, newPolicyServerFactory().withName(policyServerName).build())
 
 			policyName = newName("mutating-policy")
-			policy = clusterAdmissionPolicyFactory(policyName, policyServerName, true)
+			policy = newClusterAdmissionPolicyFactory().withName(policyName).withPolicyServer(policyServerName).withMutating(true).build()
 			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
 		})
 
@@ -251,7 +251,7 @@ var _ = Describe("ClusterAdmissionPolicy controller", Label("real-cluster"), fun
 	It("should set policy status to unscheduled when creating an ClusterAdmissionPolicy without a PolicyServer assigned", func() {
 		policyName := newName("unscheduled-policy")
 		Expect(
-			k8sClient.Create(ctx, clusterAdmissionPolicyFactory(policyName, "", false)),
+			k8sClient.Create(ctx, newClusterAdmissionPolicyFactory().withName(policyName).withPolicyServer("").withMutating(false).build()),
 		).To(haveSucceededOrAlreadyExisted())
 
 		Eventually(func() (*policiesv1.ClusterAdmissionPolicy, error) {
@@ -267,13 +267,13 @@ var _ = Describe("ClusterAdmissionPolicy controller", Label("real-cluster"), fun
 
 		BeforeAll(func() {
 			Expect(
-				k8sClient.Create(ctx, clusterAdmissionPolicyFactory(policyName, policyServerName, false)),
+				k8sClient.Create(ctx, newClusterAdmissionPolicyFactory().withName(policyName).withPolicyServer(policyServerName).withMutating(false).build()),
 			).To(haveSucceededOrAlreadyExisted())
 		})
 
 		It("should set the policy status to scheduled", func() {
 			Expect(
-				k8sClient.Create(ctx, clusterAdmissionPolicyFactory(policyName, policyServerName, false)),
+				k8sClient.Create(ctx, newClusterAdmissionPolicyFactory().withName(policyName).withPolicyServer(policyServerName).withMutating(false).build()),
 			).To(haveSucceededOrAlreadyExisted())
 
 			Eventually(func() (*policiesv1.ClusterAdmissionPolicy, error) {
@@ -286,7 +286,7 @@ var _ = Describe("ClusterAdmissionPolicy controller", Label("real-cluster"), fun
 		It("should set the policy status to active when the PolicyServer is created", func() {
 			By("creating the PolicyServer")
 			Expect(
-				k8sClient.Create(ctx, policyServerFactory(policyServerName)),
+				k8sClient.Create(ctx, newPolicyServerFactory().withName(policyServerName).build()),
 			).To(haveSucceededOrAlreadyExisted())
 
 			By("changing the policy status to pending")

--- a/internal/controller/clusteradmissionpolicygroup_controller_test.go
+++ b/internal/controller/clusteradmissionpolicygroup_controller_test.go
@@ -40,10 +40,10 @@ var _ = Describe("ClusterAdmissionPolicyGroup controller", Label("real-cluster")
 
 		BeforeAll(func() {
 			policyServerName = newName("policy-server")
-			createPolicyServerAndWaitForItsService(ctx, policyServerFactory(policyServerName))
+			createPolicyServerAndWaitForItsService(ctx, newPolicyServerFactory().withName(policyServerName).build())
 
 			policyName = newName("validating-policy")
-			policy = clusterAdmissionPolicyGroupFactory(policyName, policyServerName)
+			policy = newClusterAdmissionPolicyGroupFactory().withName(policyName).withPolicyServer(policyServerName).build()
 			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
 		})
 
@@ -144,7 +144,7 @@ var _ = Describe("ClusterAdmissionPolicyGroup controller", Label("real-cluster")
 	It("should set policy status to unscheduled when creating an ClusterAdmissionPolicyGroup without a PolicyServer assigned", func() {
 		policyName := newName("unscheduled-policy")
 		Expect(
-			k8sClient.Create(ctx, clusterAdmissionPolicyGroupFactory(policyName, "")),
+			k8sClient.Create(ctx, newClusterAdmissionPolicyGroupFactory().withName(policyName).withPolicyServer("").build()),
 		).To(haveSucceededOrAlreadyExisted())
 
 		Eventually(func() (*policiesv1.ClusterAdmissionPolicyGroup, error) {
@@ -160,13 +160,13 @@ var _ = Describe("ClusterAdmissionPolicyGroup controller", Label("real-cluster")
 
 		BeforeAll(func() {
 			Expect(
-				k8sClient.Create(ctx, clusterAdmissionPolicyGroupFactory(policyName, policyServerName)),
+				k8sClient.Create(ctx, newClusterAdmissionPolicyGroupFactory().withName(policyName).withPolicyServer(policyServerName).build()),
 			).To(haveSucceededOrAlreadyExisted())
 		})
 
 		It("should set the policy status to scheduled", func() {
 			Expect(
-				k8sClient.Create(ctx, clusterAdmissionPolicyGroupFactory(policyName, policyServerName)),
+				k8sClient.Create(ctx, newClusterAdmissionPolicyGroupFactory().withName(policyName).withPolicyServer(policyServerName).build()),
 			).To(haveSucceededOrAlreadyExisted())
 
 			Eventually(func() (*policiesv1.ClusterAdmissionPolicyGroup, error) {
@@ -179,7 +179,7 @@ var _ = Describe("ClusterAdmissionPolicyGroup controller", Label("real-cluster")
 		It("should set the policy status to active when the PolicyServer is created", func() {
 			By("creating the PolicyServer")
 			Expect(
-				k8sClient.Create(ctx, policyServerFactory(policyServerName)),
+				k8sClient.Create(ctx, newPolicyServerFactory().withName(policyServerName).build()),
 			).To(haveSucceededOrAlreadyExisted())
 
 			By("changing the policy status to pending")

--- a/internal/controller/factories_test.go
+++ b/internal/controller/factories_test.go
@@ -1,0 +1,318 @@
+package controller
+
+import (
+	"os"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	policiesv1 "github.com/kubewarden/kubewarden-controller/api/policies/v1"
+	"github.com/kubewarden/kubewarden-controller/internal/constants"
+)
+
+type admissionPolicyFactory struct {
+	name         string
+	namespace    string
+	policyServer string
+	mutating     bool
+	rules        []admissionregistrationv1.RuleWithOperations
+	module       string
+}
+
+func newAdmissionPolicyFactory() *admissionPolicyFactory {
+	return &admissionPolicyFactory{
+		name:         newName("validating-policy"),
+		namespace:    "",
+		policyServer: "",
+		mutating:     false,
+		rules:        []admissionregistrationv1.RuleWithOperations{},
+		module:       "registry://ghcr.io/kubewarden/tests/pod-privileged:v0.2.5",
+	}
+}
+
+func (fac *admissionPolicyFactory) withName(name string) *admissionPolicyFactory {
+	fac.name = name
+	return fac
+}
+
+func (fac *admissionPolicyFactory) withNamespace(namespace string) *admissionPolicyFactory {
+	fac.namespace = namespace
+	return fac
+}
+
+func (fac *admissionPolicyFactory) withPolicyServer(policyServer string) *admissionPolicyFactory {
+	fac.policyServer = policyServer
+	return fac
+}
+
+func (fac *admissionPolicyFactory) withMutating(mutating bool) *admissionPolicyFactory {
+	fac.mutating = mutating
+	return fac
+}
+
+func (fac *admissionPolicyFactory) build() *policiesv1.AdmissionPolicy {
+	policy := policiesv1.AdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fac.name,
+			Namespace: fac.namespace,
+			Finalizers: []string{
+				// On a real cluster the Kubewarden finalizer is added by our mutating
+				// webhook. This is not running now, hence we have to manually add the finalizer
+				constants.KubewardenFinalizer,
+				// By adding this finalizer automatically, we ensure that when
+				// testing removal of finalizers on deleted objects, that they will
+				// exist at all times
+				integrationTestsFinalizer,
+			},
+		},
+		Spec: policiesv1.AdmissionPolicySpec{
+			PolicySpec: policiesv1.PolicySpec{
+				PolicyServer: fac.policyServer,
+				Module:       fac.module,
+				Rules:        fac.rules,
+				Mutating:     fac.mutating,
+				MatchConditions: []admissionregistrationv1.MatchCondition{
+					{
+						Name:       "noop",
+						Expression: "true",
+					},
+				},
+			},
+		},
+	}
+	return &policy
+}
+
+type clusterAdmissionPolicyFactory struct {
+	name         string
+	policyServer string
+	mutating     bool
+	rules        []admissionregistrationv1.RuleWithOperations
+	module       string
+}
+
+func newClusterAdmissionPolicyFactory() *clusterAdmissionPolicyFactory {
+	return &clusterAdmissionPolicyFactory{
+		name:         newName("validating-cluster-policy"),
+		policyServer: "",
+		mutating:     false,
+		rules:        []admissionregistrationv1.RuleWithOperations{},
+		module:       "registry://ghcr.io/kubewarden/tests/pod-privileged:v0.2.5",
+	}
+}
+
+func (fac *clusterAdmissionPolicyFactory) withName(name string) *clusterAdmissionPolicyFactory {
+	fac.name = name
+	return fac
+}
+
+func (fac *clusterAdmissionPolicyFactory) withPolicyServer(policyServer string) *clusterAdmissionPolicyFactory {
+	fac.policyServer = policyServer
+	return fac
+}
+
+func (fac *clusterAdmissionPolicyFactory) withMutating(mutating bool) *clusterAdmissionPolicyFactory {
+	fac.mutating = mutating
+	return fac
+}
+
+func (fac *clusterAdmissionPolicyFactory) build() *policiesv1.ClusterAdmissionPolicy {
+	clusterAdmissionPolicy := policiesv1.ClusterAdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fac.name,
+			Finalizers: []string{
+				// On a real cluster the Kubewarden finalizer is added by our mutating
+				// webhook. This is not running now, hence we have to manually add the finalizer
+				constants.KubewardenFinalizer,
+				// By adding this finalizer automatically, we ensure that when
+				// testing removal of finalizers on deleted objects, that they will
+				// exist at all times
+				integrationTestsFinalizer,
+			}},
+		Spec: policiesv1.ClusterAdmissionPolicySpec{
+			PolicySpec: policiesv1.PolicySpec{
+				PolicyServer: fac.policyServer,
+				Module:       fac.module,
+				Rules:        fac.rules,
+				Mutating:     fac.mutating,
+				MatchConditions: []admissionregistrationv1.MatchCondition{
+					{Name: "noop", Expression: "true"},
+				},
+			},
+		},
+	}
+	return &clusterAdmissionPolicy
+}
+
+type policyServerBuilder struct {
+	name string
+}
+
+func newPolicyServerFactory() *policyServerBuilder {
+	return &policyServerBuilder{
+		name: newName("policy-server"),
+	}
+}
+
+func (fac *policyServerBuilder) withName(name string) *policyServerBuilder {
+	fac.name = name
+	return fac
+}
+
+func (fac *policyServerBuilder) build() *policiesv1.PolicyServer {
+	policyServer := policiesv1.PolicyServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fac.name,
+			Finalizers: []string{
+				// On a real cluster the Kubewarden finalizer is added by our mutating
+				// webhook. This is not running now, hence we have to manually add the finalizer
+				constants.KubewardenFinalizer,
+				// By adding this finalizer automatically, we ensure that when
+				// testing removal of finalizers on deleted objects, that they will
+				// exist at all times
+				integrationTestsFinalizer,
+			},
+		},
+		Spec: policiesv1.PolicyServerSpec{
+			Image:    policyServerRepository() + ":" + policyServerVersion(),
+			Replicas: 1,
+		},
+	}
+	return &policyServer
+}
+
+type admissionPolicyGroupFactory struct {
+	name         string
+	namespace    string
+	policyServer string
+}
+
+func newAdmissionPolicyGroupFactory() *admissionPolicyGroupFactory {
+	return &admissionPolicyGroupFactory{
+		name:         newName("validating-policygroup"),
+		namespace:    "",
+		policyServer: "",
+	}
+}
+
+func (fac *admissionPolicyGroupFactory) withName(name string) *admissionPolicyGroupFactory {
+	fac.name = name
+	return fac
+}
+
+func (fac *admissionPolicyGroupFactory) withNamespace(namespace string) *admissionPolicyGroupFactory {
+	fac.namespace = namespace
+	return fac
+}
+
+func (fac *admissionPolicyGroupFactory) withPolicyServer(policyServer string) *admissionPolicyGroupFactory {
+	fac.policyServer = policyServer
+	return fac
+}
+
+func (fac *admissionPolicyGroupFactory) build() *policiesv1.AdmissionPolicyGroup {
+	admissionPolicy := policiesv1.AdmissionPolicyGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fac.name,
+			Namespace: fac.namespace,
+			Finalizers: []string{
+				// On a real cluster the Kubewarden finalizer is added by our mutating
+				// webhook. This is not running now, hence we have to manually add the finalizer
+				constants.KubewardenFinalizer,
+				// By adding this finalizer automatically, we ensure that when
+				// testing removal of finalizers on deleted objects, that they will
+				// exist at all times
+				integrationTestsFinalizer,
+			},
+		},
+		Spec: policiesv1.AdmissionPolicyGroupSpec{
+			PolicyGroupSpec: policiesv1.PolicyGroupSpec{
+				PolicyServer: fac.policyServer,
+				Policies: policiesv1.PolicyGroupMembers{
+					"pod-privileged": {
+						Module: "registry://ghcr.io/kubewarden/tests/pod-privileged:v0.2.5",
+					},
+				},
+				Rules: []admissionregistrationv1.RuleWithOperations{},
+				MatchConditions: []admissionregistrationv1.MatchCondition{
+					{Name: "noop", Expression: "true"},
+				},
+			},
+		},
+	}
+	return &admissionPolicy
+}
+
+type clusterAdmissionPolicyGroupFactory struct {
+	name         string
+	policyServer string
+}
+
+func newClusterAdmissionPolicyGroupFactory() *clusterAdmissionPolicyGroupFactory {
+	return &clusterAdmissionPolicyGroupFactory{
+		name:         newName("validating-policygroup"),
+		policyServer: "",
+	}
+}
+
+func (fac *clusterAdmissionPolicyGroupFactory) withName(name string) *clusterAdmissionPolicyGroupFactory {
+	fac.name = name
+	return fac
+}
+
+func (fac *clusterAdmissionPolicyGroupFactory) withPolicyServer(policyServer string) *clusterAdmissionPolicyGroupFactory {
+	fac.policyServer = policyServer
+	return fac
+}
+
+func (fac *clusterAdmissionPolicyGroupFactory) build() *policiesv1.ClusterAdmissionPolicyGroup {
+	clusterAdmissionPolicy := policiesv1.ClusterAdmissionPolicyGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fac.name,
+			Finalizers: []string{
+				// On a real cluster the Kubewarden finalizer is added by our mutating
+				// webhook. This is not running now, hence we have to manually add the finalizer
+				constants.KubewardenFinalizer,
+				// By adding this finalizer automatically, we ensure that when
+				// testing removal of finalizers on deleted objects, that they will
+				// exist at all times
+				integrationTestsFinalizer,
+			},
+		},
+		Spec: policiesv1.ClusterAdmissionPolicyGroupSpec{
+			PolicyGroupSpec: policiesv1.PolicyGroupSpec{
+				Rules:        []admissionregistrationv1.RuleWithOperations{},
+				PolicyServer: fac.policyServer,
+				MatchConditions: []admissionregistrationv1.MatchCondition{
+					{Name: "noop", Expression: "true"},
+				},
+				Policies: policiesv1.PolicyGroupMembers{
+					"pod-privileged": {
+						Module: "registry://ghcr.io/kubewarden/tests/pod-privileged:v0.2.5",
+					},
+					"user-group-psp": {
+						Module: "registry://ghcr.io/kubewarden/tests/user-group-psp:v0.4.9",
+					},
+				},
+			},
+		},
+	}
+	return &clusterAdmissionPolicy
+}
+
+func policyServerRepository() string {
+	repository, ok := os.LookupEnv("POLICY_SERVER_REPOSITORY")
+	if !ok {
+		return defaultKubewardenRepository
+	}
+	return repository
+}
+
+func policyServerVersion() string {
+	version, ok := os.LookupEnv("POLICY_SERVER_VERSION")
+	if !ok {
+		return "latest"
+	}
+
+	return version
+}


### PR DESCRIPTION
## Description

Creates builders to allow dynamic object building during tests.

Part of #824 

@kubewarden/kubewarden-developers this is one of a series of PR open to refactor the webhooks tests. This is a initial change to use builder pattern to build (hehe) test objects. This is not a 100% convertion. But it's a start to see if you are all  fine with the current changes before the next one following the same idea. 