### PR TITLE
fix: stricter checks on AdmissionPolicy and AdmissionPolicyGroup rules

### DIFF
--- a/config/crd/bases/policies.kubewarden.io_policyservers.yaml
+++ b/config/crd/bases/policies.kubewarden.io_policyservers.yaml
@@ -1438,6 +1438,32 @@ spec:
                           Note that this field cannot be set when spec.os.name is windows.
                         format: int64
                         type: integer
+                      seLinuxChangePolicy:
+                        description: |-
+                          seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                          It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                          Valid values are "MountOption" and "Recursive".
+
+                          "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                          This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                          "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                          This requires all Pods that share the same volume to use the same SELinux label.
+                          It is not possible to share the same volume among privileged and unprivileged Pods.
+                          Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                          whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                          CSIDriver instance. Other volumes are always re-labelled recursively.
+                          "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                          If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                          If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                          and "Recursive" for all other volumes.
+
+                          This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                          All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
                       seLinuxOptions:
                         description: |-
                           The SELinux context to be applied to all containers.


### PR DESCRIPTION
By design, AdmissionPolicy and AdmissionPolicyGroup can evaluate only namespaced resources. The resources to be evaluated are determined by the `rules` provided by the user.

There might be Kubernetes namespaced resources that should not be validated by AdmissionPolicy and AdmissionPolicyGroup policies because of their sensitive nature.

For example, PolicyReport are namespaced resources that contain the list of non compliant objects found inside of a namespace.

Prior to this commit, an AdmissionPolicy or an AdmissionPolicyGroup could prevent the creation of PolicyReports. Moreover, a mutating AdmissionPolicy could even alter the contents of the PolicyReports created inside of the namespace.

This commit extends the validation rules applied to AdmissionPolicy and AdmissionPolicyGroup to prevent them from validating sensitive types of namespaced resources.

To achieve that, the new validation will also restrict the usage of wildcards when defining `apiGroups` and `resources` rules for AdmissionPolicy and AdmissionPolicyGroup objects.
