### PR TITLE
fix: policies file generation missing timeoutEvalSeconds.

### DIFF
--- a/internal/controller/policyserver_controller_configmap.go
+++ b/internal/controller/policyserver_controller_configmap.go
@@ -92,6 +92,7 @@ func (p policyServerConfigEntry) MarshalJSON() ([]byte, error) {
 		ContextAwareResources []policiesv1.ContextAwareResource `json:"contextAwareResources,omitempty"`
 		Settings              runtime.RawExtension              `json:"settings,omitempty"`
 		Message               string                            `json:"message,omitempty"`
+		TimeoutEvalSeconds    *int32                            `json:"timeoutEvalSeconds,omitempty"`
 	}{
 		NamespacedName:        p.NamespacedName,
 		Module:                p.Module,
@@ -100,6 +101,7 @@ func (p policyServerConfigEntry) MarshalJSON() ([]byte, error) {
 		ContextAwareResources: p.ContextAwareResources,
 		Settings:              p.Settings,
 		Message:               p.Message,
+		TimeoutEvalSeconds:    p.TimeoutEvalSeconds,
 	})
 	if err != nil {
 		return nil, errors.New("failed to encode policy server configuration")


### PR DESCRIPTION
## Description

The marshalling funcion used to generate the policies file used by policy-server to load the policies is missing the recently added timeoutEvalSeconds field. Therefore, the policy-server is not enforcing the evaluation timeout for the policies. This commit fix the tests to guarantee that the function is working as expected and fix the MarshalJSON code as well.

Fix #1206 


## Test

```shell
make test
```

