### PR TITLE
fix(ci): updatecli checking for files that does not exist

### DIFF
--- a/updatecli/updatecli.release.d/open-release-pr.yaml
+++ b/updatecli/updatecli.release.d/open-release-pr.yaml
@@ -240,9 +240,8 @@ targets:
         spec:
           files:
             - crates/policy-server/Cargo.toml
-            - crates/policy-server/Cargo.lock
             - crates/kwctl/Cargo.toml
-            - crates/kwctl/Cargo.lock
+            - Cargo.lock
 
 scms:
   default:


### PR DESCRIPTION
## Description

The updatecli script used to open the release PR is checking for Cargo.lock files that does not exist in the monorepo. This commit fix that by removing those ones and add the unique Cargo.lock file from the root of the repository

Part of https://github.com/kubewarden/adm-controller/issues/1657
