### PR TITLE
ci: Disable bumps for local docker images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,31 @@
   },
   "packageRules": [
     {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "kubewarden/kubewarden-controller",
+        "kubewarden/audit-scanner"
+      ],
+      "matchPaths": [
+        "charts/kubewarden-controller/values.yaml"
+      ],
+      "enabled": false
+    },
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "kubewarden/policy-server"
+      ],
+      "matchPaths": [
+        "charts/kubewarden-defaults/values.yaml"
+      ],
+      "enabled": false
+    },
+    {
       "matchPackageNames": [
         "k8s.io/client-go"
       ],


### PR DESCRIPTION

## Description

This should fix warning:

> Renovate failed to look up the following dependencies:
>
> Failed to look up docker package kubewarden/kubewarden-controller, Failed to look up docker package kubewarden/audit-scanner, Failed to look up docker package kubewarden/policy-server
>
> Files affected:
>
> charts/kubewarden-controller/values.yaml,
> charts/kubewarden-defaults/values.yaml

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
