### PR TITLE
ci go improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,8 +137,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
-          check-latest: true # Always check for the latest patch release
+          go-version-file: "go.mod"
       - run: make test-go
       - name: Upload Go test coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
@@ -161,8 +160,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
-          check-latest: true # Always check for the latest patch release
+          go-version-file: "go.mod"
       - run: make test-e2e
 
   golangci:
@@ -176,8 +174,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
-          check-latest: true # Always check for the latest patch release
+          go-version-file: "go.mod"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
@@ -478,8 +475,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
-          check-latest: true
+          go-version-file: "go.mod"
       - run: |
           make check-generate
 

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
       - go.sum
+      - go.mod
   schedule:
     - cron: "0 0 * * *"
 
@@ -17,7 +18,7 @@ jobs:
       - name: Install Golang
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          go-version-file: "go.mod"
           check-latest: true # Always check for the latest patch release
       - name: govulncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -20,12 +20,11 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Install Golang
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: "go.mod"
-          check-latest: true # Always check for the latest patch release
       - name: govulncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:
+          # required to override the default value that is 'stable'
+          # in this way `go-version-file` is going to be taken into account
+          go-version-input: ""
+          go-version-file: "go.mod"
           go-package: ./...

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -15,6 +15,11 @@ jobs:
     name: govulncheck
     runs-on: ubuntu-latest
     steps:
+      # checkout the source, required to have `go.mod`
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - name: Install Golang
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:


### PR DESCRIPTION
This PR does some improvements to some GHA that deal with Go.

We now install the same version of go that is mentioned inside of the `go.mod` file. Moreover, we intruct govulncheck to look also at the `go.mod`.
