### PR TITLE
ci: add rollup job for stable branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,3 +298,33 @@ jobs:
         run: make charts-check-common-values
       - name: helm unit tests
         run: make helm-unittest
+
+  # Rollup job for branch protection - single stable job name that depends on all checks
+  ci-success:
+    name: CI Success
+    if: always()
+    needs:
+      - changes
+      - test-go
+      - e2e-go
+      - golangci
+      - calculate-crates-matrix
+      - fmt-rust-per-crate
+      - clippy-rust-per-crate
+      - unit-tests-rust-per-crate
+      - integration-tests-burrego
+      - integration-tests-kwctl
+      - integration-tests-policy-server
+      - integration-tests-policy-evaluator
+      - shellcheck
+      - charts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all jobs status
+        run: |
+          # Check if any job failed or was cancelled
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" || "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more jobs failed or were cancelled"
+            exit 1
+          fi
+          echo "All jobs passed or were skipped"


### PR DESCRIPTION
Add a ci-success job that depends on all CI jobs to provide a single, stable status check for GitHub branch protection rules.

Previously, matrix jobs (fmt-rust-per-crate, clippy-rust-per-crate, unit-tests-rust-per-crate) created multiple dynamic status checks that confused GitHub's branch protection when used as merge criteria. Each matrix variant appeared as a separate check, making it impractical to configure required checks that would remain stable as the matrix changed.

The ci-success job runs after all checks complete (using if: always()) and fails if any dependency failed or was cancelled. This provides a single "CI Success" status check that can be configured as required for merging, regardless of matrix changes or conditional job execution.