### PR TITLE
chore(deps): update rust dependency bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cached"


### PR DESCRIPTION
Patch release required to address RUSTSEC-2026-0007.

This was notified by our daily audit GHA (see [here](https://github.com/kubewarden/kubewarden-controller/actions/runs/21733937434/job/62694686738)).
