### PR TITLE
fix: remove legacy policy server service port from configuration.

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -10,7 +10,7 @@ const (
 	PolicyServerEnableMetricsEnvVar                 = "KUBEWARDEN_ENABLE_METRICS"
 	PolicyServerDeploymentConfigVersionAnnotation   = "kubewarden/config-version"
 	PolicyServerDeploymentPodSpecConfigVersionLabel = "kubewarden/config-version"
-	PolicyServerPort                                = 8443
+	PolicyServerListenPort                          = 8443
 	PolicyServerServicePort                         = 443
 	PolicyServerMetricsPortEnvVar                   = "KUBEWARDEN_POLICY_SERVER_SERVICES_METRICS_PORT"
 	PolicyServerMetricsPort                         = 8080

--- a/internal/controller/policyserver_controller_deployment.go
+++ b/internal/controller/policyserver_controller_deployment.go
@@ -598,7 +598,7 @@ func getPolicyServerContainer(policyServer *policiesv1.PolicyServer) corev1.Cont
 			},
 			{
 				Name:  "KUBEWARDEN_PORT",
-				Value: strconv.Itoa(constants.PolicyServerPort),
+				Value: strconv.Itoa(constants.PolicyServerListenPort),
 			},
 			{
 				Name:  "KUBEWARDEN_READINESS_PROBE_PORT",

--- a/internal/controller/policyserver_controller_service.go
+++ b/internal/controller/policyserver_controller_service.go
@@ -67,16 +67,7 @@ func (r *PolicyServerReconciler) updateService(svc *corev1.Service, policyServer
 			{
 				Name:       "policy-server",
 				Port:       constants.PolicyServerServicePort,
-				TargetPort: intstr.FromInt(constants.PolicyServerPort),
-				Protocol:   corev1.ProtocolTCP,
-			},
-			// Keep adding the old port to avoid breaking a cluster
-			// during the upgrade to Kubewarden 1.23.0
-			// TODO: remove this port with a future release
-			{
-				Name:       "policy-server-legacy",
-				Port:       constants.PolicyServerPort,
-				TargetPort: intstr.FromInt(constants.PolicyServerPort),
+				TargetPort: intstr.FromInt(constants.PolicyServerListenPort),
 				Protocol:   corev1.ProtocolTCP,
 			},
 		},

--- a/internal/controller/policyserver_controller_test.go
+++ b/internal/controller/policyserver_controller_test.go
@@ -645,12 +645,7 @@ var _ = Describe("PolicyServer controller", func() {
 				// This is the new port used by the policy server service
 				Expect(service.Spec.Ports).To(ContainElement(MatchFields(IgnoreExtras, Fields{
 					"Port":       Equal(int32(constants.PolicyServerServicePort)),
-					"TargetPort": Equal(intstr.IntOrString{IntVal: int32(constants.PolicyServerPort)}),
-				})))
-				// This is the legacy port used by the policy server service
-				Expect(service.Spec.Ports).To(ContainElement(MatchFields(IgnoreExtras, Fields{
-					"Port":       Equal(int32(constants.PolicyServerPort)),
-					"TargetPort": Equal(intstr.IntOrString{IntVal: int32(constants.PolicyServerPort)}),
+					"TargetPort": Equal(intstr.IntOrString{IntVal: int32(constants.PolicyServerListenPort)}),
 				})))
 				// This checks that the service has the legacy and recommended labels
 				// TODO simplify this with a future release


### PR DESCRIPTION
Removes the old policy server service port that was used before adding
port 443. This port was kept to avoid issues during the upgrade to
Kubewarden v1.23. Now, after several releases since switching to port
443, we can remove the old port from the service configuration.

Signed-off-by: José Guilherme Vanz <jguilhermevanz@suse.com>
