### PR TITLE
fix(ci): required permissions to run ci from release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,24 @@ permissions: read-all
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml
-    permissions: read-all
+    # Specify all permissions explicitly - read for most, write for attestations
+    permissions:
+      actions: read
+      artifact-metadata: read
+      attestations: write
+      checks: read
+      contents: read
+      deployments: read
+      discussions: read
+      id-token: write
+      issues: read
+      models: read
+      packages: read
+      pages: read
+      pull-requests: read
+      repository-projects: read
+      security-events: read
+      statuses: read
     with:
       run_all: true
 


### PR DESCRIPTION
## Description

In order to run the CI workflow in the release CI, it's necessary to give some write permissions required by a nested job (build-kwctl).

[Here](https://github.com/jvanz/kubewarden-controller/actions/runs/21678645508/job/62506239371) is an example of the running CI after this fix. 

