### PR TITLE
chore(automation): move renovate config to monorepo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,7 +43,7 @@
       "groupName": "GitHub Actions"
     },
     {
-      "_comment": "bundle dependencies updates together",
+      "description": "bundle dependencies updates together",
       "matchUpdateTypes": [
         "patch",
         "minor",


### PR DESCRIPTION
Move the configuration of renovate into the monorepo. While doing that, disable the automatic merge for cargo lock files.
