### PR TITLE
dev: fix tilt environment

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -51,8 +51,7 @@ install = helm(
     settings.get('helm_charts_path') + '/charts/kubewarden-controller/', 
     name='kubewarden-controller', 
     namespace='kubewarden', 
-    set=['image.repository=' + settings.get('image'), 'global.cattle.systemDefaultRegistry=' + settings.get('registry')]
-    , **additional_helm_installation_args
+    **additional_helm_installation_args
 )
 
 objects = decode_yaml_stream(install)
@@ -63,6 +62,7 @@ for o in objects:
         o['spec']['template']['spec']['securityContext']['runAsNonRoot'] = False
         # Disable the leader election to speed up the startup time.
         o['spec']['template']['spec']['containers'][0]['args'].remove('--leader-elect')
+        o['spec']['template']['spec']['containers'][0]['image'] = settings.get('registry') + '/' + settings.get('image')
 
     # Update the cluster and namespace roles used by the controller. This ensures
     # that always we have the latest roles applied to the cluster.

--- a/Tiltfile
+++ b/Tiltfile
@@ -12,7 +12,7 @@ if str(local("command -v " + kubectl_cmd + " || true", quiet = True)) == "":
 # Create the kubewarden namespace
 # This is required since the helm() function doesn't support the create_namespace flag
 load('ext://namespace', 'namespace_create')
-namespace_create('kubewarden')
+namespace_create('kubewarden', labels = settings.get('namespace_labels', []))
 
 # Install CRDs
 

--- a/tilt-settings.yaml.example
+++ b/tilt-settings.yaml.example
@@ -3,3 +3,9 @@ image: <your github handle>/kubewarden-controller
 helm_charts_path: ../helm-charts/
 audit_scanner_path: ../audit-scanner/
 controller_values_file: your-kubewarden-controller-helm-chart-values.yaml
+
+# This can be used to add labels to the `kubewarden` namespace.
+# It can be useful to test the effect of PSA (https://kubernetes.io/docs/concepts/security/pod-security-admission/)
+# on our stack.
+namespace_labels:
+  - pod-security.kubernetes.io/warn: restricted


### PR DESCRIPTION
Do not configure the registry that holds the development image of kubewarden-controller as the place from which all the images of the `kubewarden-controller` helm chart have to be pulled from. This would cause the deployment to fail, since all the other images (like kubectl, audit-scanner) are not mirrored on the local registry.
Instead, patch the image attribute of the Deployment.

Add the ability to set labels of the `kubewarden` namespace created by Tilt. This allows to test different PSA profiles and tune our deployment.
