### PR TITLE
ci: Substitute peter-evans/repository-dispatch with gh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,9 +307,18 @@ jobs:
             });
 
       - name: Trigger chart update
-        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
-        with:
-          token: ${{ secrets.WORKFLOW_PAT }}
-          repository: "${{github.repository_owner}}/helm-charts"
-          event-type: update-chart
-          client-payload: '{"version": "${{ github.ref_name }}", "oldVersion": "${{ steps.get_last_release_tag.outputs.old_release_tag }}", "repository": "${{ github.repository }}", "crds_asset_id": "${{steps.upload_release_assets.outputs.crds_asset_id}}"}'
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+        run: |
+          echo '{
+            "event_type": "update-chart",
+            "client_payload": {
+              "version": "${{ github.ref_name }}",
+              "oldVersion": "${{ steps.get_last_release_tag.outputs.old_release_tag }}",
+              "repository": "${{ github.repository }}",
+              "crds_asset_id": "${{ steps.upload_release_assets.outputs.crds_asset_id }}"
+            }
+          }' > payload.json
+          gh api repos/${{ github.repository_owner }}/helm-charts/dispatches \
+            -X POST \
+            --input payload.json


### PR DESCRIPTION
## Description

Part of https://github.com/kubewarden/kubewarden-controller/issues/1099.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tagged a `v1.24.0-viccuad` from my fork, which run:
- https://github.com/viccuad/kubewarden-controller/actions/runs/14729015367/job/41339724835
Which triggered correctly the dispath on viccuad/helm-charts:
- https://github.com/viccuad/helm-charts/actions/runs/14729399016

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
