### PR TITLE
chore: update container images to use adm-controller namespace

### DIFF
--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -118,7 +118,7 @@ policyServer:
   # maxUnavailable: 1
   image:
     # The registry is defined in the global.cattle.systemDefaultRegistry value
-    repository: "kubewarden/policy-server"
+    repository: "kubewarden/adm-controller/policy-server"
     tag: v1.35.0
   serviceAccountName: policy-server
   # Configmap containing a Sigstore verification configuration under a key

--- a/crates/policy-evaluator/tests/integration_test.rs
+++ b/crates/policy-evaluator/tests/integration_test.rs
@@ -416,7 +416,7 @@ async fn test_host_capabilities<F, Fut>(
     "ghcr.io/kubewarden/tests/context-aware-test-policy:latest",
     OciManifest::Image(Default::default())
 )]
-#[case::container_image("ghcr.io/kubewarden/policy-server:latest", OciManifest::ImageIndex(policy_fetcher::oci_client::manifest::OciImageIndex{schema_version:2, media_type: None, manifests: vec![], annotations: None, artifact_type: None}))]
+#[case::container_image("ghcr.io/kubewarden/adm-controller/policy-server:latest", OciManifest::ImageIndex(policy_fetcher::oci_client::manifest::OciImageIndex{schema_version:2, media_type: None, manifests: vec![], annotations: None, artifact_type: None}))]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_oci_manifest_capability(
     #[case] policy_uri: &str,

--- a/e2e/test-verification/resources/server-with-verification.yml
+++ b/e2e/test-verification/resources/server-with-verification.yml
@@ -4,6 +4,6 @@ kind: PolicyServer
 metadata:
   name: reserved-instance-for-tenant-a
 spec:
-  image: ghcr.io/kubewarden/policy-server:latest
+  image: ghcr.io/kubewarden/adm-controller/policy-server:latest
   replicas: 1
   verificationConfig: my-verification-config

--- a/e2e/test-verification/resources/server-without-verification.yml
+++ b/e2e/test-verification/resources/server-without-verification.yml
@@ -4,5 +4,5 @@ kind: PolicyServer
 metadata:
   name: reserved-instance-for-tenant-a
 spec:
-  image: ghcr.io/kubewarden/policy-server:v0.2.4
+  image: ghcr.io/kubewarden/adm-controller/policy-server:latest
   replicas: 1

--- a/renovate.json
+++ b/renovate.json
@@ -20,8 +20,8 @@
         "docker"
       ],
       "matchPackageNames": [
-        "kubewarden/kubewarden-controller",
-        "kubewarden/audit-scanner"
+        "kubewarden/adm-controller/controller",
+        "kubewarden/adm-controller/audit-scanner"
       ],
       "matchPaths": [
         "charts/kubewarden-controller/values.yaml"
@@ -33,7 +33,7 @@
         "docker"
       ],
       "matchPackageNames": [
-        "kubewarden/policy-server"
+        "kubewarden/adm-controller/policy-server"
       ],
       "matchPaths": [
         "charts/kubewarden-defaults/values.yaml"


### PR DESCRIPTION
## Description

Update all container image references to use the new adm-controller namespace within the ghcr.io/kubewarden registry. This includes updates to policy-server, kubewarden-controller, and audit-scanner image references across Helm values, test resources, test code, and renovate configuration.

Part of https://github.com/kubewarden/adm-controller/issues/1657