### PR TITLE
chore(ci): Actually use opa checksum for v1.12.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
         uses: kubewarden/github-actions/opa-installer@63e6bff6226bbdd84a4244892417eb27676b7a8c # v5.0.1
         with:
           opa-version: v1.12.2
-          checksum: cd6b0b2d762571a746f0261890b155e6dd71cca90dad6b42b6fcf6dd7f619f08
+          checksum: a4ba8734ed95ceaac850c12684a42467ed6b0dc9633a9db8dd14d47d05e37751
       - name: Install bats
         run: sudo apt-get install -y bats
       - name: Run e2e tests


### PR DESCRIPTION


## Description

This fixes the burrego e2e tests.

<!-- Please provide the link to the GitHub issue you are addressing -->
In the [previous try](https://github.com/kubewarden/kubewarden-controller/pull/1661), I used the checksum for v0.65.0, which is the version used by default in the action.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
