### PR TITLE
chore: update go lang used in Dockerfile to v1.26.2 

### DIFF
--- a/Dockerfile.audit-scanner
+++ b/Dockerfile.audit-scanner
@@ -1,5 +1,5 @@
 # Build the audit-scanner binary
-FROM golang:1.26.1@sha256:595c7847cff97c9a9e76f015083c481d26078f961c9c8dca3923132f51fe12f1 AS builder
+FROM golang:1.26.2@sha256:2a2b4b5791cea8ae09caecba7bad0bd9631def96e5fe362e4a5e67009fe4ae61 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile.kubewarden-controller
+++ b/Dockerfile.kubewarden-controller
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Build the manager binary
-FROM golang:1.26.1@sha256:595c7847cff97c9a9e76f015083c481d26078f961c9c8dca3923132f51fe12f1 AS build
+FROM golang:1.26.2@sha256:2a2b4b5791cea8ae09caecba7bad0bd9631def96e5fe362e4a5e67009fe4ae61 AS build
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
## Description

Updates the Go lang version used in Dockerfiles to v1.26.2.

> [!WARNING]
> I'm not updating go lang in other places because there is the PR #1631 which is doing that. 