### PR TITLE
fix: shorten cluster name to fit into 32 chars limit

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -67,7 +67,7 @@ env:
   K3D_VERSION: v5.8.3
   K3D_CHECKSUM_AMD64: dbaa79a76ace7f4ca230a1ff41dc7d8a5036a8ad0309e9c54f9bf3836dbe853e
   K3D_CHECKSUM_ARM64: 0b8110f2229631af7402fb828259330985918b08fefd38b7f1b788a1c8687216
-  K3D_CLUSTER_NAME: ${{ github.repository_owner }}-${{ github.event.repository.name }}
+  K3D_CLUSTER_NAME: ${{ github.repository_owner }}-${{ github.run_id }}
   MTLS: ${{ github.event_name == 'pull_request' && 'true' || inputs.MTLS }}
 
 jobs:


### PR DESCRIPTION
## Description

k3d has limit of 32 characters for cluster name.
This variable is not used for debugging, we can switch to shorter / less readable name.

```
FATA[0000] Failed Cluster Configuration Validation:  provided cluster name 'kubewarden-kubewarden-controller-private' does not match requirements: Cluster name must be <= 32 characters, but has 40
```

