### PR TITLE
policy server remove non standard labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ KUSTOMIZE_VERSION ?= v5.4.1
 CONTROLLER_TOOLS_VERSION ?= v0.16.1
 ENVTEST_VERSION ?= release-0.18
 GOLANGCI_LINT_VERSION ?= v2.0.2
-GINKGO_VERSION ?= v2.23.0
+GINKGO_VERSION ?= v2.23.4
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/api/policies/v1/policyserver_types.go
+++ b/api/policies/v1/policyserver_types.go
@@ -187,10 +187,6 @@ func (ps *PolicyServer) NameWithPrefix() string {
 	return "policy-server-" + ps.Name
 }
 
-func (ps *PolicyServer) AppLabel() string {
-	return "kubewarden-" + ps.NameWithPrefix()
-}
-
 // CommonLabels returns the common labels to be used with the resources
 // associated to a Policy Server. The labels defined follow
 // Kubernetes guidelines: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -26,10 +26,10 @@ const (
 	PolicyServerVerificationConfigEntry         = "verification-config"
 	PolicyServerVerificationConfigContainerPath = "/verification"
 
-	AppLabelKey                     = "app"
-	PolicyServerLabelKey            = "kubewarden/policy-server"
+	// Policy Server Labels.
+
+	PolicyServerLabelKey            = "kubewarden.io/policy-server"
 	ComponentPolicyServerLabelValue = "policy-server"
-	NameLabelKey                    = "app.kubernetes.io/name"
 	InstanceLabelKey                = "app.kubernetes.io/instance"
 	ComponentLabelKey               = "app.kubernetes.io/component"
 	PartOfLabelKey                  = "app.kubernetes.io/part-of"

