### PR TITLE
label-based test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,15 +77,6 @@ jobs:
             fi
           fi
 
-          # Check if commit message contains [ci full] or [full ci] to run all checks
-          COMMIT_MSG='${{ github.event.head_commit.message }}'
-          if echo "$COMMIT_MSG" | grep -qiE '\[(ci full|full ci)\]'; then
-            echo "Commit message contains [ci full] or [full ci], running all checks"
-            echo "go=true" >> $GITHUB_OUTPUT
-            echo "rust=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
           # Determine base ref for comparison
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE_REF="${{ github.event.pull_request.base.sha }}"


### PR DESCRIPTION
This PR modernizes the CI trigger mechanism by replacing commit message-based triggers with GitHub labels:

- Removed: `[ci full]` and `[full ci]` commit message triggers
- Added: Three new labels for on-demand test execution:
  - `ci-rust`: Runs all Rust jobs
  - `ci-go`: Runs all Go jobs
  - `ci-full`: Runs complete test suite (both Rust and Go)
