### PR TITLE
ci: fix attestation generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,16 +115,6 @@ jobs:
             jq '.layers[] | select(.annotations["in-toto.io/predicate-type"] == "https://slsa.dev/provenance/v0.2") | .digest')
           echo "PROVENANCE_DIGEST=${DIGEST}" >> "$GITHUB_ENV"
 
-      - name: Sign provenance manifest
-        run: |
-          cosign sign --yes \
-          ghcr.io/${{github.repository_owner}}/kubewarden-controller@${{ env.PROVENANCE_DIGEST}}
-
-          cosign verify \
-            --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-            --certificate-identity="https://github.com/${{github.repository_owner}}/kubewarden-controller/.github/workflows/release.yml@${{ github.ref }}" \
-            ghcr.io/${{github.repository_owner}}/kubewarden-controller@${{ env.PROVENANCE_DIGEST}}
-
       - name: Find SBOM manifest layer digest
         run: |
           set -e
@@ -132,30 +122,38 @@ jobs:
             jq '.layers | map(select(.annotations["in-toto.io/predicate-type"] == "https://spdx.dev/Document")) | map(.digest) | join(" ")')
           echo "SBOM_DIGEST=${DIGEST}" >> "$GITHUB_ENV"
 
+      # We need to upload provenance and SBOM files, plus their signatures under the GitHub Release page.
+      # Moreover, the files have to be named in a certain way.
+      # This is required by [ossf](https://github.com/ossf/scorecard/blob/main/docs/checks.md#signed-releases)
       - name: Download provenance and SBOM files
         run: |
           set -e
           crane blob ghcr.io/${{github.repository_owner}}/kubewarden-controller@${{ env.PROVENANCE_DIGEST}} \
-            > kubewarden-controller-attestation-${{ matrix.arch }}-provenance.json
-          sha256sum kubewarden-controller-attestation-${{ matrix.arch }}-provenance.json \
-            >> kubewarden-controller-attestation-${{ matrix.arch }}-checksum.txt
+            > kubewarden-controller-attestation-${{ matrix.arch }}-provenance.intoto.jsonl
 
           crane blob ghcr.io/${{github.repository_owner}}/kubewarden-controller@${{ env.SBOM_DIGEST}} \
             > kubewarden-controller-attestation-${{ matrix.arch }}-sbom.json
-          sha256sum kubewarden-controller-attestation-${{ matrix.arch }}-sbom.json \
-            >> kubewarden-controller-attestation-${{ matrix.arch }}-checksum.txt
 
-      - name: Sign checksum file
+      - name: Sign provenance and SBOM files
         run: |
+          set -e
           cosign sign-blob --yes \
-            --bundle kubewarden-controller-attestation-${{ matrix.arch }}-checksum-cosign.bundle \
-            kubewarden-controller-attestation-${{ matrix.arch }}-checksum.txt
-
+            --bundle kubewarden-controller-attestation-${{ matrix.arch }}-provenance.intoto.jsonl.bundle.sigstore \
+            kubewarden-controller-attestation-${{ matrix.arch }}-provenance.intoto.jsonl
           cosign verify-blob \
-            --bundle kubewarden-controller-attestation-${{ matrix.arch }}-checksum-cosign.bundle \
+            --bundle kubewarden-controller-attestation-${{ matrix.arch }}-provenance.intoto.jsonl.bundle.sigstore \
             --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
             --certificate-identity="https://github.com/${{github.repository_owner}}/kubewarden-controller/.github/workflows/release.yml@${{ github.ref }}" \
-            kubewarden-controller-attestation-${{ matrix.arch }}-checksum.txt
+            kubewarden-controller-attestation-${{ matrix.arch }}-provenance.intoto.jsonl
+
+          cosign sign-blob --yes \
+            --bundle kubewarden-controller-attestation-${{ matrix.arch }}-sbom.json.bundle.sigstore \
+            kubewarden-controller-attestation-${{ matrix.arch }}-sbom.json
+          cosign verify-blob \
+            --bundle kubewarden-controller-attestation-${{ matrix.arch }}-sbom.json.bundle.sigstore \
+            --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+            --certificate-identity="https://github.com/${{github.repository_owner}}/kubewarden-controller/.github/workflows/release.yml@${{ github.ref }}" \
+            kubewarden-controller-attestation-${{ matrix.arch }}-sbom.json
 
       - name: Upload SBOMs as artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -252,12 +250,6 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R
 
-      - name: Create tarball for the attestation files
-        run: |
-          for arch in "amd64" "arm64"; do
-            tar -czf attestation-$arch.tar.gz $(ls kubewarden-controller-attestation-$arch-*)
-          done
-
       - name: Upload release assets
         id: upload_release_assets
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
@@ -267,8 +259,14 @@ jobs:
             let path = require('path');
 
             let files = [
-              'attestation-amd64.tar.gz',
-              'attestation-arm64.tar.gz',
+              'kubewarden-controller-attestation-amd64-provenance.intoto.jsonl',
+              'kubewarden-controller-attestation-amd64-provenance.intoto.jsonl.bundle.sigstore',
+              'kubewarden-controller-attestation-arm64-provenance.intoto.jsonl',
+              'kubewarden-controller-attestation-arm64-provenance.intoto.jsonl.bundle.sigstore',
+              'kubewarden-controller-attestation-amd64-sbom.json',
+              'kubewarden-controller-attestation-amd64-sbom.json.bundle.sigstore',
+              'kubewarden-controller-attestation-arm64-sbom.json',
+              'kubewarden-controller-attestation-arm64-sbom.json.bundle.sigstore',
               "CRDS.tar.gz"]
             const {RELEASE_ID} = process.env
 


### PR DESCRIPTION
Release was broken because we've moved to cosign v3 as a result of updating to the latest release of cosign-installer GHA.

As opposed to v2, cosign v3 fails when we attempt to sign the attestation generated by docker buildx. That's because docker buildx pushes the attestations as blobs inside of the OCI registry.
When we invoke `cosign sign` using v3, the code attempts to find a `manifest`, and rightfully fails (there's no manifest at that location, just a blob).

That lead us to revisit why we were signing the attestation blob. It turns out we don't need to do that, since the attestation blob is part of the OCI index that is already signed by cosign.

We still need to upload the attestation and its signature to the GitHub Release as assets. That's one of the requirements of openssf.

While fixing the code, we also realized the assets need to be named in a different way to match the openssf checks. That's why, inside of this PR, we do no longer bundle them inside of an archive.

This is a port of https://github.com/kubewarden/sbomscanner/pull/552
