### PR TITLE
fix(docs): broken documention link

### DIFF
--- a/api/policies/v1alpha2/policyserver_types.go
+++ b/api/policies/v1alpha2/policyserver_types.go
@@ -32,7 +32,7 @@ type PolicyServerSpec struct {
 	// Annotations is an unstructured key value map stored with a resource that may be
 	// set by external tools to store and retrieve arbitrary metadata. They are not
 	// queryable and should be preserved when modifying objects.
-	// More info: http://kubernetes.io/docs/user-guide/annotations
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
 


### PR DESCRIPTION
## Description

Updates the v1alpha2 CRD fixing a broken documentation link.

Issue reported by @jhkrug 
