### PR TITLE
chore: rename hauler.yaml references to hauler_manifest.yaml

### DIFF
--- a/charts/hauler_manifest.yaml
+++ b/charts/hauler_manifest.yaml
@@ -3,7 +3,7 @@
 #
 # To sync this file with Hauler and load everything into its storage, you can
 # run:
-# hauler store sync --filename hauler.yaml
+# hauler store sync --filename hauler_manifest.yaml
 apiVersion: content.hauler.cattle.io/v1
 kind: Images
 metadata:

--- a/updatecli/update-deps-values.yaml
+++ b/updatecli/update-deps-values.yaml
@@ -61,7 +61,7 @@ ociArtifacts:
     key: "$.preDeleteJob.image.tag"
 # The helmCharts list all the Helm charts listed in the Hauler that needs to be
 # updated regurlarly. This list should be in the same order as defined in the
-# charts/hauler.yaml file.
+# charts/hauler_manifest.yaml file.
 helmCharts:
   - name: kubewarden-crds
     file: "charts/kubewarden-crds/Chart.yaml"

--- a/updatecli/updatecli.d/update-hauler-manifest.yaml
+++ b/updatecli/updatecli.d/update-hauler-manifest.yaml
@@ -69,7 +69,7 @@ conditions:
     kind: yaml
     disablesourceinput: true
     spec:
-      file: "charts/hauler.yaml"
+      file: "charts/hauler_manifest.yaml"
       key: "$.spec.charts[{{ $i }}].name"
       value: "{{ $chart.name }}"
   # {{ end }}
@@ -85,7 +85,7 @@ targets:
     dependson:
       - '{{ printf "source#source/%sVersion" $oci.image }}'
     spec:
-      file: "charts/hauler.yaml"
+      file: "charts/hauler_manifest.yaml"
       matchpattern: "(.*)- ?name: ?{{ $oci.image }}:(v?.+) ?(.*)"
       replacepattern: '$1- name: {{ $oci.image }}:{{ printf "source/%sVersion" $oci.image | source }}'
   # {{ if $oci.workflowUrl }}
@@ -97,7 +97,7 @@ targets:
       - '{{ printf "source#source/%sVersion" $oci.image }}'
     scmid: "default"
     spec:
-      file: "charts/hauler.yaml"
+      file: "charts/hauler_manifest.yaml"
       matchpattern: "(.*)? certificate-identity-regexp: ?{{ $oci.workflowUrl }}/(v?.+) ?(.*)"
       replacepattern: '$1 certificate-identity-regexp: {{ $oci.workflowUrl }}/{{ printf "source/%sVersion" $oci.image | source }}'
   # {{ end }}
@@ -111,7 +111,7 @@ targets:
     dependson:
       - '{{ printf "condition#condition/%sPosition" $chart.name }}'
     spec:
-      file: "charts/hauler.yaml"
+      file: "charts/hauler_manifest.yaml"
       # Yamlpath to filter the helm chart by name did not work. That's why we
       # have the condition to ensure the script is not updating the wrong helm
       # chart
@@ -123,7 +123,7 @@ targets:
     sourceid: policyReporterChartAppVersion
     scmid: default
     spec:
-      file: "charts/hauler.yaml"
+      file: "charts/hauler_manifest.yaml"
       matchpattern: "(.*)- ?name: ?ghcr.io/kyverno/policy-reporter:(v?.+) ?(.*)"
       replacepattern: '$1- name: ghcr.io/kyverno/policy-reporter:{{ source "policyReporterChartAppVersion" }}'
   policyReporterUIImage:
@@ -132,7 +132,7 @@ targets:
     sourceid: policyReporterChartUIImageTagValue
     scmid: default
     spec:
-      file: "charts/hauler.yaml"
+      file: "charts/hauler_manifest.yaml"
       matchpattern: "(.*)- ?name: ?ghcr.io/kyverno/policy-reporter-ui:(v?.+) ?(.*)"
       replacepattern: '$1- name: ghcr.io/kyverno/policy-reporter-ui:{{ source "policyReporterChartUIImageTagValue" }}'
 

--- a/updatecli/updatecli.release.d/open-release-pr.yaml
+++ b/updatecli/updatecli.release.d/open-release-pr.yaml
@@ -70,21 +70,21 @@ conditions:
     kind: yaml
     disablesourceinput: true
     spec:
-      file: "./charts/hauler.yaml"
+      file: "./charts/hauler_manifest.yaml"
       key: "$.spec.charts[0].name"
       value: "kubewarden-crds"
   kubewardenControllerChartPosition:
     kind: yaml
     disablesourceinput: true
     spec:
-      file: "./charts/hauler.yaml"
+      file: "./charts/hauler_manifest.yaml"
       key: "$.spec.charts[1].name"
       value: "kubewarden-controller"
   kubewardenDefaultsChartPosition:
     kind: yaml
     disablesourceinput: true
     spec:
-      file: "./charts/hauler.yaml"
+      file: "./charts/hauler_manifest.yaml"
       key: "$.spec.charts[2].name"
       value: "kubewarden-defaults"
 
@@ -95,7 +95,7 @@ targets:
     sourceid: crdsChartVersion
     scmid: "default"
     spec:
-      file: "charts/hauler.yaml"
+      file: "charts/hauler_manifest.yaml"
       # Yamlpath to filter the helm chart by name did not work. That's why we
       # have the condition to ensure the script is not updating the wrong helm
       # chart
@@ -106,7 +106,7 @@ targets:
     sourceid: controllerChartVersion
     scmid: "default"
     spec:
-      file: "charts/hauler.yaml"
+      file: "charts/hauler_manifest.yaml"
       # Yamlpath to filter the helm chart by name did not work. That's why we
       # have the condition to ensure the script is not updating the wrong helm
       # chart
@@ -117,7 +117,7 @@ targets:
     sourceid: "defaultsChartVersion"
     scmid: "default"
     spec:
-      file: "charts/hauler.yaml"
+      file: "charts/hauler_manifest.yaml"
       # Yamlpath to filter the helm chart by name did not work. That's why we
       # have the condition to ensure the script is not updating the wrong helm
       # chart


### PR DESCRIPTION
## Description

Updated all references to the hauler.yaml file to use the new hauler_manifest.yaml filename across updatecli configuration files (update-deps-values.yaml, open-release-pr.yaml, and update-hauler-manifest.yaml) and the charts directory to maintain consistency with the renamed manifest file.

This changes are done to avoid the changes here:  https://github.com/kubewarden/helm-charts/pull/921
