### PR TITLE
test(policy-server): Fix flaky test_policy_server_with_https_proxy

### DIFF
--- a/crates/policy-server/tests/integration_test.rs
+++ b/crates/policy-server/tests/integration_test.rs
@@ -747,8 +747,11 @@ mod certificate_reload_helpers {
     }
 
     pub async fn policy_server_is_ready(address: &str) -> anyhow::Result<StatusCode> {
-        // wait for the server to start
-        let client = reqwest::Client::builder().build().unwrap();
+        // wait for the server to start.
+        // no_proxy() is required because other tests in this suite set HTTP_PROXY/HTTPS_PROXY
+        // via temp_env (process-global), which would cause reqwest to route this localhost
+        // request through an external proxy (tinyproxy in Docker), making it fail with 500.
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
 
         let url = reqwest::Url::parse(&format!("http://{address}/readiness")).unwrap();
         let response = client.get(url).send().await?;


### PR DESCRIPTION


## Description

Fix flaky test_policy_server_with_https_proxy by bypassing proxy settings in integration tests `policy_server_is_ready()` helper function. This is done by building the reqwest client with .no_proxy().

We have tests on the testsuite that set proxy env vars via `temp_env::async_with_vars`, which modifies process env vars.

Because the integration tests run in parallel, this was picked up by the helper function, and routed the localhost readiness request through the tinyproxy instance running in Docker of the
`test_policy_server_with_https_proxy` test. Tinyproxy cannot reach the host's 127.0.0.1, so it returned 500.

Since policy_server_is_ready returns Ok(500) rather than Err, the retry logic stopped immediately instead of retrying, failing the flaky test.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI for the flaky test.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
This PR serves as a proof of concept.

The correct fix would be to refactor the proxy tests by setting the new `ProxyConfig{}` struct instead of env vars that leak.
That can be done after we merge https://github.com/kubewarden/kubewarden-controller/pull/1515.