### PR TITLE
 chore: updates golang linter.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
         with:
-          version: v2.0.2
+          version: v2.1.0
 
   shellcheck:
     name: Shellcheck


### PR DESCRIPTION
Updates the golang linter used in the CI workflow to v2.1.0.

Required to make the CI [here](https://github.com/kubewarden/kubewarden-controller/pull/1117) happy. 

