### PR TITLE
fix: keep "app" label in the policy server deployment

### DIFF
--- a/api/policies/v1/policyserver_types.go
+++ b/api/policies/v1/policyserver_types.go
@@ -187,6 +187,10 @@ func (ps *PolicyServer) NameWithPrefix() string {
 	return "policy-server-" + ps.Name
 }
 
+func (ps *PolicyServer) AppLabel() string {
+	return "kubewarden-" + ps.NameWithPrefix()
+}
+
 // CommonLabels returns the common labels to be used with the resources
 // associated to a Policy Server. The labels defined follow
 // Kubernetes guidelines: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -28,6 +28,7 @@ const (
 
 	// Policy Server Labels.
 
+	AppLabelKey                     = "app"
 	PolicyServerLabelKey            = "kubewarden.io/policy-server"
 	ComponentPolicyServerLabelValue = "policy-server"
 	InstanceLabelKey                = "app.kubernetes.io/instance"

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -28,6 +28,9 @@ const (
 
 	// Policy Server Labels.
 
+	// AppLabelKey is the label used to identify the pod template in the deployment
+	//
+	// Deprecated: use the other standard labels.
 	AppLabelKey                     = "app"
 	PolicyServerLabelKey            = "kubewarden.io/policy-server"
 	ComponentPolicyServerLabelValue = "policy-server"

--- a/internal/controller/policyserver_controller_deployment.go
+++ b/internal/controller/policyserver_controller_deployment.go
@@ -377,6 +377,7 @@ func buildPolicyServerDeploymentSpec(
 	podSecurityContext *corev1.PodSecurityContext,
 ) appsv1.DeploymentSpec {
 	templateLabels := map[string]string{
+		//nolint:staticcheck // this label will remove soon when policy lifecycle is revisited
 		constants.AppLabelKey: policyServer.AppLabel(),
 		constants.PolicyServerDeploymentPodSpecConfigVersionLabel: configMapVersion,
 		constants.PolicyServerLabelKey:                            policyServer.Name,
@@ -389,6 +390,7 @@ func buildPolicyServerDeploymentSpec(
 		Replicas: &policyServer.Spec.Replicas,
 		Selector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{
+				//nolint:staticcheck // this label will remove soon when policy lifecycle is revisited
 				constants.AppLabelKey: policyServer.AppLabel(),
 			},
 		},

--- a/internal/controller/policyserver_controller_deployment.go
+++ b/internal/controller/policyserver_controller_deployment.go
@@ -377,12 +377,11 @@ func buildPolicyServerDeploymentSpec(
 	podSecurityContext *corev1.PodSecurityContext,
 ) appsv1.DeploymentSpec {
 	templateLabels := map[string]string{
+		constants.AppLabelKey: policyServer.AppLabel(),
 		constants.PolicyServerDeploymentPodSpecConfigVersionLabel: configMapVersion,
 		constants.PolicyServerLabelKey:                            policyServer.Name,
 	}
-
-	commonLabels := policyServer.CommonLabels()
-	for key, value := range commonLabels {
+	for key, value := range policyServer.CommonLabels() {
 		templateLabels[key] = value
 	}
 
@@ -390,8 +389,7 @@ func buildPolicyServerDeploymentSpec(
 		Replicas: &policyServer.Spec.Replicas,
 		Selector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				constants.PartOfLabelKey:   commonLabels[constants.PartOfLabelKey],
-				constants.InstanceLabelKey: commonLabels[constants.InstanceLabelKey],
+				constants.AppLabelKey: policyServer.AppLabel(),
 			},
 		},
 		Strategy: appsv1.DeploymentStrategy{


### PR DESCRIPTION
## Description

Revert the change removing the "app" label from the policy server deployment. This label will be removed in future policy lifecycle refactoring. The label is also marked as deprecated

Fix #1081 

This is a spin-off https://github.com/kubewarden/kubewarden-controller/pull/1084#issuecomment-2809692577

## Test

E2e tests using this branch container image:

```console
make CONTROLLER_ARGS="--set image.tag=issue1081-app-label-deploy --set image.repository=jvanz/kubewarden-controller"  clean cluster install tests
```

Controller tests:

```
make tests
```
