### PR TITLE
chore: add vendor directory in the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ tilt-settings.yaml
 
 # envtest files
 .envtest
+
+vendor/


### PR DESCRIPTION
Updates the .gitignore file adding the vendor directory. This directory
is never commit and adding it there will make git commit more simple and
fast to type.
