### PR TITLE
fix(ci): fix broken release, address issue during attestation step

### DIFF
--- a/.github/workflows/attestation.yml
+++ b/.github/workflows/attestation.yml
@@ -79,8 +79,14 @@ jobs:
       - name: Find SBOM manifest layer digest
         run: |
           set -e
-          DIGEST=$(crane manifest ghcr.io/${{github.repository_owner}}/${{ inputs.component }}@${{ env.ATTESTATION_MANIFEST_DIGEST}} |  \
-            jq -r '.layers | map(select(.annotations["in-toto.io/predicate-type"] == "https://spdx.dev/Document")) | map(.digest) | join(" ")')
+          DIGEST=$(crane manifest ghcr.io/${{github.repository_owner}}/${{ inputs.component }}@${{ env.ATTESTATION_MANIFEST_DIGEST}}  | \
+            jq -r '.layers 
+              | map(select(.annotations["in-toto.io/predicate-type"] == "https://spdx.dev/Document"))
+              | map(.digest)
+              | if length == 0 then empty 
+                elif length == 1 then .[0]
+                else error("ERROR: Multiple SBOM layers found in attestation manifest")
+                end')
           if [[ -z "${DIGEST}" ]]; then
             echo "ERROR: No SBOM layer found in attestation manifest for ${{ inputs.component }} (${{ inputs.arch }})"
             exit 1


### PR DESCRIPTION
The SLSA provenance predicate was changed to a different value, this caused a digest to be empty, leading to a cascaded failure.

- Replace `slsa.dev/provenance/v0.2` with `v1` (`docker/build-push-action` v6 generates v1): this is the actual fix
- Add empty-digest guards on attestation, provenance, and SBOM lookup steps: this will provide a more clear message if something like that happens again.
- Add missing `-r` flag to jq in SBOM digest step: this is a minor improvemnt. It prevents double quuotes to land into the `crane` command later on.
