### PR TITLE
fix(charts): allow evaluations in controller namespace.

### DIFF
--- a/charts/kubewarden-controller/templates/deployment.yaml
+++ b/charts/kubewarden-controller/templates/deployment.yaml
@@ -51,7 +51,9 @@ spec:
         - --leader-elect
         - --deployments-namespace={{ .Release.Namespace }}
         - --webhook-service-name={{ include "kubewarden-controller.fullname" . }}-webhook-service
+        {{- if .Values.alwaysAcceptAdmissionReviewsOnDeploymentsNamespace }}
         - --always-accept-admission-reviews-on-deployments-namespace
+        {{- end }}
         - --zap-log-level={{ .Values.logLevel }}
        {{- if .Values.mTLS.enable }}
         - --client-ca-configmap-name={{ .Values.mTLS.configMapName }}

--- a/charts/kubewarden-controller/tests/always_accept_admission_reviews_test.yaml
+++ b/charts/kubewarden-controller/tests/always_accept_admission_reviews_test.yaml
@@ -1,0 +1,25 @@
+suite: alwaysAcceptAdmissionReviewsOnDeploymentsNamespace flag
+templates:
+  - deployment.yaml
+tests:
+  - it: "should include the flag when alwaysAcceptAdmissionReviewsOnDeploymentsNamespace is true (default)"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--always-accept-admission-reviews-on-deployments-namespace"
+
+  - it: "should include the flag when alwaysAcceptAdmissionReviewsOnDeploymentsNamespace is explicitly true"
+    set:
+      alwaysAcceptAdmissionReviewsOnDeploymentsNamespace: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--always-accept-admission-reviews-on-deployments-namespace"
+
+  - it: "should not include the flag when alwaysAcceptAdmissionReviewsOnDeploymentsNamespace is false"
+    set:
+      alwaysAcceptAdmissionReviewsOnDeploymentsNamespace: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--always-accept-admission-reviews-on-deployments-namespace"

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -145,6 +145,12 @@ preDeleteHook:
     runAsNonRoot: true
     seccompProfile:
       type: RuntimeDefault
+# If true, the controller will always accept admission reviews in the
+# deployment namespace. It is recommended to keep this value true unless you
+# have a specific reason to disable it. This is a safety flag to avoid policy
+# evaluations that could interfere with the Kubewarden stack running in the
+# admission controller namespace.
+alwaysAcceptAdmissionReviewsOnDeploymentsNamespace: true
 # Verbosity of logging. Can be one of 'debug', 'info', 'error'.
 logLevel: info
 # open-telemetry options


### PR DESCRIPTION
## Description

In a recent change we added a new configuration field in cluster wide policies. This flag tells the controller not to add the namespace selector that skips evaluation of resources in the controller namespace. However, there is a second layer of security to avoid resource evaluations in some namespace configured in the policy-server. When the controller has the
"--always-accept-admission-reviews-on-deployments-namespace" CLI flag enabled, it adds the
"KUBEWARDEN_ALWAYS_ACCEPT_ADMISSION_REVIEWS_ON_NAMESPACE" environment variable in the policy server deployment, configuring it to consider any request for that namespace (in this case the controller one) as accepted. This makes the policy configuration have no effect.

To fix this, this commit adds a new value field in the kubewarden-controller helm chart to allow cluster administrators to disable this CLI flag. Therefore, they would be able to run policies in the Kubewarden namespace.

Fix #1540 
