### PR TITLE
feat(ci): add Hauler manifest validation to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
     outputs:
       go: ${{ steps.changed-files.outputs.go }}
       rust: ${{ steps.changed-files.outputs.rust }}
+      ci-full: ${{ steps.changed-files.outputs.ci-full }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -42,6 +43,7 @@ jobs:
             echo "run_all=true, running all checks"
             echo "go=true" >> $GITHUB_OUTPUT
             echo "rust=true" >> $GITHUB_OUTPUT
+            echo "ci-full=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -54,6 +56,7 @@ jobs:
               echo "Label 'ci-full' found, running all checks"
               echo "go=true" >> $GITHUB_OUTPUT
               echo "rust=true" >> $GITHUB_OUTPUT
+              echo "ci-full=true" >> $GITHUB_OUTPUT
               exit 0
             fi
             
@@ -299,6 +302,16 @@ jobs:
       - name: helm unit tests
         run: make helm-unittest
 
+  validate-hauler-manifest:
+    name: Validate Hauler manifest
+    needs: changes
+    if: needs.changes.outputs.ci-full == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Run validation script
+        run: ./scripts/validate-hauler-manifest.sh
+
   # Rollup job for branch protection - single stable job name that depends on all checks
   ci-success:
     name: CI Success
@@ -318,6 +331,7 @@ jobs:
       - integration-tests-policy-evaluator
       - shellcheck
       - charts
+      - validate-hauler-manifest
     runs-on: ubuntu-latest
     steps:
       - name: Check all jobs status

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,12 @@
+# Scripts Directory
+
+This directory contains utility scripts used for development, testing, and
+CI/CD operations for the Kubewarden project.
+
+The scripts in this directory serve various purposes:
+
+- **Validation and Testing:** Ensure consistency and correctness of project
+  artifacts
+- **Chart Management:** Helper scripts for Helm chart operations
+- **Policy Operations:** Tools for managing Kubewarden policies
+- **Maintenance:** Scripts for cleanup and uninstallation tasks

--- a/scripts/validate-hauler-manifest.sh
+++ b/scripts/validate-hauler-manifest.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+
+# This script validates that the Hauler manifest
+# (`charts/hauler_manifest.yaml`) stays in sync with Helm chart definitions. It
+# compares versions of container images and Helm charts between the chart
+# definitions and the Hauler manifest to prevent version mismatches that could
+# cause issues in air-gapped deployments.
+# 
+# The script runs automatically in CI when the `ci-full` label is added to a
+# PR, on pushes to the main branch, and on manual workflow triggers. It
+# validates all container images (kubewarden-controller, audit-scanner,
+# policy-server, kuberlr-kubectl, and policy modules) and Helm charts
+# (kubewarden-crds, kubewarden-controller, kubewarden-defaults,
+# policy-reporter, openreports).
+# 
+# The weekly updatecli workflow automatically updates both Helm chart values
+# and the Hauler manifest. This validation serves as a safety check to catch
+# any manual changes or update failures.
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+HAULER_MANIFEST="$REPO_ROOT/charts/hauler_manifest.yaml"
+CONTROLLER_VALUES="$REPO_ROOT/charts/kubewarden-controller/values.yaml"
+DEFAULTS_VALUES="$REPO_ROOT/charts/kubewarden-defaults/values.yaml"
+CONTROLLER_CHART="$REPO_ROOT/charts/kubewarden-controller/Chart.yaml"
+DEFAULTS_CHART="$REPO_ROOT/charts/kubewarden-defaults/Chart.yaml"
+CRDS_CHART="$REPO_ROOT/charts/kubewarden-crds/Chart.yaml"
+
+ERRORS=0
+
+echo "🔍 Validating Hauler manifest against Helm charts..."
+echo
+
+# Check if yq is installed
+if ! command -v yq &> /dev/null; then
+    echo -e "${RED}❌ Error: yq is not installed. Please install yq v4.x${NC}"
+    echo "   Install: https://github.com/mikefarah/yq#install"
+    exit 1
+fi
+
+# Function to extract image version from Hauler manifest
+get_hauler_image_version() {
+    local image_name=$1
+    yq eval ".spec.images[] | select(.name | contains(\"$image_name\")) | .name" "$HAULER_MANIFEST" | sed 's/.*://'
+}
+
+# Function to compare versions
+compare_version() {
+    local name=$1
+    local chart_version=$2
+    local hauler_version=$3
+    local location=$4
+
+    if [[ "$chart_version" != "$hauler_version" ]]; then
+        echo -e "${RED}❌ Mismatch: $name${NC}"
+        echo "   Chart ($location): $chart_version"
+        echo "   Hauler manifest: $hauler_version"
+        echo
+        ERRORS=$((ERRORS + 1))
+    else
+        echo -e "${GREEN}✅ Match: $name = $chart_version${NC}"
+    fi
+}
+
+echo "📦 Validating Container Images..."
+echo "=================================="
+echo
+
+# Validate kubewarden-controller image
+CONTROLLER_CHART_VERSION=$(yq eval '.image.tag' "$CONTROLLER_VALUES")
+CONTROLLER_HAULER_VERSION=$(get_hauler_image_version "kubewarden-controller")
+compare_version "kubewarden-controller" "$CONTROLLER_CHART_VERSION" "$CONTROLLER_HAULER_VERSION" "$CONTROLLER_VALUES"
+
+# Validate audit-scanner image
+AUDIT_SCANNER_CHART_VERSION=$(yq eval '.auditScanner.image.tag' "$CONTROLLER_VALUES")
+AUDIT_SCANNER_HAULER_VERSION=$(get_hauler_image_version "audit-scanner")
+compare_version "audit-scanner" "$AUDIT_SCANNER_CHART_VERSION" "$AUDIT_SCANNER_HAULER_VERSION" "$CONTROLLER_VALUES"
+
+# Validate policy-server image
+POLICY_SERVER_CHART_VERSION=$(yq eval '.policyServer.image.tag' "$DEFAULTS_VALUES")
+POLICY_SERVER_HAULER_VERSION=$(get_hauler_image_version "policy-server")
+compare_version "policy-server" "$POLICY_SERVER_CHART_VERSION" "$POLICY_SERVER_HAULER_VERSION" "$DEFAULTS_VALUES"
+
+# Validate kuberlr-kubectl image
+KUBERLR_CHART_VERSION=$(yq eval '.preDeleteJob.image.tag' "$CONTROLLER_VALUES")
+KUBERLR_HAULER_VERSION=$(get_hauler_image_version "kuberlr-kubectl")
+compare_version "kuberlr-kubectl" "$KUBERLR_CHART_VERSION" "$KUBERLR_HAULER_VERSION" "$CONTROLLER_VALUES"
+
+echo
+echo "🔐 Validating Policy Images..."
+echo "==============================="
+echo
+
+# Validate allow-privilege-escalation-psp policy
+POLICY_VERSION=$(yq eval '.recommendedPolicies.allowPrivilegeEscalationPolicy.module.tag' "$DEFAULTS_VALUES")
+HAULER_VERSION=$(get_hauler_image_version "allow-privilege-escalation-psp")
+compare_version "allow-privilege-escalation-psp" "$POLICY_VERSION" "$HAULER_VERSION" "$DEFAULTS_VALUES"
+
+# Validate capabilities-psp policy
+POLICY_VERSION=$(yq eval '.recommendedPolicies.capabilitiesPolicy.module.tag' "$DEFAULTS_VALUES")
+HAULER_VERSION=$(get_hauler_image_version "capabilities-psp")
+compare_version "capabilities-psp" "$POLICY_VERSION" "$HAULER_VERSION" "$DEFAULTS_VALUES"
+
+# Validate host-namespaces-psp policy
+POLICY_VERSION=$(yq eval '.recommendedPolicies.hostNamespacePolicy.module.tag' "$DEFAULTS_VALUES")
+HAULER_VERSION=$(get_hauler_image_version "host-namespaces-psp")
+compare_version "host-namespaces-psp" "$POLICY_VERSION" "$HAULER_VERSION" "$DEFAULTS_VALUES"
+
+# Validate hostpaths-psp policy
+POLICY_VERSION=$(yq eval '.recommendedPolicies.hostPathsPolicy.module.tag' "$DEFAULTS_VALUES")
+HAULER_VERSION=$(get_hauler_image_version "hostpaths-psp")
+compare_version "hostpaths-psp" "$POLICY_VERSION" "$HAULER_VERSION" "$DEFAULTS_VALUES"
+
+# Validate pod-privileged policy
+POLICY_VERSION=$(yq eval '.recommendedPolicies.podPrivilegedPolicy.module.tag' "$DEFAULTS_VALUES")
+HAULER_VERSION=$(get_hauler_image_version "pod-privileged")
+compare_version "pod-privileged" "$POLICY_VERSION" "$HAULER_VERSION" "$DEFAULTS_VALUES"
+
+# Validate user-group-psp policy
+POLICY_VERSION=$(yq eval '.recommendedPolicies.userGroupPolicy.module.tag' "$DEFAULTS_VALUES")
+HAULER_VERSION=$(get_hauler_image_version "user-group-psp")
+compare_version "user-group-psp" "$POLICY_VERSION" "$HAULER_VERSION" "$DEFAULTS_VALUES"
+
+echo
+echo "📋 Validating Helm Charts..."
+echo "============================="
+echo
+
+# Function to extract chart version from Hauler manifest
+get_hauler_chart_version() {
+    local chart_name=$1
+    yq eval ".spec.charts[] | select(.name == \"$chart_name\") | .version" "$HAULER_MANIFEST"
+}
+
+# Validate kubewarden-crds chart
+CHART_VERSION=$(yq eval '.version' "$CRDS_CHART")
+HAULER_VERSION=$(get_hauler_chart_version "kubewarden-crds")
+compare_version "kubewarden-crds chart" "$CHART_VERSION" "$HAULER_VERSION" "$CRDS_CHART"
+
+# Validate kubewarden-controller chart
+CHART_VERSION=$(yq eval '.version' "$CONTROLLER_CHART")
+HAULER_VERSION=$(get_hauler_chart_version "kubewarden-controller")
+compare_version "kubewarden-controller chart" "$CHART_VERSION" "$HAULER_VERSION" "$CONTROLLER_CHART"
+
+# Validate kubewarden-defaults chart
+CHART_VERSION=$(yq eval '.version' "$DEFAULTS_CHART")
+HAULER_VERSION=$(get_hauler_chart_version "kubewarden-defaults")
+compare_version "kubewarden-defaults chart" "$CHART_VERSION" "$HAULER_VERSION" "$DEFAULTS_CHART"
+
+# Validate policy-reporter chart (from kubewarden-controller dependencies)
+CHART_VERSION=$(yq eval '.dependencies[0].version' "$CONTROLLER_CHART")
+HAULER_VERSION=$(get_hauler_chart_version "policy-reporter")
+compare_version "policy-reporter chart" "$CHART_VERSION" "$HAULER_VERSION" "$CONTROLLER_CHART dependencies"
+
+# Validate openreports chart (from kubewarden-crds dependencies)
+CHART_VERSION=$(yq eval '.dependencies[0].version' "$CRDS_CHART")
+HAULER_VERSION=$(get_hauler_chart_version "openreports")
+compare_version "openreports chart" "$CHART_VERSION" "$HAULER_VERSION" "$CRDS_CHART dependencies"
+
+echo
+echo "=================================="
+if [[ $ERRORS -eq 0 ]]; then
+    echo -e "${GREEN}✅ All validations passed! Hauler manifest is in sync with Helm charts.${NC}"
+    exit 0
+else
+    echo -e "${RED}❌ Found $ERRORS version mismatch(es). Please update the Hauler manifest.${NC}"
+    echo
+    echo -e "${YELLOW}💡 Tip: The updatecli workflow should automatically keep these in sync.${NC}"
+    echo "   If you're seeing this error, you may need to run updatecli manually or"
+    echo "   wait for the next scheduled run (Mondays at 3:30 AM)."
+    exit 1
+fi


### PR DESCRIPTION
## Description

Add automated validation to ensure the Hauler manifest stays in sync with Helm chart definitions. This prevents version mismatches that could cause issues in air-gapped deployments.

The validation script compares container image versions and Helm chart versions between the chart definitions and the Hauler manifest, failing if any mismatches are detected. This is integrated as a new job in the main CI workflow that runs on all PRs and pushes.

This complements the updatecli automation by providing a safety check to catch manual changes or update failures.

Fix https://github.com/kubewarden/kubewarden-controller/issues/1411

@kubewarden/kubewarden-developers let's wait for the other hauler PRs (https://github.com/kubewarden/kubewarden-controller/pull/1410, https://github.com/kubewarden/kubewarden-controller/pull/1409 ) to get merged first.

## Test

This is an output of the validation script of a run in this branch:

```console
🔍 Validating Hauler manifest against Helm charts...

📦 Validating Container Images...
==================================

[0;31m❌ Mismatch: kubewarden-controller[0m
   Chart (/home/jvanz/SUSE/kubewarden-controller/charts/kubewarden-controller/values.yaml): v1.32.0-rc3
   Hauler manifest: v1.31.0

[0;31m❌ Mismatch: audit-scanner[0m
   Chart (/home/jvanz/SUSE/kubewarden-controller/charts/kubewarden-controller/values.yaml): v1.32.0-rc3
   Hauler manifest: v1.31.0

[0;31m❌ Mismatch: policy-server[0m
   Chart (/home/jvanz/SUSE/kubewarden-controller/charts/kubewarden-defaults/values.yaml): v1.32.0-rc3
   Hauler manifest: v1.31.0

[0;31m❌ Mismatch: kuberlr-kubectl[0m
   Chart (/home/jvanz/SUSE/kubewarden-controller/charts/kubewarden-controller/values.yaml): v7.0.0
   Hauler manifest: v6.0.0


🔐 Validating Policy Images...
===============================

[0;31m❌ Mismatch: allow-privilege-escalation-psp[0m
   Chart (/home/jvanz/SUSE/kubewarden-controller/charts/kubewarden-defaults/values.yaml): v1.0.9
   Hauler manifest: v1.0.5

[0;31m❌ Mismatch: capabilities-psp[0m
   Chart (/home/jvanz/SUSE/kubewarden-controller/charts/kubewarden-defaults/values.yaml): v1.0.9
   Hauler manifest: v1.0.7

[0;31m❌ Mismatch: host-namespaces-psp[0m
   Chart (/home/jvanz/SUSE/kubewarden-controller/charts/kubewarden-defaults/values.yaml): v1.1.7
   Hauler manifest: v1.1.5

[0;31m❌ Mismatch: hostpaths-psp[0m
   Chart (/home/jvanz/SUSE/kubewarden-controller/charts/kubewarden-defaults/values.yaml): v1.1.6
   Hauler manifest: v1.1.2

[0;31m❌ Mismatch: pod-privileged[0m
   Chart (/home/jvanz/SUSE/kubewarden-controller/charts/kubewarden-defaults/values.yaml): v1.0.9
   Hauler manifest: v1.0.8

[0;31m❌ Mismatch: user-group-psp[0m
   Chart (/home/jvanz/SUSE/kubewarden-controller/charts/kubewarden-defaults/values.yaml): v1.1.4
   Hauler manifest: v1.1.2


📋 Validating Helm Charts...
=============================

[0;31m❌ Mismatch: kubewarden-crds chart[0m
   Chart (/home/jvanz/SUSE/kubewarden-controller/charts/kubewarden-crds/Chart.yaml): 1.24.0-rc3
   Hauler manifest: 1.23.0

[0;31m❌ Mismatch: kubewarden-controller chart[0m
   Chart (/home/jvanz/SUSE/kubewarden-controller/charts/kubewarden-controller/Chart.yaml): 5.10.0-rc3
   Hauler manifest: 5.9.0

[0;31m❌ Mismatch: kubewarden-defaults chart[0m
   Chart (/home/jvanz/SUSE/kubewarden-controller/charts/kubewarden-defaults/Chart.yaml): 3.10.0-rc3
   Hauler manifest: 3.9.0

[0;32m✅ Match: policy-reporter chart = 3.7.0[0m
[0;32m✅ Match: openreports chart = 0.2.1[0m

==================================
[0;31m❌ Found 13 version mismatch(es). Please update the Hauler manifest.[0m

[1;33m💡 Tip: The updatecli workflow should automatically keep these in sync.[0m
   If you're seeing this error, you may need to run updatecli manually or
   wait for the next scheduled run (Mondays at 3:30 AM).

```

