### PR TITLE
fix(ci): fix breaking input name changes from kubewarden/github-actions

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -39,7 +39,7 @@ jobs:
           component: ${{ matrix.component }}
           arch: ${{ matrix.arch }}
           platform: ${{ matrix.platform }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   merge:
     runs-on: ubuntu-latest
@@ -71,4 +71,4 @@ jobs:
           component: ${{ matrix.component }}
           tag: ${{ env.TAG_NAME }}
           arch: amd64,arm64
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -106,7 +106,7 @@ jobs:
       - name: "Install kwctl"
         uses: kubewarden/github-actions/kwctl-installer@0f1672d63bd3572f204917d68390d87f7430069a # v5.0.0
         with:
-          KWCTL_VERSION: latest
+          kwctl-version: latest
 
       - run: sudo npm install -g bats
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           component: ${{ matrix.component }}
           arch: ${{ matrix.arch }}
           platform: ${{ matrix.platform }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   merge-containers:
     name: Merge multi-arch manifests
@@ -106,7 +106,7 @@ jobs:
           component: ${{ matrix.component }}
           tag: ${{ github.ref_name }}
           arch: amd64,arm64
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   build-kwctl:
     name: Build kwctl binaries
@@ -135,7 +135,7 @@ jobs:
         with:
           component: ${{ matrix.component }}
           arch: ${{ matrix.arch }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     name: Create release


### PR DESCRIPTION
## Description

Fix the input names of the github-actions v5.0.0

Fix #1659 
