### PR TITLE
ci(renovate): group PRs by language

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,18 @@
     {
       "matchPackageNames": ["github.com/google/cel-go"],
       "enabled": false
+    },
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "Go dependencies"
+    },
+    {
+      "matchManagers": ["cargo"],
+      "groupName": "Rust dependencies"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions"
     }
   ]
 }


### PR DESCRIPTION
Make distinct PRs for rust, go and GHA updates.
