### PR TITLE
feat(ci): update rust toolchain updatecli script.

### DIFF
--- a/updatecli/update-deps.yaml
+++ b/updatecli/update-deps.yaml
@@ -1,7 +1,8 @@
 policies:
-  - name: Update Go version, Helm chart dependencies and Hauler manifest
+  - name: Update Go version, Rust toolchain, Helm chart dependencies and Hauler manifest
     config:
       - ./updatecli.d/go.yaml
+      - ./updatecli.d/update-rust-toolchain.yaml
       - ./updatecli.d/update-chart-deps.yaml
       - ./updatecli.d/update-hauler-manifest.yaml
     values:

--- a/updatecli/updatecli.d/update-rust-toolchain.yaml
+++ b/updatecli/updatecli.d/update-rust-toolchain.yaml
@@ -1,0 +1,57 @@
+name: Update Rust version inside of rust-toolchain file
+
+# {{ if .pipelineid }}
+pipelineid: "{{ .pipelineid }}"
+# {{ end }}
+
+scms:
+  github:
+    kind: github
+    spec:
+      user: "{{ .github.author }}"
+      email: "{{ .github.email }}"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "kubewarden-controller"
+      branch: "{{ .github.branch }}"
+      commitusingapi: true
+      commitmessage:
+        type: "chore"
+        scope: deps
+        title: "update Rust toolchain version"
+        footers: "Signed-off-by: kubewarden-controller bot <kubewarden-controller-bot@users.noreply.github.com>"
+        hidecredit: true
+
+sources:
+  rust-lang:
+    name: Get the latest release of Rust from rust-lang
+    kind: githubrelease
+    spec:
+      owner: rust-lang
+      repository: rust
+      versionfilter:
+        kind: semver
+        pattern: "*"
+
+targets:
+  dataFile:
+    name: 'deps(rust): update Rust version to {{ source "rust-lang" }}'
+    kind: toml
+    scmid: github
+    spec:
+      file: "rust-toolchain.toml"
+      key: toolchain.channel
+
+actions:
+  default:
+    title: 'deps(rust): update Rust toolchain to {{ source "rust-lang" }}'
+    kind: github/pullrequest
+    scmid: github
+    spec:
+      automerge: false
+      mergemethod: squash
+      description: |
+        Automatic Rust toolchain update.
+      draft: false
+      labels:
+        - "kind/chore"
+        - "area/dependencies"


### PR DESCRIPTION
## Description

Adds a new updatecli script to bump the Rust toolchain version together with all the other dependencies updates.

Fix https://github.com/kubewarden/kubewarden-controller/issues/1479


## Test

This PR is an example of the update: https://github.com/jvanz/kubewarden-controller/pull/179/changes

> [!WARNING]
> The example PR will contains more than the rust-toolchain update because the test was done in main branch. Therefore, I contains all the changes of this PR as well. 
