### PR TITLE
fix(ci): missing autolabeler permissions

### DIFF
--- a/.github/workflows/autolabeler.yml
+++ b/.github/workflows/autolabeler.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   autolabeler:


### PR DESCRIPTION
## Description

Adds the missing permissions to allow autolabeler to add labels in the pull requests.

