### PR TITLE
fix(ci): skip autolabeler in PR from forks

### DIFF
--- a/.github/workflows/autolabeler.yml
+++ b/.github/workflows/autolabeler.yml
@@ -1,15 +1,18 @@
-name: Autolabeler
+name: Auto label
 
 on:
   pull_request:
-    # Only following types are handled by the action, but one can default to all as well
     types: [opened, reopened, synchronize, edited]
+
+permissions: {}
 
 jobs:
   autolabeler:
+    # Skip fork PRs — the GITHUB_TOKEN is read-only and cannot add labels
+    if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     permissions:
-      contents: read
       pull-requests: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter/autolabeler@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1


### PR DESCRIPTION
## Description

Following the recommendation from the SUSE security team, the `pull_request_target` triggers from all our CI files have been removed. However, this trigger is required to allow the autolabeler action tagging PRs from forks. It's not possible to use `pull_request` only because Github by default set all the permissions to read-only for this trigger. Ignoring what it is defined in the CI file.

Because of that, this PR updates the autolabeler CI workflow to skip the tagging when the PR came from a fork.


