### PR TITLE
ci(renovate): ignore wg-policy-prototype

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,31 +4,48 @@
     "helpers:pinGitHubActionDigestsToSemver",
     "schedule:weekends"
   ],
-  "labels": ["area/dependencies"],
+  "labels": [
+    "area/dependencies"
+  ],
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": false
   },
   "packageRules": [
     {
-      "matchPackageNames": ["k8s.io/client-go"],
+      "matchPackageNames": [
+        "k8s.io/client-go"
+      ],
       "allowedVersions": "/^0\\.[0-9]+\\.[0-9]+$/"
     },
     {
-      "matchPackageNames": ["github.com/google/cel-go"],
+      "matchPackageNames": [
+        "github.com/google/cel-go"
+      ],
       "enabled": false
     },
     {
-      "matchManagers": ["gomod"],
+      "matchManagers": [
+        "gomod"
+      ],
       "groupName": "Go dependencies"
     },
     {
-      "matchManagers": ["cargo"],
+      "matchManagers": [
+        "cargo"
+      ],
       "groupName": "Rust dependencies"
     },
     {
-      "matchManagers": ["github-actions"],
+      "matchManagers": [
+        "github-actions"
+      ],
       "groupName": "GitHub Actions"
+    },
+    {
+      "ignoreDeps": [
+        "sigs.k8s.io/wg-policy-prototypes*"
+      ]
     }
   ],
   "rebaseWhen": "behind-base-branch",


### PR DESCRIPTION
This module is discontinued and we're going to remove it soon. We have configured the `go.mod` to stick to the latest version that works for us, but renovate keeps trying to update (and break) it.
