### PR TITLE
fix(ci): move permissions to job level

### DIFF
--- a/.github/workflows/autolabeler.yml
+++ b/.github/workflows/autolabeler.yml
@@ -5,13 +5,10 @@ on:
     # Only following types are handled by the action, but one can default to all as well
     types: [opened, reopened, synchronize, edited]
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   autolabeler:
     permissions:
+      contents: read
       pull-requests: write
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

To avoid confusion and values overwriting, move all the permissions on the autolabeler workflow to the job level.

This is a continuation of https://github.com/kubewarden/kubewarden-controller/pull/1608