### PR TITLE
fix(ci): add second cosign signature for compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,15 +52,22 @@ jobs:
           provenance: mode=max
           tags: |
             ghcr.io/${{github.repository_owner}}/kubewarden-controller:${{ env.TAG_NAME }}
-      - name: Sign container image
+      # We need to disable the new bundle format enabled by default since
+      # cosign v3.x.x because some verification tools (e.g. slsactl and old
+      # cosign) are not able to properly verify the signatures using this
+      # new format
+      - name: Sign container image with cosign v2 signature format
         run: |
-          # We need to disable the new bundle format enabled by default since
-          # cosign v3.x.x because some verification tools (e.g. slsactl and old
-          # cosign) are not able to properly verify the signatures using this
-          # new format
           cosign sign --yes --new-bundle-format=false --use-signing-config=false \
             ghcr.io/${{github.repository_owner}}/kubewarden-controller@${{ steps.build-image.outputs.digest }}
 
+      - name: Sign container image with cosign v3 signature format
+        run: |
+          cosign sign --yes --new-bundle-format=true --use-signing-config=true \
+            ghcr.io/${{github.repository_owner}}/kubewarden-controller@${{ steps.build-image.outputs.digest }}
+
+      - name: Verify container image signature
+        run: |
           cosign verify \
             --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
             --certificate-identity="https://github.com/${{github.repository_owner}}/kubewarden-controller/.github/workflows/release.yml@${{ github.ref }}" \
@@ -141,22 +148,20 @@ jobs:
       - name: Sign provenance and SBOM files
         run: |
           set -e
-          # We need to disable the new bundle format enabled by default since
-          # cosign v3.x.x because some verification tools (e.g. slsactl and old
-          # cosign) are not able to properly verify the signatures using this
-          # new format
-          cosign sign-blob --yes --new-bundle-format=false --use-signing-config=false \
+          cosign sign-blob --yes \
             --bundle kubewarden-controller-attestation-${{ matrix.arch }}-provenance.intoto.jsonl.bundle.sigstore \
             kubewarden-controller-attestation-${{ matrix.arch }}-provenance.intoto.jsonl
+
           cosign verify-blob \
             --bundle kubewarden-controller-attestation-${{ matrix.arch }}-provenance.intoto.jsonl.bundle.sigstore \
             --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
             --certificate-identity="https://github.com/${{github.repository_owner}}/kubewarden-controller/.github/workflows/release.yml@${{ github.ref }}" \
             kubewarden-controller-attestation-${{ matrix.arch }}-provenance.intoto.jsonl
 
-          cosign sign-blob --yes --new-bundle-format=false --use-signing-config=false \
+          cosign sign-blob --yes \
             --bundle kubewarden-controller-attestation-${{ matrix.arch }}-sbom.json.bundle.sigstore \
             kubewarden-controller-attestation-${{ matrix.arch }}-sbom.json
+
           cosign verify-blob \
             --bundle kubewarden-controller-attestation-${{ matrix.arch }}-sbom.json.bundle.sigstore \
             --certificate-oidc-issuer=https://token.actions.githubusercontent.com \


### PR DESCRIPTION
## Description

In order to allow old cosign version and other verification tools to verify the signature it's necessary to add a second signature using the old format. The default format before cosign v3 changed the default signature bundle.

Updates the CI to sign the blobs using only cosign v3 signature bundle format.

