### PR TITLE
chore!: Don't install wgpolicyk8s reports by default

### DIFF
--- a/charts/kubewarden-crds/values.yaml
+++ b/charts/kubewarden-crds/values.yaml
@@ -5,7 +5,7 @@
 #
 # These reports are marked as DEPRECATED and its support will be removed in a
 # future release, in favour of OpenReports.
-installPolicyReportCRDs: true
+installPolicyReportCRDs: false
 
 # deploy reports.openreports.io, clusterreports.openreports.io CRDs
 # Set to false if they are already defined inside of the cluster


### PR DESCRIPTION


## Description

This is part of the migration to new OpenReports.io.

Users that want to keep using them must both:
- Set .Values.installPolicyReportCRDs to true for kubewarden-crds chart
- Set .Values.auditScanner.reportCRDsKind to policyreport for kubewarden-controller chart

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI.

Performed a manual helm upgrade of kubewarden-crds with this PR, which of course means that old PolicyReports CRDs were removed.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
