### PR TITLE
chore: add release contributors section

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -29,6 +29,10 @@ name-template: "v$RESOLVED_VERSION"
 template: |
   $CHANGES
 
+  ## Contributors
+
+  $CONTRIBUTORS
+
 autolabeler:
   # Tag any PR with "!" in the subject as major update. In other words, breaking change
   - label: "kind/breaking-change"


### PR DESCRIPTION
## Summary
- Add a Contributors section to the Release Drafter template using `$CONTRIBUTORS`.
- Keep the existing release categories, labels, and version resolver unchanged.

Fixes #831

## Validation
- `yq '.' .github/release-drafter.yml`
- `yq -e '.template == "$CHANGES\n\n## Contributors\n\n$CONTRIBUTORS\n"' .github/release-drafter.yml`
- `git diff --check`