### PR TITLE
test: Consume mirrored kalaksi:tinyproxy image

### DIFF
--- a/crates/kwctl/tests/proxy.rs
+++ b/crates/kwctl/tests/proxy.rs
@@ -15,7 +15,7 @@ const POLICY_URI: &str = "registry://ghcr.io/kubewarden/tests/pod-privileged:v0.
 const LOCAL_POLICY_PATH: &str = "kubewarden/tests/pod-privileged:v0.2.5";
 
 fn start_proxy() -> (Container<GenericImage>, u16) {
-    let proxy_image = GenericImage::new("registry.gitlab.com/kalaksi-containers/tinyproxy", "1.7")
+    let proxy_image = GenericImage::new("ghcr.io/kubewarden/tests/kalaksi-tinyproxy", "1.7")
         .with_wait_for(WaitFor::message_on_stdout("Starting main loop"))
         .with_exposed_port(8888.tcp());
     let container = proxy_image

--- a/crates/policy-evaluator/tests/proxy.rs
+++ b/crates/policy-evaluator/tests/proxy.rs
@@ -19,13 +19,12 @@ mod proxy_tests {
     use crate::common::setup_callback_handler;
 
     async fn start_proxy() -> (ContainerAsync<GenericImage>, u16) {
-        let container =
-            GenericImage::new("registry.gitlab.com/kalaksi-containers/tinyproxy", "1.7")
-                .with_wait_for(WaitFor::message_on_stdout("Starting main loop"))
-                .with_exposed_port(8888.tcp())
-                .start()
-                .await
-                .expect("Failed to start proxy container");
+        let container = GenericImage::new("ghcr.io/kubewarden/tests/kalaksi-tinyproxy", "1.7")
+            .with_wait_for(WaitFor::message_on_stdout("Starting main loop"))
+            .with_exposed_port(8888.tcp())
+            .start()
+            .await
+            .expect("Failed to start proxy container");
         let port = container
             .get_host_port_ipv4(8888)
             .await

--- a/crates/policy-server/tests/integration_test.rs
+++ b/crates/policy-server/tests/integration_test.rs
@@ -1312,13 +1312,12 @@ mod proxy_helpers {
         runners::AsyncRunner,
     };
     pub async fn start_proxy() -> (ContainerAsync<GenericImage>, u16) {
-        let container =
-            GenericImage::new("registry.gitlab.com/kalaksi-containers/tinyproxy", "1.7")
-                .with_wait_for(WaitFor::message_on_stdout("Starting main loop"))
-                .with_exposed_port(8888.tcp())
-                .start()
-                .await
-                .expect("Failed to start proxy container");
+        let container = GenericImage::new("ghcr.io/kubewarden/tests/kalaksi-tinyproxy", "1.7")
+            .with_wait_for(WaitFor::message_on_stdout("Starting main loop"))
+            .with_exposed_port(8888.tcp())
+            .start()
+            .await
+            .expect("Failed to start proxy container");
         let port = container
             .get_host_port_ipv4(8888)
             .await


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

test: Consume [mirrored kalaksi:tinyproxy image](https://github.com/orgs/kubewarden/packages/container/package/tests%2Fkalaksi-tinyproxy)

Fix errors on integration tests.
This works around rate limits from dockerhub or gitlab.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
