### PR TITLE
fix(ci): Set opa checksum, fixes burrego e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,7 @@ jobs:
         uses: kubewarden/github-actions/opa-installer@0f1672d63bd3572f204917d68390d87f7430069a # v5.0.0
         with:
           opa-version: v1.12.2
+          checksum: cd6b0b2d762571a746f0261890b155e6dd71cca90dad6b42b6fcf6dd7f619f08
       - name: Install bats
         run: sudo apt-get install -y bats
       - name: Run e2e tests


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

The burego e2e tests are failing in main. This fixes it
https://github.com/kubewarden/kubewarden-controller/actions/runs/24394755260

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
