### PR TITLE
fixed crd annotations link in go docstring

### DIFF
--- a/api/policies/v1/policyserver_types.go
+++ b/api/policies/v1/policyserver_types.go
@@ -54,7 +54,7 @@ type PolicyServerSpec struct {
 	// Annotations is an unstructured key value map stored with a resource that may be
 	// set by external tools to store and retrieve arbitrary metadata. They are not
 	// queryable and should be preserved when modifying objects.
-	// More info: http://kubernetes.io/docs/user-guide/annotations
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
 


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Closes kubewarden/docs#565

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
This PR fixes a broken link to Kubernetes annotations documentation on the [CRDs reference page](https://docs.kubewarden.io/reference/CRDs).

Updated the link in go docstring from https://kubernetes.io/docs/user-guide/annotations to https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ 