### PR TITLE
ci: add Cargo.toml version check to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions: read-all
 
 jobs:
   version-check:
-    name: Check Cargo.toml version
+    name: Check Cargo.toml files version
     runs-on: ubuntu-latest
     steps:
       - name: Download source code


### PR DESCRIPTION
Added a version-check job to validate Cargo.toml version against tag version during release.

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #1477 
