### PR TITLE
refactor(policy-server): Keep old policy-server label key

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -32,7 +32,7 @@ const (
 	//
 	// Deprecated: use the other standard labels.
 	AppLabelKey                     = "app"
-	PolicyServerLabelKey            = "kubewarden.io/policy-server"
+	PolicyServerLabelKey            = "kubewarden/policy-server"
 	ComponentPolicyServerLabelValue = "policy-server"
 	InstanceLabelKey                = "app.kubernetes.io/instance"
 	ComponentLabelKey               = "app.kubernetes.io/component"


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/kubewarden-controller/issues/1104

Revert the change that set a valid domain for the PolicyServerLabelKey, instead of just `kubewarden`, as this would make upgrades break without further reconciler changes.

This label is used to tie Pods, ConfigMaps, Services with a specific PolicyServer by the controller, and will be removed in future policy lifecycle refactoring.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
E2E tests.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
