### PR TITLE
fix(ci): update hauler manifest on release.

### DIFF
--- a/.github/workflows/open-release-pr.yml
+++ b/.github/workflows/open-release-pr.yml
@@ -38,5 +38,4 @@ jobs:
           UPDATECLI_GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
         run: |-
-          updatecli apply --config updatecli/updatecli.release.d/open-release-pr.yaml \
-            --values updatecli/values.yaml
+          updatecli compose apply --file ./updatecli/open-release-pr.yaml

--- a/updatecli/open-release-pr.yaml
+++ b/updatecli/open-release-pr.yaml
@@ -1,0 +1,9 @@
+policies:
+  - name: Open release PR
+    config:
+      - ./updatecli.release.d/open-release-pr.yaml
+      - ./updatecli.d/update-hauler-manifest.yaml
+    values:
+      - ./values/scms.yaml
+      - ./values/deps-values.yaml
+      - ./values/release-pr-values.yaml

--- a/updatecli/updatecli.d/update-hauler-manifest.yaml
+++ b/updatecli/updatecli.d/update-hauler-manifest.yaml
@@ -134,6 +134,7 @@ targets:
       matchpattern: "(.*)- ?name: ?ghcr.io/kyverno/policy-reporter-ui:(v?.+) ?(.*)"
       replacepattern: '$1- name: ghcr.io/kyverno/policy-reporter-ui:{{ source "policyReporterChartUIImageTagValue" }}'
 
+# {{ if .pr.haulerUpdatePr }}
 actions:
   openUpdatePR:
     title: '{{ default "deps: Update helm chart dependencies" .pr.title }}'
@@ -158,3 +159,4 @@ actions:
       labels:
         - "kind/chore"
         - "area/dependencies"
+# {{ end }}

--- a/updatecli/updatecli.release.d/open-release-pr.yaml
+++ b/updatecli/updatecli.release.d/open-release-pr.yaml
@@ -252,6 +252,7 @@ scms:
         hidecredit: true
         footers: "Signed-off-by: kubewarden-controller bot <kubewarden-controller-bot@users.noreply.github.com>"
 
+# {{ if not .pr.haulerUpdatePr }}
 actions:
   openUpdatePR:
     title: 'build: {{ source "newestGitHubDraftReleaseVersion" }} release'
@@ -280,3 +281,4 @@ actions:
       #           {{ end }}
       #     {{ end }}
       draft: false
+#     {{ end }}

