### PR TITLE
build(deps): disable cel-go bot updates 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,9 @@ require (
 	sigs.k8s.io/controller-runtime v0.20.1
 )
 
+// CEL needs to be pinned to the same version as the one used by the k8s.io/apiserver package
+replace github.com/google/cel-go => github.com/google/cel-go v0.22.0
+
 require (
 	cel.dev/expr v0.18.0 // indirect
 	dario.cat/mergo v1.0.0 // indirect

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,13 @@
 {
-  "extends": [
-    "github>kubewarden/github-actions//renovate-config/default"
-  ],
+  "extends": ["github>kubewarden/github-actions//renovate-config/default"],
   "packageRules": [
     {
       "matchPackageNames": ["k8s.io/client-go"],
       "allowedVersions": "/^0\\.[0-9]+\\.[0-9]+$/"
+    },
+    {
+      "matchPackageNames": ["github.com/google/cel-go"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Description

We should align the `cel-go` version with the one used in `k8s.io/apiserver`. Since `cel-go` is a direct dependency, a replace directive is required, and the Renovate bot should exclude it from updates

.