### PR TITLE
    feat(controller): flag to allow policies in kubewarden namespace

### DIFF
--- a/api/policies/v1/admissionpolicy_types.go
+++ b/api/policies/v1/admissionpolicy_types.go
@@ -133,6 +133,10 @@ func (r *AdmissionPolicy) GetNamespaceSelector() *metav1.LabelSelector {
 	}
 }
 
+func (r *AdmissionPolicy) GetAllowInsideKubewardenNamespace() bool {
+	return false
+}
+
 func (r *AdmissionPolicy) GetObjectSelector() *metav1.LabelSelector {
 	return r.Spec.ObjectSelector
 }

--- a/api/policies/v1/admissionpolicygroup_types.go
+++ b/api/policies/v1/admissionpolicygroup_types.go
@@ -157,6 +157,10 @@ func (r *AdmissionPolicyGroup) GetNamespaceSelector() *metav1.LabelSelector {
 	}
 }
 
+func (r *AdmissionPolicyGroup) GetAllowInsideKubewardenNamespace() bool {
+	return false
+}
+
 func (r *AdmissionPolicyGroup) GetObjectSelector() *metav1.LabelSelector {
 	return r.Spec.ObjectSelector
 }

--- a/api/policies/v1/clusteradmissionpolicy_types.go
+++ b/api/policies/v1/clusteradmissionpolicy_types.go
@@ -88,6 +88,17 @@ type ClusterAdmissionPolicySpec struct {
 	// the policy is assigned to.
 	// +optional
 	ContextAwareResources []ContextAwareResource `json:"contextAwareResources,omitempty"`
+
+	// AllowInsideKubewardenNamespace controls whether the policy should also be
+	// evaluated for resources in the namespace where Kubewarden is deployed.
+	// By default (false), an exclusion rule is added to the webhook so that the
+	// Kubewarden namespace is never targeted, protecting against an accidental
+	// lockout. Set this to true only if you deliberately want the policy to apply
+	// inside the Kubewarden namespace.
+	// Warning: setting this to true may cause a deadlock if the policy prevents
+	// Kubewarden components from starting.
+	// +optional
+	AllowInsideKubewardenNamespace bool `json:"allowInsideKubewardenNamespace,omitempty"`
 }
 
 // ClusterAdmissionPolicy is the Schema for the clusteradmissionpolicies API
