### PR TITLE
feat: support running with PSA `enforce: restricted`

### DIFF
--- a/internal/controller/policyserver_controller_test.go
+++ b/internal/controller/policyserver_controller_test.go
@@ -148,7 +148,7 @@ var _ = Describe("PolicyServer controller", func() {
 					"ReadOnlyRootFilesystem":   PointTo(BeTrue()),
 					"Capabilities": PointTo(MatchAllFields(Fields{
 						"Add":  BeNil(),
-						"Drop": Equal([]corev1.Capability{"all"}),
+						"Drop": Equal([]corev1.Capability{"ALL"}),
 					})),
 					"SELinuxOptions": BeNil(),
 					"WindowsOptions": BeNil(),
@@ -172,7 +172,10 @@ var _ = Describe("PolicyServer controller", func() {
 					"FSGroup":             BeNil(),
 					"Sysctls":             BeNil(),
 					"FSGroupChangePolicy": BeNil(),
-					"SeccompProfile":      BeNil(),
+					"SeccompProfile": PointTo(MatchAllFields(Fields{
+						"Type":             Equal(corev1.SeccompProfileTypeRuntimeDefault),
+						"LocalhostProfile": BeNil(),
+					})),
 				})),
 				"Affinity": PointTo(MatchAllFields(Fields{
 					"NodeAffinity":    BeNil(),


### PR DESCRIPTION
Allow Policy Server deployments to run with PSA `restricted` mode enforced.

Note well: user has the ability to provide their own security contexts (see https://docs.kubewarden.io/reference/CRDs#policyserversecurity) that override our defualt values and lead to failures.