--- a/updatecli/values/deps-values.yaml
+++ b/updatecli/values/deps-values.yaml
@@ -1,0 +1,89 @@
+# The following values are used to update the Hauler manifest.
+# The ociArtifacts list all the container images and policies that needs
+# to be updated in the manifest
+ociArtifacts:
+  # Kubewarden container images
+  #
+  # The workflowUrl field defined in the Kubewarden
+  # container images is the url used to validate the identity with cosign
+  #
+  # The skipVersionFromRegistry field defined in the Kubewarden images is a
+  # flag to skip update of the images version in the Helm chart with the
+  # version in the registry. These container image should use the container
+  # image defined in the release process
+  - file: "charts/kubewarden-controller/values.yaml"
+    key: "$.image.tag"
+    image: "ghcr.io/kubewarden/kubewarden-controller"
+    workflowUrl: "https://github.com/kubewarden/kubewarden-controller/.github/workflows/release.yml@refs/tags"
+    skipVersionFromRegistry: true
+  - file: "charts/kubewarden-controller/values.yaml"
+    key: "$.auditScanner.image.tag"
+    image: "ghcr.io/kubewarden/audit-scanner"
+    workflowUrl: "https://github.com/kubewarden/kubewarden-controller/.github/workflows/release.yml@refs/tags"
+    skipVersionFromRegistry: true
+  - file: "charts/kubewarden-defaults/values.yaml"
+    key: "$.policyServer.image.tag"
+    image: "ghcr.io/kubewarden/policy-server"
+    workflowUrl: "https://github.com/kubewarden/kubewarden-controller/.github/workflows/release.yml@refs/tags"
+    skipVersionFromRegistry: true
+  # Policies
+  - image: ghcr.io/kubewarden/policies/allow-privilege-escalation-psp
+    file: "charts/kubewarden-defaults/values.yaml"
+    key: "$.recommendedPolicies.allowPrivilegeEscalationPolicy.module.tag"
+  - image: ghcr.io/kubewarden/policies/host-namespaces-psp
+    file: "charts/kubewarden-defaults/values.yaml"
+    key: "$.recommendedPolicies.hostNamespacePolicy.module.tag"
+  - image: ghcr.io/kubewarden/policies/pod-privileged
+    file: "charts/kubewarden-defaults/values.yaml"
+    key: "$.recommendedPolicies.podPrivilegedPolicy.module.tag"
+  - image: ghcr.io/kubewarden/policies/user-group-psp
+    file: "charts/kubewarden-defaults/values.yaml"
+    key: "$.recommendedPolicies.userGroupPolicy.module.tag"
+  - image: ghcr.io/kubewarden/policies/hostpaths-psp
+    file: "charts/kubewarden-defaults/values.yaml"
+    key: "$.recommendedPolicies.hostPathsPolicy.module.tag"
+  - image: ghcr.io/kubewarden/policies/capabilities-psp
+    file: "charts/kubewarden-defaults/values.yaml"
+    key: "$.recommendedPolicies.capabilitiesPolicy.module.tag"
+  # Third party dependencies
+  - image: ghcr.io/rancher/kuberlr-kubectl
+    file: "charts/kubewarden-controller/values.yaml"
+    key: "$.preDeleteJob.image.tag"
+# The helmCharts list all the Helm charts listed in the Hauler that needs to be
+# updated regurlarly. This list should be in the same order as defined in the
+# charts/hauler_manifest.yaml file.
+helmCharts:
+  - name: kubewarden-crds
+    file: "charts/kubewarden-crds/Chart.yaml"
+    versionKey: "$.version"
+  - name: kubewarden-controller
+    file: "charts/kubewarden-controller/Chart.yaml"
+    versionKey: "$.version"
+  - name: kubewarden-defaults
+    file: "charts/kubewarden-defaults/Chart.yaml"
+    versionKey: "$.version"
+  - name: policy-reporter
+    file: "charts/kubewarden-controller/Chart.yaml"
+    versionKey: "$.dependencies[0].version"
+    repository: https://kyverno.github.io/policy-reporter
+  - name: openreports
+    file: "charts/kubewarden-crds/Chart.yaml"
+    versionKey: "$.dependencies[0].version"
+    repository: https://openreports.github.io/reports-api
+
+kubewardenContainerImage:
+  - name: "controller"
+    file: "charts/kubewarden-controller/values.yaml"
+    key: "$.image.tag"
+    image: "ghcr.io/kubewarden/kubewarden-controller"
+    workflowUrl: "https://github.com/kubewarden/kubewarden-controller/.github/workflows/release.yml@refs/tags"
+  - name: "auditScanner"
+    file: "charts/kubewarden-controller/values.yaml"
+    key: "$.auditScanner.image.tag"
+    image: "ghcr.io/kubewarden/audit-scanner"
+    workflowUrl: "https://github.com/kubewarden/audit-scanner/.github/workflows/release.yml@refs/tags"
+  - name: "policyServer"
+    file: "charts/kubewarden-defaults/values.yaml"
+    key: "$.policyServer.image.tag"
+    image: "ghcr.io/kubewarden/policy-server"
+    workflowUrl: "https://github.com/kubewarden/policy-server/.github/workflows/release.yml@refs/tags"

--- a/updatecli/values/release-pr-values.yaml
+++ b/updatecli/values/release-pr-values.yaml
@@ -1,0 +1,13 @@
+pipelineid: release_pr # PR branch will be named: updatecli_main_release_pr
+
+# pr contains the pull request settings that can be overridden
+pr:
+  # the haulerUpdatePr values configures if the updatecli.d/update-hauler-manifest.yaml
+  # action PR should be configure of not. In the release script, it should be disable
+  haulerUpdatePr: false
+  labels:
+    - "kind/chore"
+    - "area/release"
+    - "ci-full" # this triggers all CI jobs
+  reviewers:
+    - "kubewarden/kubewarden-developers"

--- a/updatecli/values/scms.yaml
+++ b/updatecli/values/scms.yaml
@@ -1,0 +1,8 @@
+github:
+  owner: "UPDATECLI_GITHUB_OWNER"
+  branch: "main"
+  author: "Kubewarden bot"
+  email: "cncf-kubewarden-maintainers@lists.cncf.io"
+  user: "UPDATECLI_GITHUB_OWNER"
+  token: "UPDATECLI_GITHUB_TOKEN"
+  repo: "kubewarden-controller"

--- a/updatecli/values/update-deps-values.yaml
+++ b/updatecli/values/update-deps-values.yaml
@@ -1,0 +1,3 @@
+pipelineid: "update_all_dependencies"
+pr:
+  title: "Update Helm charts dependencies"


### PR DESCRIPTION
## Description

Updates the updatecli script use to create the PR to start a release to also updates the charts/hauler_manifest.yaml file with the latest versions of the release.

This change also split some values into multiple files to a future refactoring of the script used to update the dependencies. Therefore, it will not be necessary to duplicate information like repository data and artifact to be updated on multiple values files.


Fix https://github.com/kubewarden/kubewarden-controller/issues/1449

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

You can see an example of a run of this script [here](https://github.com/jvanz/kubewarden-controller/pull/156)


## Additional Information

In a follow up PR I'll refactor the updatecli script used to update dependencies to use the shared values files. 

