### PR TITLE
feat: Add new optional PolicyServer.spec.PriorityClassName

### DIFF
--- a/api/policies/v1/policyserver_types.go
+++ b/api/policies/v1/policyserver_types.go
@@ -119,6 +119,15 @@ type PolicyServerSpec struct {
 	// used to ensure that the policy server pod is not scheduled onto a
 	// node with a taint.
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
+	// PriorityClassName is the name of the PriorityClass to be used for the
+	// policy server pods. Useful to schedule policy server pods with higher
+	// priority to ensure their availability over other cluster workload
+	// resources.
+	// Note: If the referenced PriorityClass is deleted, existing pods
+	// remain unchanged, but new pods that reference it cannot be created.
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
 type ReconciliationTransitionReason string

--- a/config/crd/bases/policies.kubewarden.io_policyservers.yaml
+++ b/config/crd/bases/policies.kubewarden.io_policyservers.yaml
@@ -1142,6 +1142,15 @@ spec:
                   eviction. The value can be an absolute number or a percentage. Only one of
                   MinAvailable or Max MaxUnavailable can be set.
                 x-kubernetes-int-or-string: true
+              priorityClassName:
+                description: |-
+                  PriorityClassName is the name of the PriorityClass to be used for the
+                  policy server pods. Useful to schedule policy server pods with higher
+                  priority to ensure their availability over other cluster workload
+                  resources.
+                  Note: If the referenced PriorityClass is deleted, existing pods
+                  remain unchanged, but new pods that reference it cannot be created.
+                type: string
               replicas:
                 description: Replicas is the number of desired replicas.
                 format: int32

--- a/docs/crds/CRD-docs-for-docs-repo.adoc
+++ b/docs/crds/CRD-docs-for-docs-repo.adoc
@@ -815,7 +815,7 @@ MinAvailable or Max MaxUnavailable can be set. + |  |
 | *`annotations`* __object (keys:string, values:string)__ | Annotations is an unstructured key value map stored with a resource that may be +
 set by external tools to store and retrieve arbitrary metadata. They are not +
 queryable and should be preserved when modifying objects. +
-More info: http://kubernetes.io/docs/user-guide/annotations + |  | 
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ + |  | 
 | *`env`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#envvar-v1-core[$$EnvVar$$] array__ | List of environment variables to set in the container. + |  | 
 | *`serviceAccountName`* __string__ | Name of the service account associated with the policy server. +
 Namespace service account will be used if not specified. + |  | 
@@ -846,6 +846,12 @@ otherwise to an implementation-defined value + |  |
 | *`tolerations`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#toleration-v1-core[$$Toleration$$] array__ | Tolerations describe the policy server pod's tolerations. It can be +
 used to ensure that the policy server pod is not scheduled onto a +
 node with a taint. + |  | 
+| *`priorityClassName`* __string__ | PriorityClassName is the name of the PriorityClass to be used for the +
+policy server pods. Useful to schedule policy server pods with higher +
+priority to ensure their availability over other cluster workload +
+resources. +
+Note: If the referenced PriorityClass is deleted, existing pods +
+remain unchanged, but new pods that reference it cannot be created. + |  | 
 |===
 
 

--- a/docs/crds/CRD-docs-for-docs-repo.md
+++ b/docs/crds/CRD-docs-for-docs-repo.md
@@ -504,7 +504,7 @@ _Appears in:_
 | `replicas` _integer_ | Replicas is the number of desired replicas. |  |  |
 | `minAvailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#intorstring-intstr-util)_ | Number of policy server replicas that must be still available after the<br />eviction. The value can be an absolute number or a percentage. Only one of<br />MinAvailable or Max MaxUnavailable can be set. |  |  |
 | `maxUnavailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#intorstring-intstr-util)_ | Number of policy server replicas that can be unavailable after the<br />eviction. The value can be an absolute number or a percentage. Only one of<br />MinAvailable or Max MaxUnavailable can be set. |  |  |
-| `annotations` _object (keys:string, values:string)_ | Annotations is an unstructured key value map stored with a resource that may be<br />set by external tools to store and retrieve arbitrary metadata. They are not<br />queryable and should be preserved when modifying objects.<br />More info: http://kubernetes.io/docs/user-guide/annotations |  |  |
+| `annotations` _object (keys:string, values:string)_ | Annotations is an unstructured key value map stored with a resource that may be<br />set by external tools to store and retrieve arbitrary metadata. They are not<br />queryable and should be preserved when modifying objects.<br />More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |  |  |
 | `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#envvar-v1-core) array_ | List of environment variables to set in the container. |  |  |
 | `serviceAccountName` _string_ | Name of the service account associated with the policy server.<br />Namespace service account will be used if not specified. |  |  |
 | `imagePullSecret` _string_ | Name of ImagePullSecret secret in the same namespace, used for pulling<br />policies from repositories. |  |  |
@@ -516,6 +516,7 @@ _Appears in:_
 | `limits` _[ResourceList](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#resourcelist-v1-core)_ | Limits describes the maximum amount of compute resources allowed. |  |  |
 | `requests` _[ResourceList](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#resourcelist-v1-core)_ | Requests describes the minimum amount of compute resources required.<br />If Request is omitted for, it defaults to Limits if that is explicitly specified,<br />otherwise to an implementation-defined value |  |  |
 | `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#toleration-v1-core) array_ | Tolerations describe the policy server pod's tolerations. It can be<br />used to ensure that the policy server pod is not scheduled onto a<br />node with a taint. |  |  |
+| `priorityClassName` _string_ | PriorityClassName is the name of the PriorityClass to be used for the<br />policy server pods. Useful to schedule policy server pods with higher<br />priority to ensure their availability over other cluster workload<br />resources.<br />Note: If the referenced PriorityClass is deleted, existing pods<br />remain unchanged, but new pods that reference it cannot be created. |  |  |
 
 
 

--- a/internal/controller/policyserver_controller_deployment.go
+++ b/internal/controller/policyserver_controller_deployment.go
@@ -408,6 +408,7 @@ func buildPolicyServerDeploymentSpec(
 				ServiceAccountName: policyServer.Spec.ServiceAccountName,
 				Tolerations:        policyServer.Spec.Tolerations,
 				Affinity:           &policyServer.Spec.Affinity,
+				PriorityClassName:  policyServer.Spec.PriorityClassName,
 				Volumes: []corev1.Volume{
 					{
 						Name: policyStoreVolume,

--- a/internal/controller/policyserver_controller_test.go
+++ b/internal/controller/policyserver_controller_test.go
@@ -132,6 +132,18 @@ var _ = Describe("PolicyServer controller", func() {
 			})))
 		})
 
