### PR TITLE
fix(policy-server): initialize crypto provider.

### DIFF
--- a/crates/policy-server/src/main.rs
+++ b/crates/policy-server/src/main.rs
@@ -10,6 +10,7 @@ use clap::ArgMatches;
 use policy_server::PolicyServer;
 use policy_server::metrics::setup_metrics;
 use policy_server::tracing::setup_tracing;
+use rustls::crypto::aws_lc_rs::default_provider;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -21,6 +22,16 @@ async fn main() -> Result<()> {
     let config = policy_server::config::Config::from_args(&matches)?;
 
     let tracer_provider = setup_tracing(&config.log_level, &config.log_fmt, config.log_no_color)?;
+
+    // This is necessary to ensure that we are using proper initializing the crypto provider.
+    // Without this initialization step, depending on which cli flags policy server has, the
+    // kubernetes client is initialized before the crypto provider causing a crash. In other
+    // scenarios the client is initialized after other dependencies which set the provider for us.
+    // Therefore, the following install_default() call ensure that we will have always a crypto
+    // provider initialized before any operation may require it.
+    if let Err(e) = default_provider().install_default() {
+        tracing::warn!("Failed to install rustls crypto provider: {:?}", e);
+    }
 
     if config.metrics_enabled {
         setup_metrics()?;


### PR DESCRIPTION
## Description

When the policy-server starts, depending on the flag passed, the initialization code path is different. This is causing problems because when the "sigstore-trust-config" CLI flag is passed, the Kubernetes client is initialized earlier. As this client required a crypto provider ready to be used, the program crashes due the missing provider. This does not happen in other scenarios because the code path is a little bit different and some of our other dependencies initialize the crypto provider for us.

This commit fixes the issue following a similar approach that we use in kwctl where the crypto provider is initialized in the beginning of the main function.
