### PR TITLE
ci: Upload logs of Go e2e tests, rename Helm chart e2e GH job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
         with:
           name: e2e-test-cluster-logs
           path: e2e/logs
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 7
 
   golangci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,14 @@ jobs:
           go-version: "1.26"
           check-latest: true # Always check for the latest patch release
       - run: make test-e2e
+      - name: Upload cluster logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-test-cluster-logs
+          path: e2e/logs
+          if-no-files-found: error
+          retention-days: 7
 
   golangci:
     name: Golangci-lint

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,4 +1,4 @@
-name: End-to-end tests
+name: Helm charts End-to-end tests
 
 run-name: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.display_title || '' }}
 
@@ -71,7 +71,8 @@ env:
   MTLS: ${{ github.event_name == 'pull_request' && 'true' || inputs.MTLS }}
 
 jobs:
-  e2e:
+  helm-charts-e2e:
+    name: Helm charts e2e tests
     # x86: ubuntu-latest, arm64: ubuntu-24.04-arm
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     permissions:


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix https://github.com/kubewarden/adm-controller/issues/1717

- Upload logs for Go e2e tests
- Rename GH job for Helm charts e2e tests to remove confusion

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
