### PR TITLE
policy server use kubernetes recommended labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ KUSTOMIZE_VERSION ?= v5.4.1
 CONTROLLER_TOOLS_VERSION ?= v0.16.1
 ENVTEST_VERSION ?= release-0.18
 GOLANGCI_LINT_VERSION ?= v1.64.5
-GINKGO_VERSION ?= v2.22.2
+GINKGO_VERSION ?= v2.23.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/api/policies/v1/policyserver_types.go
+++ b/api/policies/v1/policyserver_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"github.com/kubewarden/kubewarden-controller/internal/constants"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -188,6 +189,18 @@ func (ps *PolicyServer) NameWithPrefix() string {
 
 func (ps *PolicyServer) AppLabel() string {
 	return "kubewarden-" + ps.NameWithPrefix()
+}
+
+// CommonLabels returns the common labels to be used with the resources
+// associated to a Policy Server. The labels defined follow
+// Kubernetes guidelines: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
+func (ps *PolicyServer) CommonLabels() map[string]string {
+	return map[string]string{
+		constants.ComponentLabelKey: constants.ComponentPolicyServerLabelValue,
+		constants.InstanceLabelKey:  ps.NameWithPrefix(),
+		constants.PartOfLabelKey:    constants.PartOfLabelValue,
+		constants.ManagedByKey:      "kubewarden-controller",
+	}
 }
 
 //+kubebuilder:object:root=true

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -32,10 +32,13 @@ const (
 	// Labels.
 	AppLabelKey                     = "app"
 	PolicyServerLabelKey            = "kubewarden/policy-server"
+	ComponentPolicyServerLabelValue = "policy-server"
+	NameLabelKey                    = "app.kubernetes.io/name"
+	InstanceLabelKey                = "app.kubernetes.io/instance"
+	ComponentLabelKey               = "app.kubernetes.io/component"
 	PartOfLabelKey                  = "app.kubernetes.io/part-of"
 	PartOfLabelValue                = "kubewarden"
-	ComponentLabelKey               = "app.kubernetes.io/component"
-	ComponentPolicyServerLabelValue = "policy-server"
+	ManagedByKey                    = "app.kubernetes.io/managed-by"
 
 	// Index.
 	PolicyServerIndexKey = ".spec.policyServer"

--- a/internal/controller/policyserver_controller_configmap.go
+++ b/internal/controller/policyserver_controller_configmap.go
@@ -115,6 +115,7 @@ func (r *PolicyServerReconciler) reconcilePolicyServerConfigMap(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      policyServer.NameWithPrefix(),
 			Namespace: r.DeploymentsNamespace,
+			Labels:    policyServer.CommonLabels(),
 		},
 	}
 	_, err := controllerutil.CreateOrPatch(ctx, r.Client, cfg, func() error {

--- a/internal/controller/policyserver_controller_pdb.go
+++ b/internal/controller/policyserver_controller_pdb.go
@@ -41,6 +41,7 @@ func reconcilePodDisruptionBudget(ctx context.Context, policyServer *policiesv1.
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      policyServer.NameWithPrefix(),
 			Namespace: namespace,
+			Labels:    policyServer.CommonLabels(),
 		},
 	}
 	_, err := controllerutil.CreateOrPatch(ctx, k8s, pdb, func() error {

--- a/internal/controller/policyserver_controller_service.go
+++ b/internal/controller/policyserver_controller_service.go
@@ -38,6 +38,7 @@ func (r *PolicyServerReconciler) reconcilePolicyServerService(ctx context.Contex
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      policyServer.NameWithPrefix(),
 			Namespace: r.DeploymentsNamespace,
+			Labels:    policyServer.CommonLabels(),
 		},
 	}
 	_, err := controllerutil.CreateOrPatch(ctx, r.Client, &svc, func() error {

--- a/internal/controller/policyserver_controller_test.go
+++ b/internal/controller/policyserver_controller_test.go
@@ -87,6 +87,10 @@ var _ = Describe("PolicyServer controller", func() {
 					"TolerationSeconds": PointTo(Equal(tolerationSeconds)),
 				}),
 			}))
+
+			for k, v := range policyServer.CommonLabels() {
+				Expect(deployment.Spec.Template.ObjectMeta.Labels).To(HaveKeyWithValue(k, v))
+			}
 		})
 
 		It("should use the policy server affinity configuration in the policy server deployment", func() {


### PR DESCRIPTION
All the resources associated with Policy Server are now using the labels recommended by Kubernetes, see [here](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels).