### PR TITLE
chore: remove unused kubewarden-controller-metrics-reader ClusterRole

### DIFF
--- a/charts/kubewarden-controller/templates/rbac.yaml
+++ b/charts/kubewarden-controller/templates/rbac.yaml
@@ -167,20 +167,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kubewarden-controller-metrics-reader
-  labels:
-    {{- include "kubewarden-controller.labels" . | nindent 4 }}
-  annotations:
-    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
-rules:
-- nonResourceURLs:
-  - /metrics
-  verbs:
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
   name: kubewarden-controller-proxy-role
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}

--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,9 +1,0 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: metrics-reader
-rules:
-- nonResourceURLs:
-  - "/metrics"
-  verbs:
-  - get

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -9,10 +9,9 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
-# Comment the following 4 lines if you want to disable
+# Comment the following 3 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
 #- auth_proxy_service.yaml
 #- auth_proxy_role.yaml
 #- auth_proxy_role_binding.yaml
-#- auth_proxy_client_clusterrole.yaml


### PR DESCRIPTION
## Summary

Removes the unused `kubewarden-controller-metrics-reader` ClusterRole, which is a kubebuilder scaffold leftover from the `kube-rbac-proxy` pattern.

### Investigation findings

- **No ClusterRoleBinding** references `kubewarden-controller-metrics-reader` anywhere in the kubewarden ecosystem
- **`kube-rbac-proxy` is not deployed** by the Helm chart - the deployment template contains no proxy sidecar container
- **Metrics are exposed directly** by the controller on port `8088` (`cmd/controller/main.go:97`), and optionally via the OpenTelemetry Collector sidecar on port `8080`
- **Prometheus scrapes via plain HTTP** - the kubewarden docs instruct users to create ServiceMonitors targeting port `8080`/`metrics` without RBAC-based authentication
- **The `config/rbac/` scaffold files** for `kube-rbac-proxy` are all commented out in `kustomization.yaml`, confirming the pattern was intentionally disabled

### Changes

- Removed the `kubewarden-controller-metrics-reader` ClusterRole from `charts/kubewarden-controller/templates/rbac.yaml`
- Deleted the kubebuilder scaffold file `config/rbac/auth_proxy_client_clusterrole.yaml`
- Updated `config/rbac/kustomization.yaml` to remove the stale commented-out reference

### Note

The `kubewarden-controller-proxy-role` ClusterRole (for `tokenreviews`/`subjectaccessreviews`) and its binding also appear to be leftovers from the same `kube-rbac-proxy` pattern since the proxy is not deployed. This could be addressed in a follow-up if desired.

Fixes #1532