+		It("should use the policy server priorityClassName configuration in the policy server deployment", func() {
+			policyServer := policiesv1.NewPolicyServerFactory().WithName(policyServerName).Build()
+			defaultSystemClusterCriticalPriorityClass := "system-cluster-critical" // one of the default highest PriorityClass
+			policyServer.Spec.PriorityClassName = defaultSystemClusterCriticalPriorityClass
+			createPolicyServerAndWaitForItsService(ctx, policyServer)
+
+			deployment, err := getTestPolicyServerDeployment(ctx, policyServerName)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(deployment.Spec.Template.Spec.PriorityClassName).To(Equal(defaultSystemClusterCriticalPriorityClass))
+		})
+
 		It("should create policy server deployment with some default configuration", func() {
 			policyServer := policiesv1.NewPolicyServerFactory().WithName(policyServerName).Build()
 			createPolicyServerAndWaitForItsService(ctx, policyServer)


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/kubewarden-controller/issues/1077

Add new optional PolicyServer.spec.PriorityClassName, and update the CRD definitions.

If the PolicyServer.spec.PriorityClassName is not set (or is an empty string), Kubernetes will not assign a PriorityClass and the Pods will inherit the default priority (behaviour prior to this change).

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Added a new unit test which checks that the `spec.PriorityClassName` is correctly used when set.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
