### PR TITLE
ci(release): Bump attestation GHA to 4.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
         arch: [amd64, arm64]
     steps:
       - name: Generate and sign attestations
-        uses: kubewarden/github-actions/attestation@f1695ca9a575bf58b85d6c3652c7ff7d1d12ec24 # v4.5.16
+        uses: kubewarden/github-actions/attestation@f301a7874dd642510fff54a89e4329881bf871ef # v4.6.0
         with:
           component: ${{ matrix.component }}
           arch: ${{ matrix.arch }}


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->


Fixes attestation[ errors on release job.](https://github.com/kubewarden/kubewarden-controller/actions/runs/23291030458/job/67729086463#step:2:359)

This consumes a feat to understand SLSA attestation predicate v1, which is what docker buildx creates now.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

Untested.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [x] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