--- a/internal/controller/policyserver_controller_deployment.go
+++ b/internal/controller/policyserver_controller_deployment.go
@@ -295,7 +295,6 @@ func configureLabelsAndAnnotations(policyServerDeployment *appsv1.Deployment, po
 	if policyServerDeployment.Labels == nil {
 		policyServerDeployment.Labels = make(map[string]string)
 	}
-	policyServerDeployment.Labels[constants.AppLabelKey] = policyServer.AppLabel()
 	policyServerDeployment.Labels[constants.PolicyServerLabelKey] = policyServer.Name
 
 	for key, value := range policyServer.CommonLabels() {
@@ -378,11 +377,12 @@ func buildPolicyServerDeploymentSpec(
 	podSecurityContext *corev1.PodSecurityContext,
 ) appsv1.DeploymentSpec {
 	templateLabels := map[string]string{
-		constants.AppLabelKey: policyServer.AppLabel(),
 		constants.PolicyServerDeploymentPodSpecConfigVersionLabel: configMapVersion,
 		constants.PolicyServerLabelKey:                            policyServer.Name,
 	}
-	for key, value := range policyServer.CommonLabels() {
+
+	commonLabels := policyServer.CommonLabels()
+	for key, value := range commonLabels {
 		templateLabels[key] = value
 	}
 
@@ -390,7 +390,8 @@ func buildPolicyServerDeploymentSpec(
 		Replicas: &policyServer.Spec.Replicas,
 		Selector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				constants.AppLabelKey: policyServer.AppLabel(),
+				constants.PartOfLabelKey:   commonLabels[constants.PartOfLabelKey],
+				constants.InstanceLabelKey: commonLabels[constants.InstanceLabelKey],
 			},
 		},
 		Strategy: appsv1.DeploymentStrategy{

--- a/internal/controller/policyserver_controller_pdb.go
+++ b/internal/controller/policyserver_controller_pdb.go
@@ -37,11 +37,12 @@ func deletePodDisruptionBudget(ctx context.Context, policyServer *policiesv1.Pol
 }
 
 func reconcilePodDisruptionBudget(ctx context.Context, policyServer *policiesv1.PolicyServer, k8s client.Client, namespace string) error {
+	commonLabels := policyServer.CommonLabels()
 	pdb := &k8spoliciesv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      policyServer.NameWithPrefix(),
 			Namespace: namespace,
-			Labels:    policyServer.CommonLabels(),
+			Labels:    commonLabels,
 		},
 	}
 	_, err := controllerutil.CreateOrPatch(ctx, k8s, pdb, func() error {
@@ -53,7 +54,8 @@ func reconcilePodDisruptionBudget(ctx context.Context, policyServer *policiesv1.
 
 		pdb.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				constants.AppLabelKey:          policyServer.AppLabel(),
+				constants.InstanceLabelKey:     commonLabels[constants.InstanceLabelKey],
+				constants.PartOfLabelKey:       commonLabels[constants.PartOfLabelKey],
 				constants.PolicyServerLabelKey: policyServer.GetName(),
 			},
 		}

--- a/internal/controller/policyserver_controller_service.go
+++ b/internal/controller/policyserver_controller_service.go
@@ -50,16 +50,18 @@ func (r *PolicyServerReconciler) reconcilePolicyServerService(ctx context.Contex
 }
 
 func (r *PolicyServerReconciler) updateService(svc *corev1.Service, policyServer *policiesv1.PolicyServer) error {
+	commonLabels := policyServer.CommonLabels()
+
 	svc.Name = policyServer.NameWithPrefix()
 	svc.Namespace = r.DeploymentsNamespace
 	templateLabels := map[string]string{
-		constants.AppLabelKey:          policyServer.AppLabel(),
 		constants.PolicyServerLabelKey: policyServer.Name,
 	}
 	for key, value := range policyServer.CommonLabels() {
 		templateLabels[key] = value
 	}
 	svc.Labels = templateLabels
+
 	svc.Spec = corev1.ServiceSpec{
 		Ports: []corev1.ServicePort{
 			{
@@ -79,7 +81,8 @@ func (r *PolicyServerReconciler) updateService(svc *corev1.Service, policyServer
 			},
 		},
 		Selector: map[string]string{
-			constants.AppLabelKey: policyServer.AppLabel(),
+			constants.InstanceLabelKey: commonLabels[constants.InstanceLabelKey],
+			constants.PartOfLabelKey:   commonLabels[constants.PartOfLabelKey],
 		},
 	}
 	if r.MetricsEnabled {

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -193,7 +193,8 @@ func policyServerPodDisruptionBudgetMatcher(policyServer *policiesv1.PolicyServe
 				"MinAvailable":   minAvailableMatcher,
 				"Selector": PointTo(MatchAllFields(Fields{
 					"MatchLabels": MatchAllKeys(Keys{
-						constants.AppLabelKey:          Equal(policyServer.AppLabel()),
+						constants.InstanceLabelKey:     Equal(policyServer.CommonLabels()[constants.InstanceLabelKey]),
+						constants.PartOfLabelKey:       Equal(policyServer.CommonLabels()[constants.PartOfLabelKey]),
 						constants.PolicyServerLabelKey: Equal(policyServer.GetName()),
 					}),
 					"MatchExpressions": Ignore(),


### PR DESCRIPTION
> **WARNING:** do not merge

This PR builds on top of https://github.com/kubewarden/kubewarden-controller/pull/1037/ and it must be merged a couple of releases after 1.23 is out.

This PR removes the old non-standard labels used by Policy Server. In certain cases it replaces them using the recommended Kubernetes labels.

We cannot merge this PR right now because we could cause a downtime during a Kubewarden upgrade.

With the 1.23 release all the Policy Server workloads will have the old and the new labels set.
With the 1.24+ release, the Policy Server workloads will have only the new labels. The Policy Server Service will use only the new labels inside of its selector.
However, we don't know how quickly the new workloads (the only using only the new labels) will be rolled out by Kubernetes. At the same time, the kubewarden-controller will update the selectors of the Policy Server service. We must ensure the selector keeps working as expected while the new workloads are rolled out.