@@ -210,6 +221,10 @@ func (r *ClusterAdmissionPolicy) GetUniqueName() string {
 
 func (r *ClusterAdmissionPolicy) GetContextAwareResources() []ContextAwareResource {
 	return r.Spec.ContextAwareResources
+}
+
+func (r *ClusterAdmissionPolicy) GetAllowInsideKubewardenNamespace() bool {
+	return r.Spec.AllowInsideKubewardenNamespace
 }
 
 func (r *ClusterAdmissionPolicy) GetBackgroundAudit() bool {

--- a/api/policies/v1/clusteradmissionpolicygroup_types.go
+++ b/api/policies/v1/clusteradmissionpolicygroup_types.go
@@ -83,6 +83,17 @@ type ClusterAdmissionPolicyGroupSpec struct {
 	// Default to the empty LabelSelector, which matches everything.
 	// +optional
 	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector,omitempty"`
+
+	// AllowInsideKubewardenNamespace controls whether the policy should also be
+	// evaluated for resources in the namespace where Kubewarden is deployed.
+	// By default (false), an exclusion rule is added to the webhook so that the
+	// Kubewarden namespace is never targeted, protecting against an accidental
+	// lockout. Set this to true only if you deliberately want the policy to apply
+	// inside the Kubewarden namespace.
+	// Warning: setting this to true may cause a deadlock if the policy prevents
+	// Kubewarden components from starting.
+	// +optional
+	AllowInsideKubewardenNamespace bool `json:"allowInsideKubewardenNamespace,omitempty"`
 }
 
 // ClusterAdmissionPolicyGroup is the Schema for the clusteradmissionpolicies API
@@ -196,6 +207,10 @@ func (r *ClusterAdmissionPolicyGroup) GetMatchConditions() []admissionregistrati
 
 func (r *ClusterAdmissionPolicyGroup) GetNamespaceSelector() *metav1.LabelSelector {
 	return r.Spec.NamespaceSelector
+}
+
+func (r *ClusterAdmissionPolicyGroup) GetAllowInsideKubewardenNamespace() bool {
+	return r.Spec.AllowInsideKubewardenNamespace
 }
 
 func (r *ClusterAdmissionPolicyGroup) GetObjectSelector() *metav1.LabelSelector {

--- a/api/policies/v1/factories.go
+++ b/api/policies/v1/factories.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	integrationTestsFinalizer          = "integration-tests-safety-net-finalizer"
+	integrationTestsFinalizer          = "kubewarden.io/integration-tests-safety-net-finalizer"
 	defaultKubewardenRepository        = "ghcr.io/kubewarden/policy-server"
 	maxNameSuffixLength                = 8
 	defaultPolicyGroupRejectionMessage = "policy group default rejection message"

--- a/api/policies/v1/policy.go
+++ b/api/policies/v1/policy.go
@@ -118,6 +118,7 @@ type PolicySelectors interface {
 	GetNamespaceSelector() *metav1.LabelSelector
 	GetObjectSelector() *metav1.LabelSelector
 	GetObjectMeta() *metav1.ObjectMeta
+	GetAllowInsideKubewardenNamespace() bool
 }
 
 // +kubebuilder:object:generate:=false

--- a/charts/kubewarden-crds/templates/clusteradmissionpolicies.yaml
+++ b/charts/kubewarden-crds/templates/clusteradmissionpolicies.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -77,6 +78,17 @@ spec:
           spec:
             description: ClusterAdmissionPolicySpec defines the desired state of ClusterAdmissionPolicy.
             properties:
+              allowInsideKubewardenNamespace:
+                description: |-
+                  AllowInsideKubewardenNamespace controls whether the policy should also be
+                  evaluated for resources in the namespace where Kubewarden is deployed.
+                  By default (false), an exclusion rule is added to the webhook so that the
+                  Kubewarden namespace is never targeted, protecting against an accidental
+                  lockout. Set this to true only if you deliberately want the policy to apply
+                  inside the Kubewarden namespace.
+                  Warning: setting this to true may cause a deadlock if the policy prevents
+                  Kubewarden components from starting.
+                type: boolean
               backgroundAudit:
                 default: true
                 description: |-

--- a/charts/kubewarden-crds/templates/clusteradmissionpolicygroups.yaml
+++ b/charts/kubewarden-crds/templates/clusteradmissionpolicygroups.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -78,6 +79,17 @@ spec:
             description: ClusterAdmissionPolicyGroupSpec defines the desired state
               of ClusterAdmissionPolicyGroup.
             properties:
+              allowInsideKubewardenNamespace:
+                description: |-
+                  AllowInsideKubewardenNamespace controls whether the policy should also be
+                  evaluated for resources in the namespace where Kubewarden is deployed.
+                  By default (false), an exclusion rule is added to the webhook so that the
+                  Kubewarden namespace is never targeted, protecting against an accidental
+                  lockout. Set this to true only if you deliberately want the policy to apply
+                  inside the Kubewarden namespace.
+                  Warning: setting this to true may cause a deadlock if the policy prevents
+                  Kubewarden components from starting.
+                type: boolean
               backgroundAudit:
                 default: true
                 description: |-

--- a/config/crd/bases/policies.kubewarden.io_clusteradmissionpolicies.yaml
+++ b/config/crd/bases/policies.kubewarden.io_clusteradmissionpolicies.yaml
@@ -78,6 +78,17 @@ spec:
           spec:
             description: ClusterAdmissionPolicySpec defines the desired state of ClusterAdmissionPolicy.
             properties:
+              allowInsideKubewardenNamespace:
+                description: |-
+                  AllowInsideKubewardenNamespace controls whether the policy should also be
+                  evaluated for resources in the namespace where Kubewarden is deployed.
+                  By default (false), an exclusion rule is added to the webhook so that the
+                  Kubewarden namespace is never targeted, protecting against an accidental
+                  lockout. Set this to true only if you deliberately want the policy to apply
+                  inside the Kubewarden namespace.
+                  Warning: setting this to true may cause a deadlock if the policy prevents
+                  Kubewarden components from starting.
+                type: boolean
               backgroundAudit:
                 default: true
                 description: |-

--- a/config/crd/bases/policies.kubewarden.io_clusteradmissionpolicygroups.yaml
+++ b/config/crd/bases/policies.kubewarden.io_clusteradmissionpolicygroups.yaml
@@ -79,6 +79,17 @@ spec:
             description: ClusterAdmissionPolicyGroupSpec defines the desired state
               of ClusterAdmissionPolicyGroup.
             properties:
+              allowInsideKubewardenNamespace:
+                description: |-
+                  AllowInsideKubewardenNamespace controls whether the policy should also be
+                  evaluated for resources in the namespace where Kubewarden is deployed.
+                  By default (false), an exclusion rule is added to the webhook so that the
+                  Kubewarden namespace is never targeted, protecting against an accidental
+                  lockout. Set this to true only if you deliberately want the policy to apply
+                  inside the Kubewarden namespace.
+                  Warning: setting this to true may cause a deadlock if the policy prevents
+                  Kubewarden components from starting.
+                type: boolean
               backgroundAudit:
                 default: true
                 description: |-

--- a/config/crd/bases/policies.kubewarden.io_policyservers.yaml
+++ b/config/crd/bases/policies.kubewarden.io_policyservers.yaml
@@ -1642,7 +1642,7 @@ spec:
                   Name of SigstoreTrustConfig configmap in the kubewarden namespace (same
                   namespace as the controller deployment), containing Sigstore trust
                   configuration (ClientTrustConfig JSON). The configuration must be under a
-                  key named sigstore-trust-config in the Configmap. This is used to configure
+                  key named sigstore-trust-config in the ConfigMap. This is used to configure
                   a custom Sigstore instance instead of the default public Sigstore infrastructure.
                   WARNING: This feature requires strict access control. Users with write access
                   to this ConfigMap can influence policy signature verification.

--- a/internal/controller/admissionpolicy_controller.go
+++ b/internal/controller/admissionpolicy_controller.go
@@ -74,10 +74,10 @@ func (r *AdmissionPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 // SetupWithManager sets up the controller with the Manager.
 func (r *AdmissionPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.policySubReconciler = &policySubReconciler{
-		r.Client,
-		r.Log,
-		r.DeploymentsNamespace,
-		r.FeatureGateAdmissionWebhookMatchConditions,
+		Client:               r.Client,
+		Log:                  r.Log,
+		deploymentsNamespace: r.DeploymentsNamespace,
+		featureGateAdmissionWebhookMatchConditions: r.FeatureGateAdmissionWebhookMatchConditions,
 	}
 
 	err := ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/admissionpolicygroup_controller.go
+++ b/internal/controller/admissionpolicygroup_controller.go
@@ -74,10 +74,10 @@ func (r *AdmissionPolicyGroupReconciler) Reconcile(ctx context.Context, req ctrl
 // SetupWithManager sets up the controller with the Manager.
 func (r *AdmissionPolicyGroupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.policySubReconciler = &policySubReconciler{
-		r.Client,
-		r.Log,
-		r.DeploymentsNamespace,
-		r.FeatureGateAdmissionWebhookMatchConditions,
+		Client:               r.Client,
+		Log:                  r.Log,
+		deploymentsNamespace: r.DeploymentsNamespace,
+		featureGateAdmissionWebhookMatchConditions: r.FeatureGateAdmissionWebhookMatchConditions,
 	}
 
 	err := ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/clusteradmissionpolicy_controller.go
+++ b/internal/controller/clusteradmissionpolicy_controller.go
@@ -74,10 +74,10 @@ func (r *ClusterAdmissionPolicyReconciler) Reconcile(ctx context.Context, req ct
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterAdmissionPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.policySubReconciler = &policySubReconciler{
-		r.Client,
-		r.Log,
-		r.DeploymentsNamespace,
-		r.FeatureGateAdmissionWebhookMatchConditions,
+		Client:               r.Client,
+		Log:                  r.Log,
+		deploymentsNamespace: r.DeploymentsNamespace,
+		featureGateAdmissionWebhookMatchConditions: r.FeatureGateAdmissionWebhookMatchConditions,
 	}
 
 	err := ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/clusteradmissionpolicygroup_controller.go
+++ b/internal/controller/clusteradmissionpolicygroup_controller.go
@@ -74,10 +74,10 @@ func (r *ClusterAdmissionPolicyGroupReconciler) Reconcile(ctx context.Context, r
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterAdmissionPolicyGroupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.policySubReconciler = &policySubReconciler{
-		r.Client,
-		r.Log,
-		r.DeploymentsNamespace,
-		r.FeatureGateAdmissionWebhookMatchConditions,
+		Client:               r.Client,
+		Log:                  r.Log,
+		deploymentsNamespace: r.DeploymentsNamespace,
+		featureGateAdmissionWebhookMatchConditions: r.FeatureGateAdmissionWebhookMatchConditions,
 	}
 
 	err := ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/policy_subreconciler_webhook.go
+++ b/internal/controller/policy_subreconciler_webhook.go
@@ -193,6 +193,10 @@ func (r *policySubReconciler) reconcileMutatingWebhookConfigurationDeletion(ctx 
 func (r *policySubReconciler) namespaceSelector(policy policiesv1.Policy) *metav1.LabelSelector {
 	switch policy.(type) {
 	case *policiesv1.ClusterAdmissionPolicyGroup, *policiesv1.ClusterAdmissionPolicy:
+		if policy.GetAllowInsideKubewardenNamespace() {
+			return policy.GetNamespaceSelector()
+		}
+
 		namespaceSelector := &metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{
 				{

--- a/internal/controller/policy_subreconciler_webhook_test.go
+++ b/internal/controller/policy_subreconciler_webhook_test.go
@@ -1,0 +1,92 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	policiesv1 "github.com/kubewarden/kubewarden-controller/api/policies/v1"
+)
+
+const testDeploymentsNamespace = "kubewarden"
+
+// expectedExcludeExpr is the LabelSelectorRequirement that must be present
+// in the NamespaceSelector to exclude the deployments namespace.
+var expectedExcludeExpr = metav1.LabelSelectorRequirement{
+	Key:      "kubernetes.io/metadata.name",
+	Operator: metav1.LabelSelectorOpNotIn,
+	Values:   []string{testDeploymentsNamespace},
+}
+
+func TestNamespaceSelectorClusterAdmissionTypePolicies(t *testing.T) {
+	tests := []struct {
+		name                           string
+		allowInsideKubewardenNamespace bool
+		policyNSSel                    *metav1.LabelSelector
+		expected                       *metav1.LabelSelector
+	}{
+		{
+			name:                           "adds NotIn expression when allowInsideKubewardenNamespace is false and policy has no NamespaceSelector",
+			allowInsideKubewardenNamespace: false,
+			policyNSSel:                    nil,
+			expected: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					expectedExcludeExpr,
+				},
+			},
+		},
+		{
+			name:                           "merges existing MatchExpressions with the NotIn expression when allowInsideKubewardenNamespace is false",
+			allowInsideKubewardenNamespace: false,
+			policyNSSel: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "env", Operator: metav1.LabelSelectorOpIn, Values: []string{"prod"}},
+				},
+			},
+			expected: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					expectedExcludeExpr,
+					{Key: "env", Operator: metav1.LabelSelectorOpIn, Values: []string{"prod"}},
+				},
+			},
+		},
+		{
+			name:                           "returns the policy NamespaceSelector unchanged when allowInsideKubewardenNamespace is true",
+			allowInsideKubewardenNamespace: true,
+			policyNSSel: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "prod"},
+			},
+			expected: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "prod"},
+			},
+		},
+		{
+			name:                           "returns nil when allowInsideKubewardenNamespace is true and policy has no NamespaceSelector",
+			allowInsideKubewardenNamespace: true,
+			policyNSSel:                    nil,
+			expected:                       nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &policySubReconciler{
+				deploymentsNamespace: testDeploymentsNamespace,
+			}
+			policy := policiesv1.NewClusterAdmissionPolicyFactory().Build()
+			policy.Spec.NamespaceSelector = tc.policyNSSel
+			policy.Spec.AllowInsideKubewardenNamespace = tc.allowInsideKubewardenNamespace
+
+			got := r.namespaceSelector(policy)
+			require.Equal(t, tc.expected, got)
+
+			policyGroup := policiesv1.NewClusterAdmissionPolicyGroupFactory().Build()
+			policyGroup.Spec.NamespaceSelector = tc.policyNSSel
+			policyGroup.Spec.AllowInsideKubewardenNamespace = tc.allowInsideKubewardenNamespace
+
+			got = r.namespaceSelector(policyGroup)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	integrationTestsFinalizer = "integration-tests-safety-net-finalizer"
+	integrationTestsFinalizer = "kubewarden.io/integration-tests-safety-net-finalizer"
 	clientCAConfigMapName     = "client-ca"
 	fakeSigstoreTrustConfig   = `{"trusted_root": {"version": "test"}}`
 )


### PR DESCRIPTION
## Description

Adds a new field called "allowInsideKubewardenNamespace" in the policy spec. This field allow the policy to valuate resources in the Kuberwarden namespace. When this field is "true" the controller will NOT add the namespace selector to skip resources from the Kubewarden namespace. The field has default value "false" to keep backwards compatibility.

Fix #1201 
