### PR TITLE
ci: Trigger helm-charts PR on succesful release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,3 +248,31 @@ jobs:
               prerelease: isPreRelease,
               make_latest: !isPreRelease
             });
+
+  sync-helm-charts:
+    name: Trigger Helm Charts Sync Workflow
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: generate-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            helm-charts
+      - name: Trigger chart update
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          echo '{
+            "event_type": "release-adm-controller",
+            "client_payload": {
+              "source_repo": "${{ github.repository }}",
+              "tag": "${{ github.ref_name }}"
+            }
+          }' > payload.json
+          gh api repos/${{ github.repository_owner }}/helm-charts/dispatches \
+            -X POST \
+            --input payload.json


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/kubewarden-controller/issues/1443
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

This needs our GH app to have the following permissions:
- [actions: read & write](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-actions)
- [contents: read & write](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-contents). Read is not enough, see [here](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event--fine-grained-access-tokens).

Under the GH app settings page, a coaster will appear informing of the need of these actions to enable them.
NOTE: this is the way to enable permissions, as going to the settings were all of the permissions are laid out DOES NOT change the permissions ultimately.

This is tooooo broad, particularly the contents permissions.



## Test

<!-- Please provides a short description about how to test your pullrequest -->
On my fork: https://github.com/viccuad/kubewarden-controller/actions/runs/21748856519/job/62742530484
Which triggered https://github.com/viccuad/helm-charts/actions/runs/21749181999 (ignore error on opening PR)
<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

Sbomscanner tackles this by having the full updatecli job that updates the helm-charts repo be inside the sbomscanner repo, and using updatecli with the GH app token to open a normal PR. Which is what we moved away from.


### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
