### PR TITLE
ci: Don't bump container FROM tags with updatecli anymore 

### DIFF
--- a/updatecli/updatecli.d/go.yaml
+++ b/updatecli/updatecli.d/go.yaml
@@ -24,19 +24,6 @@ targets:
     spec:
       file: go.mod
 
-  dockerfile:
-    name: "deps(go): update Docker image tag"
-    kind: dockerfile
-    sourceid: go
-    scmid: default
-    spec:
-      files:
-        - Dockerfile.kubewarden-controller
-        - Dockerfile.audit-scanner
-      instruction:
-        keyword: FROM
-        matcher: golang
-
 actions:
   default:
     title: 'deps(go): update Go to {{ source "go" }} version'


### PR DESCRIPTION
## Description

This is done by renovatebot now, and renovatebot uses shasums correctly
too.

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to  https://github.com/kubewarden/kubewarden-controller/pull/1679.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

Untested.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
