### PR TITLE
refactor: move internal/audit-scanner/cmd to cmd/audit-scanner

### DIFF
--- a/cmd/audit-scanner/logging.go
+++ b/cmd/audit-scanner/logging.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"fmt"

--- a/cmd/audit-scanner/main.go
+++ b/cmd/audit-scanner/main.go
@@ -1,10 +1,6 @@
 package main
 
-import (
-	"github.com/kubewarden/kubewarden-controller/internal/audit-scanner/cmd"
-)
-
 func main() {
-	rootCmd := cmd.NewRootCommand()
-	cmd.Execute(rootCmd)
+	rootCmd := NewRootCommand()
+	Execute(rootCmd)
 }

--- a/cmd/audit-scanner/root.go
+++ b/cmd/audit-scanner/root.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"context"


### PR DESCRIPTION
Move audit-scanner cmd module files to cmd/audit-scanner to follow idiomatic Go project structure. The cmd directory should contain main packages rather than having them in internal.

Fixes 1352
