### PR TITLE
ci: Add coverage for rust code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,29 @@ jobs:
         run: sudo apt install -y bats
       - name: Run integration tests
         run: make -C crates/policy-evaluator integration-tests
+        
+  coverage-rust:
+    name: coverage-rust
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@0e76c5c569f13f7eb21e8e5b26fe710062b57b62 # v2.65.13
+        with:
+          tool: cargo-llvm-cov
+      - name: Install cosign # this is needed by some of the e2e tests
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+      - run: cargo llvm-cov --ignore-run-fail --doctests --lcov --output-path coverage/rust/lcov.info
+      - name: Upload Rust test coverage to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+        with:
+          name: rust-tests
+          files: coverage/lcov.info
+          flags: rust-tests
+          verbose: true
 
   build-kwctl:
     name: Build kwctl

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,10 @@ lint: lint-go lint-rust
 advisories-rust:
 	cargo deny check advisories
 
+.PHONY: coverage-rust
+coverage-rust:
+	cargo llvm-cov --ignore-run-fail --doctests --html --output-dir coverage/rust/
+
 CONTROLLER_SRC_DIRS := cmd/controller api internal/controller
 CONTROLLER_GO_SRCS := $(shell find $(CONTROLLER_SRC_DIRS) -type f -name '*.go')
 CONTROLLER_SRCS := $(GO_MOD_SRCS) $(CONTROLLER_GO_SRCS)

--- a/coverage/rust/.gitignore
+++ b/coverage/rust/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,10 +1,15 @@
 
 [toolchain]
 channel = "1.92.0"
-components = ["clippy", "rust-analyzer", "rustfmt"]
+components = [
+  "clippy",
+  "llvm-tools-preview", # for cargo-llvm-cov
+  "rust-analyzer",
+  "rustfmt",
+]
 profile = "minimal"
 targets = [
-  "wasm32-wasip1",
   "aarch64-unknown-linux-musl",
+  "wasm32-wasip1",
   "x86_64-unknown-linux-musl",
 ]


### PR DESCRIPTION

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/kubewarden-controller/issues/1347

Add new `make coverage-rust` that runs all Rust tests and saves the coverage locally `under coverage/rust/*` in html format.

Add new `coverage-rust` job that runs all Rust tests in CI and submits the result to Codecov.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested locally.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
