### PR TITLE
fix(ci): install kwctl version from Github Action.

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -105,8 +105,6 @@ jobs:
 
       - name: "Install kwctl"
         uses: kubewarden/github-actions/kwctl-installer@0f1672d63bd3572f204917d68390d87f7430069a # v5.0.0
-        with:
-          kwctl-version: latest
 
       - run: sudo npm install -g bats
 


### PR DESCRIPTION
## Description

Updates the e2e-tests.yml to install the default version from the kwctl-installer Github action. We cannot use "latest" as version now because it's necessary to verify the signature of binary using cosign and that require the actual version that trigger the release CI job.

Related to https://github.com/kubewarden/github-actions/pull/290