### PR TITLE
feat: Add a Helm post-install hook that deletes old PolicyReports

### DIFF
--- a/charts/kubewarden-controller/templates/post-install-clean-reports-hook.yaml
+++ b/charts/kubewarden-controller/templates/post-install-clean-reports-hook.yaml
@@ -1,0 +1,84 @@
+# Deletes all ClusterPolicyReports and PolicyReports from wgpolicyk8s.io that are
+# labelled app.kubernetes.io/managed-by=kubewarden.
+# Used for migrating from PolicyReports wgpolicyk8s.io to OpenReports.
+#
+# The hook only runs succesfully once, and the Job object persists on the cluster.
+# Delete the Job manually to force a re-run.
+{{ if eq .Values.auditScanner.reportCRDsKind "openreports" }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-clean-reports"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    # We want "run once":
+    # On first install the hook run succeeds, and is not deleted on sucess,
+    # leaving the Job in a Complete state.
+    #
+    # For subsequent hook runs, Helm atttempts to apply the Job (no-op patch
+    # since the spec is unchanged), finds it already Complete, and considers
+    # the hook satisfied, skipping re-execution.
+    # To force a re-run, delete the Job manually.
+    "helm.sh/hook-delete-policy": hook-failed
+    
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-clean-reports"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      annotations:
+        {{- include "kubewarden-controller.annotations" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      # for deletecollection verb on policyreports
+      serviceAccountName: {{ .Values.auditScanner.serviceAccountName }}
+      {{- if .Values.preDeleteHook.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.preDeleteHook.podSecurityContext | indent 8 }}
+      {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "imagePullSecrets" .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: clean-reports-job
+          image: '{{ template "system_default_registry" . }}{{ .Values.preDeleteJob.image.repository }}:{{ .Values.preDeleteJob.image.tag }}'
+          command:
+            - /bin/sh
+            - -c
+            - |
+              # Delete resources with deletecollection verb instead of delete, for performance.
+              # This can only be ensured with kubectl delete --raw
+              kubectl delete --raw \
+                "/apis/wgpolicyk8s.io/v1beta1/clusterpolicyreports?labelSelector=app.kubernetes.io%2Fmanaged-by%3Dkubewarden" \
+                || true
+              for ns in $(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}'); do
+                kubectl delete --raw \
+                  "/apis/wgpolicyk8s.io/v1beta1/namespaces/${ns}/policyreports?labelSelector=app.kubernetes.io%2Fmanaged-by%3Dkubewarden" \
+                  || true
+              done
+          env:
+            - name: KUBERLR_ALLOWDOWNLOAD
+              value: "1"
+          {{- if .Values.preDeleteHook.containerSecurityContext }}
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+{{ toYaml .Values.preDeleteHook.containerSecurityContext | indent 12 }}
+          {{- end }}
+          {{- if and .Values.resources .Values.resources.postInstallCleanReportsJob }}
+          resources:
+{{ toYaml .Values.resources.postInstallCleanReportsJob | indent 12 }}
+          {{- end }}
+{{ end }}

--- a/charts/kubewarden-controller/tests/post_install_clean_reports_hook_test.yaml
+++ b/charts/kubewarden-controller/tests/post_install_clean_reports_hook_test.yaml
@@ -1,0 +1,80 @@
+suite: post-install clean reports hook
+templates:
+  - post-install-clean-reports-hook.yaml
+tests:
+  - it: "should not render when reportCRDsKind is policyreport (default)"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: "should render the Job when reportCRDsKind is openreports"
+    set:
+      auditScanner:
+        reportCRDsKind: openreports
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Job
+
+  - it: "should have post-install and post-upgrade hook annotations"
+    set:
+      auditScanner:
+        reportCRDsKind: openreports
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-install,post-upgrade
+
+  - it: "should have hook-failed delete policy for run-once behavior"
+    set:
+      auditScanner:
+        reportCRDsKind: openreports
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: hook-failed
+
+  - it: "should delete clusterpolicyreports via deletecollection raw API with label selector"
+    set:
+      auditScanner:
+        reportCRDsKind: openreports
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "kubectl delete --raw"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "/apis/wgpolicyk8s.io/v1beta1/clusterpolicyreports\\?labelSelector=app\\.kubernetes\\.io%2Fmanaged-by%3Dkubewarden"
+
+  - it: "should delete policyreports per-namespace via deletecollection raw API with label selector"
+    set:
+      auditScanner:
+        reportCRDsKind: openreports
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "kubectl get namespaces"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "/apis/wgpolicyk8s.io/v1beta1/namespaces/.*policyreports\\?labelSelector=app\\.kubernetes\\.io%2Fmanaged-by%3Dkubewarden"
+
+  - it: "should apply resource limits and requests from values"
+    set:
+      auditScanner:
+        reportCRDsKind: openreports
+      resources:
+        postInstallCleanReportsJob:
+          limits:
+            cpu: 200m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 200m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 128Mi

--- a/charts/kubewarden-controller/values.schema.json
+++ b/charts/kubewarden-controller/values.schema.json
@@ -371,6 +371,33 @@
                         }
                     }
                 },
+                "postInstallCleanReportsJob": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
                 "preDeleteJob": {
                     "type": "object",
                     "properties": {

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -255,6 +255,13 @@ resources:
     requests:
       cpu: 50m
       memory: 64Mi
+  postInstallCleanReportsJob:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
 mTLS:
   # Enable mutual TLS authentication. This will require TLS connections with both
   # the server and client being authenticated, between the kubewarden


### PR DESCRIPTION

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/rancher/kubewarden-ui/issues/1324

When the kubewarden-controller Helm chart is deployed with `.Values.auditScanner.reportCRDsKind "openreports"`, we are performing a migration from old PolicyReports from wgpolicyk8s.io to new OpenReports from openreports.io.

Add a post-install/post-upgrade hook. This hook creates a Job that deletes all old ClusterPolicyReports and PolicyReports that are labeled as owned by Kubewarden.

This Job uses `kubectl delete --raw`, to make use of `deletecollection` verb instead of `delete` for performance reasons. In addition, it resuses the audit-scanner SA, which already has this verb.

This hook is configured to run only once, and once it's run it stays in Completed status. Subsequent `helm install` or `helm upgrade` don't retrigger the job. This is achieved with a bit of hackery, by setting `"helm.sh/hook-delete-policy"` only to `hook-failed`. If the Job is manually edited, subsequent installs *will* fail. If the Job is manually deleted, it will be recreated in subsequent installs and rerun.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Manually tested:
deployed current KW, run audit-scanner and created old PolicyReports.
Upgraded to Helm chart from this PR, first upgrade creates the Job and correctly deletes all reports.
Following upgrades don't change nor retrigger the Job.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

Another option is to add this logic to the audit-scanner. For that, I opened https://github.com/kubewarden/kubewarden-controller/pull/1512.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
