### PR TITLE
ci: fixed renovate grouping directive

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,58 +4,31 @@
     "helpers:pinGitHubActionDigestsToSemver",
     "schedule:weekends"
   ],
-  "labels": [
-    "area/dependencies"
-  ],
+  "labels": ["area/dependencies"],
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": false
   },
   "packageRules": [
     {
-      "matchPackageNames": [
-        "k8s.io/client-go"
-      ],
+      "matchPackageNames": ["k8s.io/client-go"],
       "allowedVersions": "/^0\\.[0-9]+\\.[0-9]+$/"
     },
     {
-      "matchPackageNames": [
-        "github.com/google/cel-go"
-      ],
+      "matchPackageNames": ["github.com/google/cel-go"],
       "enabled": false
     },
     {
-      "matchManagers": [
-        "gomod"
-      ],
+      "matchManagers": ["gomod"],
       "groupName": "Go dependencies"
     },
     {
-      "matchManagers": [
-        "cargo"
-      ],
+      "matchManagers": ["cargo"],
       "groupName": "Rust dependencies"
     },
     {
-      "matchManagers": [
-        "github-actions"
-      ],
+      "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions"
-    },
-    {
-      "description": "bundle dependencies updates together",
-      "matchUpdateTypes": [
-        "patch",
-        "minor",
-        "major"
-      ],
-      "groupName": "all dependencies updates",
-      "groupSlug": "all-updates",
-      "matchPackageNames": [
-        "*"
-      ],
-      "semanticCommits": "enabled",
-      "semanticCommitType": "build"
     }
   ],
   "rebaseWhen": "behind-base-branch",


### PR DESCRIPTION
Remove a wrong grouping directive from renovate's configuration.

That caused one big PR to be created, instead of theme-based ones.

See https://github.com/kubewarden/kubewarden-controller/pull/1414 as an example of that.
