### PR TITLE
fix(scripts): validate policy-reporter images from Hauler manifest.

### DIFF
--- a/scripts/validate-hauler-manifest.sh
+++ b/scripts/validate-hauler-manifest.sh
@@ -102,7 +102,7 @@ echo
 
 # Extract policy-reporter chart metadata from the vendored chart
 POLICY_REPORTER_CHART_PATH="$REPO_ROOT/charts/kubewarden-controller/charts"
-POLICY_REPORTER_CHART_VERSION=$(yq eval '.dependencies[0].version' "$CONTROLLER_CHART")
+POLICY_REPORTER_CHART_VERSION=$(yq -e eval '.dependencies[0].version' "$CONTROLLER_CHART")
 POLICY_REPORTER_TGZ="$POLICY_REPORTER_CHART_PATH/policy-reporter-${POLICY_REPORTER_CHART_VERSION}.tgz"
 
 # Check if the vendored chart exists


### PR DESCRIPTION
## Description

Updates the validate-hauler-manifest.sh script to validate the policy-reporter container images as well. Therefore, we ensure that the versions will not diverge.

```console
🔍 Validating Hauler manifest against Helm charts...                                                                                              ✔ │ 11:42:09 

📦 Validating Container Images...
==================================

✅ Match: kubewarden-controller = v1.32.0-rc4
✅ Match: audit-scanner = v1.32.0-rc4
✅ Match: policy-server = v1.32.0-rc4
✅ Match: kuberlr-kubectl = v7.0.0

🌐 Validating Third-Party Images...
====================================

❌ Mismatch: policy-reporter
   Chart (policy-reporter chart (appVersion)): 3.6.0
   Hauler manifest: 3.7.0

❌ Mismatch: policy-reporter-ui
   Chart (policy-reporter chart (ui.image.tag)): 2.5.0
   Hauler manifest: 2.5.1


🔐 Validating Policy Images...
===============================

✅ Match: allow-privilege-escalation-psp = v1.0.10
✅ Match: capabilities-psp = v1.0.10
✅ Match: host-namespaces-psp = v1.1.8
✅ Match: hostpaths-psp = v1.1.7
✅ Match: pod-privileged = v1.0.10
✅ Match: user-group-psp = v1.1.5

📋 Validating Helm Charts...
=============================

✅ Match: kubewarden-crds chart = 1.24.0-rc4
✅ Match: kubewarden-controller chart = 5.10.0-rc4
✅ Match: kubewarden-defaults chart = 3.10.0-rc4
✅ Match: policy-reporter chart = 3.7.0
✅ Match: openreports chart = 0.2.1

==================================
❌ Found 2 version mismatch(es). Please update the Hauler manifest.

💡 Tip: The updatecli workflow should automatically keep these in sync.
   If you're seeing this error, you may need to run updatecli manually or
   wait for the next scheduled run (Mondays at 3:30 AM).
```
