### PR TITLE
CI: Restore cross-platform cargo checks for kwctl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -351,13 +351,8 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: git config --global core.longpaths true
 
-      - name: fix aws-lc-sys building with cmake 4.0.0
-        if: matrix.os == 'windows-latest'
-        run: |
-          echo 'CMAKE_POLICY_VERSION_MINIMUM="3.5"' >> $GITHUB_ENV
-
       - name: Run cargo check
-        run: cargo check --manifest-path crates/kwctl/Cargo.toml
+        run: make -C crates/kwctl check
 
   # Rollup job for branch protection - single stable job name that depends on all checks
   ci-success:

--- a/crates/kwctl/Makefile
+++ b/crates/kwctl/Makefile
@@ -51,3 +51,7 @@ tag:
 	@git-chglog --output CHANGELOG.md
 	@git commit -m 'Update CHANGELOG.md' -- CHANGELOG.md
 	@git tag -f "${TAG}"
+
+.PHONY: check
+check:
+	cargo check


### PR DESCRIPTION
## Description
This PR restores cross-platform compilation checks for the `kwctl` CLI tool.  
Added Windows fixes for `git longpaths` and `aws-lc-sys`.

Fix #1478 

Test: [https://github.com/ihgazi/kubewarden-controller/actions/runs/21948151244/job/63395907339](https://github.com/ihgazi/kubewarden-controller/actions/runs/21948151244/job/63395907339)
