### PR TITLE
fix: Don't add empty annotations key

### DIFF
--- a/charts/kubewarden-defaults/templates/policyserver-default.yaml
+++ b/charts/kubewarden-defaults/templates/policyserver-default.yaml
@@ -38,10 +38,12 @@ spec:
   {{- if .Values.policyServer.verificationConfig }}
   verificationConfig: {{ .Values.policyServer.verificationConfig }}
   {{- end }}
+  {{- if .Values.policyServer.annotations }}
   annotations:
     {{- range $key, $value := .Values.policyServer.annotations }}
       {{ $key | quote }}: {{ $value | quote }}
     {{- end }}
+  {{- end }}
   {{- if .Values.policyServer.env }}
   env:
     {{- range .Values.policyServer.env }}


### PR DESCRIPTION
## Description

In Helm4, validation has become stricter, resulting in the following error when installing:

```
❯ helm version
version.BuildInfo{Version:"v4.0.5", GitCommit:"1b6053d48b51673c5581973f5ae7e104f627fcf5", GitTreeState:"clean", GoVersion:"go1.25.5", KubeClientVersion:"v1.34"}
❯ helm install --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defaults
Error: INSTALLATION FAILED: failed to create resource: PolicyServer.policies.kubewarden.io "default" is invalid: spec.annotations: Invalid value: "null": spec.annotations in body must be of type object: "null"
```

This fix prevents the empty `spec.annotations` field from being rendered, making the template compatible with Helm4

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test


To test this pull request, you can run the following commands:

- Install Helm 4
- `helm install --wait -n kubewarden kubewarden-defaults ./charts/kubewarden-defaults`

## Additional Information

### Tradeoff

None, still compatible with previous Helm versions

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
