### PR TITLE
feat!: Don't delete policies when deleting their PolicyServer

### DIFF
--- a/api/policies/v1/policyserver_types.go
+++ b/api/policies/v1/policyserver_types.go
@@ -227,15 +227,21 @@ const (
 	// PolicyServerPodDisruptionBudgetReconciled represents the condition of the
 	// Policy Server PodDisruptionBudget reconciliation.
 	PolicyServerPodDisruptionBudgetReconciled PolicyServerConditionType = "PodDisruptionBudgetReconciled"
+	// PolicyServerPolicyWebhooksCleanedUp represents the condition signalling
+	// whether the webhook configurations of the policies bound to a
+	// PolicyServer being deleted have been cleaned up. The PolicyServer's
+	// finalizer is only removed once this condition becomes True.
+	PolicyServerPolicyWebhooksCleanedUp PolicyServerConditionType = "PolicyWebhooksCleanedUp"
 )
 
 // PolicyServerStatus defines the observed state of PolicyServer.
 type PolicyServerStatus struct {
 	// Conditions represent the observed conditions of the
-	// PolicyServer resource.  Known .status.conditions.types
-	// are: "PolicyServerSecretReconciled",
-	// "PolicyServerDeploymentReconciled" and
-	// "PolicyServerServiceReconciled"
+	// PolicyServer resource.  Known .status.conditions.types are:
+	// "CertSecretReconciled", "CARootSecretReconciled",
+	// "ConfigMapReconciled", "DeploymentReconciled",
+	// "ServiceReconciled", "PodDisruptionBudgetReconciled" and
+	// "PolicyWebhooksCleanedUp"
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +listType=map

--- a/charts/kubewarden-crds/templates/crds/policies.kubewarden.io_policyservers.yaml
+++ b/charts/kubewarden-crds/templates/crds/policies.kubewarden.io_policyservers.yaml
@@ -1782,10 +1782,11 @@ spec:
               conditions:
                 description: |-
                   Conditions represent the observed conditions of the
-                  PolicyServer resource.  Known .status.conditions.types
-                  are: "PolicyServerSecretReconciled",
-                  "PolicyServerDeploymentReconciled" and
-                  "PolicyServerServiceReconciled"
+                  PolicyServer resource.  Known .status.conditions.types are:
+                  "CertSecretReconciled", "CARootSecretReconciled",
+                  "ConfigMapReconciled", "DeploymentReconciled",
+                  "ServiceReconciled", "PodDisruptionBudgetReconciled" and
+                  "PolicyWebhooksCleanedUp"
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/internal/controller/admissionpolicy_controller.go
+++ b/internal/controller/admissionpolicy_controller.go
@@ -87,6 +87,10 @@ func (r *AdmissionPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.findAdmissionPoliciesForPod),
 		).
 		Watches(
+			&policiesv1.PolicyServer{},
+			handler.EnqueueRequestsFromMapFunc(r.findAdmissionPoliciesForPolicyServer),
+		).
+		Watches(
 			&admissionregistrationv1.ValidatingWebhookConfiguration{},
 			handler.EnqueueRequestsFromMapFunc(r.findAdmissionPolicyForWebhookConfiguration),
 		).
@@ -104,6 +108,10 @@ func (r *AdmissionPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func (r *AdmissionPolicyReconciler) findAdmissionPoliciesForPod(ctx context.Context, object client.Object) []reconcile.Request {
 	return findPoliciesForPod(ctx, r.Client, object)
+}
+
+func (r *AdmissionPolicyReconciler) findAdmissionPoliciesForPolicyServer(ctx context.Context, object client.Object) []reconcile.Request {
+	return findAdmissionPoliciesForPolicyServer(ctx, r.Client, object)
 }
 
 func (r *AdmissionPolicyReconciler) findAdmissionPolicyForWebhookConfiguration(_ context.Context, webhookConfiguration client.Object) []reconcile.Request {

--- a/internal/controller/admissionpolicygroup_controller.go
+++ b/internal/controller/admissionpolicygroup_controller.go
@@ -87,6 +87,10 @@ func (r *AdmissionPolicyGroupReconciler) SetupWithManager(mgr ctrl.Manager) erro
 			handler.EnqueueRequestsFromMapFunc(r.findAdmissionPoliciesForPod),
 		).
 		Watches(
+			&policiesv1.PolicyServer{},
+			handler.EnqueueRequestsFromMapFunc(r.findAdmissionPolicyGroupsForPolicyServer),
+		).
+		Watches(
 			&admissionregistrationv1.ValidatingWebhookConfiguration{},
 			handler.EnqueueRequestsFromMapFunc(r.findAdmissionPolicyForWebhookConfiguration),
 		).
@@ -100,6 +104,10 @@ func (r *AdmissionPolicyGroupReconciler) SetupWithManager(mgr ctrl.Manager) erro
 
 func (r *AdmissionPolicyGroupReconciler) findAdmissionPoliciesForPod(ctx context.Context, object client.Object) []reconcile.Request {
 	return findPoliciesForPod(ctx, r.Client, object)
+}
+
+func (r *AdmissionPolicyGroupReconciler) findAdmissionPolicyGroupsForPolicyServer(ctx context.Context, object client.Object) []reconcile.Request {
+	return findAdmissionPolicyGroupsForPolicyServer(ctx, r.Client, object)
 }
 
 func (r *AdmissionPolicyGroupReconciler) findAdmissionPolicyForWebhookConfiguration(_ context.Context, webhookConfiguration client.Object) []reconcile.Request {

--- a/internal/controller/clusteradmissionpolicy_controller.go
+++ b/internal/controller/clusteradmissionpolicy_controller.go
@@ -87,6 +87,10 @@ func (r *ClusterAdmissionPolicyReconciler) SetupWithManager(mgr ctrl.Manager) er
 			handler.EnqueueRequestsFromMapFunc(r.findClusterAdmissionPoliciesForPod),
 		).
 		Watches(
+			&policiesv1.PolicyServer{},
+			handler.EnqueueRequestsFromMapFunc(r.findClusterAdmissionPoliciesForPolicyServer),
+		).
+		Watches(
 			&admissionregistrationv1.ValidatingWebhookConfiguration{},
 			handler.EnqueueRequestsFromMapFunc(r.findClusterAdmissionPolicyForWebhookConfiguration),
 		).
@@ -103,6 +107,10 @@ func (r *ClusterAdmissionPolicyReconciler) SetupWithManager(mgr ctrl.Manager) er
 
 func (r *ClusterAdmissionPolicyReconciler) findClusterAdmissionPoliciesForPod(ctx context.Context, object client.Object) []reconcile.Request {
 	return findClusterPoliciesForPod(ctx, r.Client, object)
+}
+
+func (r *ClusterAdmissionPolicyReconciler) findClusterAdmissionPoliciesForPolicyServer(ctx context.Context, object client.Object) []reconcile.Request {
+	return findClusterAdmissionPoliciesForPolicyServer(ctx, r.Client, object)
 }
 
 func (r *ClusterAdmissionPolicyReconciler) findClusterAdmissionPolicyForWebhookConfiguration(_ context.Context, webhookConfiguration client.Object) []reconcile.Request {

--- a/internal/controller/clusteradmissionpolicygroup_controller.go
+++ b/internal/controller/clusteradmissionpolicygroup_controller.go
@@ -87,6 +87,10 @@ func (r *ClusterAdmissionPolicyGroupReconciler) SetupWithManager(mgr ctrl.Manage
 			handler.EnqueueRequestsFromMapFunc(r.findClusterAdmissionPoliciesForPod),
 		).
 		Watches(
+			&policiesv1.PolicyServer{},
+			handler.EnqueueRequestsFromMapFunc(r.findClusterAdmissionPolicyGroupsForPolicyServer),
+		).
+		Watches(
 			&admissionregistrationv1.ValidatingWebhookConfiguration{},
 			handler.EnqueueRequestsFromMapFunc(r.findClusterAdmissionPolicyForWebhookConfiguration),
 		).
@@ -99,6 +103,10 @@ func (r *ClusterAdmissionPolicyGroupReconciler) SetupWithManager(mgr ctrl.Manage
 
 func (r *ClusterAdmissionPolicyGroupReconciler) findClusterAdmissionPoliciesForPod(ctx context.Context, object client.Object) []reconcile.Request {
 	return findClusterPoliciesForPod(ctx, r.Client, object)
+}
+
+func (r *ClusterAdmissionPolicyGroupReconciler) findClusterAdmissionPolicyGroupsForPolicyServer(ctx context.Context, object client.Object) []reconcile.Request {
+	return findClusterAdmissionPolicyGroupsForPolicyServer(ctx, r.Client, object)
 }
 
 func (r *ClusterAdmissionPolicyGroupReconciler) findClusterAdmissionPolicyForWebhookConfiguration(_ context.Context, webhookConfiguration client.Object) []reconcile.Request {

--- a/internal/controller/policy_subreconciler.go
+++ b/internal/controller/policy_subreconciler.go
@@ -86,10 +86,12 @@ func (r *policySubReconciler) reconcilePolicy(ctx context.Context, policy polici
 
 	policyServer, err := r.getPolicyServer(ctx, policy)
 	if err != nil {
-		policy.SetStatus(policiesv1.PolicyStatusScheduled)
-		//nolint:nilerr // set status to scheduled if policyServer can't be retrieved, and stop reconciling
-		return ctrl.Result{}, nil
+		if errors.Is(err, errPolicyServerNotAvailable) {
+			return r.reconcilePolicyServerUnavailable(ctx, policy)
+		}
+		return ctrl.Result{}, err
 	}
+
 	if policy.GetStatus().PolicyStatus != policiesv1.PolicyStatusActive {
 		policy.SetStatus(policiesv1.PolicyStatusPending)
 	}
@@ -130,29 +132,53 @@ func (r *policySubReconciler) reconcilePolicy(ctx context.Context, policy polici
 		return ctrl.Result{}, errors.Join(errors.New("cannot find policy server secret"), err)
 	}
 
-	if policy.IsMutating() {
-		if err = r.reconcileMutatingWebhookConfiguration(ctx, policy, &secret, policyServer.NameWithPrefix()); err != nil {
-			return ctrl.Result{}, errors.Join(errors.New("error reconciling mutating webhook"), err)
-		}
-	} else {
-		if err = r.reconcileValidatingWebhookConfiguration(ctx, policy, &secret, policyServer.NameWithPrefix()); err != nil {
-			return ctrl.Result{}, errors.Join(errors.New("error reconciling validating webhook"), err)
-		}
+	if err = r.reconcileWebhookConfiguration(ctx, policy, &secret, policyServer.NameWithPrefix()); err != nil {
+		return ctrl.Result{}, err
 	}
 	setPolicyAsActive(policy)
 
 	return ctrl.Result{}, nil
 }
 
-func (r *policySubReconciler) reconcilePolicyDeletion(ctx context.Context, policy policiesv1.Policy) (ctrl.Result, error) {
+// reconcilePolicyServerUnavailable handles the case where the PolicyServer is
+// confirmed missing or being deleted.
+// It removes the webhook configuration to prevent orphaned webhooks from blocking
+// admission requests, then sets the policy status as scheduled.
+func (r *policySubReconciler) reconcilePolicyServerUnavailable(ctx context.Context, policy policiesv1.Policy) (ctrl.Result, error) {
+	if err := r.deleteWebhookConfiguration(ctx, policy); err != nil {
+		return ctrl.Result{}, err
+	}
+	policy.SetStatus(policiesv1.PolicyStatusScheduled)
+	return ctrl.Result{}, nil
+}
+
+// reconcileWebhookConfiguration creates or patches the webhook configuration
+// for the policy, dispatching to the mutating or validating variant as needed.
+func (r *policySubReconciler) reconcileWebhookConfiguration(ctx context.Context, policy policiesv1.Policy, secret *corev1.Secret, policyServerName string) error {
 	if policy.IsMutating() {
-		if err := r.reconcileMutatingWebhookConfigurationDeletion(ctx, policy); err != nil {
-			return ctrl.Result{}, err
+		if err := r.reconcileMutatingWebhookConfiguration(ctx, policy, secret, policyServerName); err != nil {
+			return errors.Join(errors.New("error reconciling mutating webhook"), err)
 		}
-	} else {
-		if err := r.reconcileValidatingWebhookConfigurationDeletion(ctx, policy); err != nil {
-			return ctrl.Result{}, err
-		}
+		return nil
+	}
+	if err := r.reconcileValidatingWebhookConfiguration(ctx, policy, secret, policyServerName); err != nil {
+		return errors.Join(errors.New("error reconciling validating webhook"), err)
+	}
+	return nil
+}
+
+// deleteWebhookConfiguration removes the webhook configuration for the policy,
+// dispatching to the mutating or validating variant as needed.
+func (r *policySubReconciler) deleteWebhookConfiguration(ctx context.Context, policy policiesv1.Policy) error {
+	if policy.IsMutating() {
+		return r.reconcileMutatingWebhookConfigurationDeletion(ctx, policy)
+	}
+	return r.reconcileValidatingWebhookConfigurationDeletion(ctx, policy)
+}
+
+func (r *policySubReconciler) reconcilePolicyDeletion(ctx context.Context, policy policiesv1.Policy) (ctrl.Result, error) {
+	if err := r.deleteWebhookConfiguration(ctx, policy); err != nil {
+		return ctrl.Result{}, err
 	}
 	// Remove the old finalizer used to ensure that the policy server created
 	// before this controller version is delete as well. As the upgrade path
@@ -202,10 +228,22 @@ func (r *policySubReconciler) setPolicyModeStatus(ctx context.Context, policy po
 	return nil
 }
 
+// errPolicyServerNotAvailable is returned by getPolicyServer when the
+// PolicyServer CR is confirmed to not exist or is being deleted. It is
+// distinct from transient API errors so callers can decide whether to clean up
+// webhook configurations or simply requeue.
+var errPolicyServerNotAvailable = errors.New("policy server not available")
+
 func (r *policySubReconciler) getPolicyServer(ctx context.Context, policy policiesv1.Policy) (*policiesv1.PolicyServer, error) {
 	policyServer := policiesv1.PolicyServer{}
 	if err := r.Get(ctx, types.NamespacedName{Name: policy.GetPolicyServer()}, &policyServer); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, errPolicyServerNotAvailable
+		}
 		return nil, errors.Join(errors.New("could not get policy server"), err)
+	}
+	if policyServer.DeletionTimestamp != nil {
+		return nil, errPolicyServerNotAvailable
 	}
 	return &policyServer, nil
 }

--- a/internal/controller/policy_subreconciler.go
+++ b/internal/controller/policy_subreconciler.go
@@ -353,6 +353,94 @@ func findClusterPoliciesForPod(ctx context.Context, k8sClient client.Client, obj
 	return findClusterPoliciesForConfigMap(&configMap)
 }
 
+// findAdmissionPoliciesForPolicyServer maps a PolicyServer event to reconcile
+// requests for AdmissionPolicies that reference it by name.
+func findAdmissionPoliciesForPolicyServer(ctx context.Context, k8sClient client.Client, object client.Object) []reconcile.Request {
+	policyServer, ok := object.(*policiesv1.PolicyServer)
+	if !ok {
+		return []reconcile.Request{}
+	}
+
+	admissionPolicies := policiesv1.AdmissionPolicyList{}
+	if err := k8sClient.List(ctx, &admissionPolicies, client.MatchingFields{constants.PolicyServerIndexKey: policyServer.Name}); err != nil {
+		return []reconcile.Request{}
+	}
+
+	requests := make([]reconcile.Request, 0, len(admissionPolicies.Items))
+	for _, policy := range admissionPolicies.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: client.ObjectKey{Name: policy.Name, Namespace: policy.Namespace},
+		})
+	}
+	return requests
+}
+
+// findAdmissionPolicyGroupsForPolicyServer maps a PolicyServer event to
+// reconcile requests for all AdmissionPolicyGroups that reference it by name.
+func findAdmissionPolicyGroupsForPolicyServer(ctx context.Context, k8sClient client.Client, object client.Object) []reconcile.Request {
+	policyServer, ok := object.(*policiesv1.PolicyServer)
+	if !ok {
+		return []reconcile.Request{}
+	}
+
+	admissionPolicyGroups := policiesv1.AdmissionPolicyGroupList{}
+	if err := k8sClient.List(ctx, &admissionPolicyGroups, client.MatchingFields{constants.PolicyServerIndexKey: policyServer.Name}); err != nil {
+		return []reconcile.Request{}
+	}
+
+	requests := make([]reconcile.Request, 0, len(admissionPolicyGroups.Items))
+	for _, policy := range admissionPolicyGroups.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: client.ObjectKey{Name: policy.Name, Namespace: policy.Namespace},
+		})
+	}
+	return requests
+}
+
+// findClusterAdmissionPoliciesForPolicyServer maps a PolicyServer event to reconcile
+// requests for all ClusterAdmissionPolicies that reference it by name.
+func findClusterAdmissionPoliciesForPolicyServer(ctx context.Context, k8sClient client.Client, object client.Object) []reconcile.Request {
+	policyServer, ok := object.(*policiesv1.PolicyServer)
+	if !ok {
+		return []reconcile.Request{}
+	}
+
+	clusterAdmissionPolicies := policiesv1.ClusterAdmissionPolicyList{}
+	if err := k8sClient.List(ctx, &clusterAdmissionPolicies, client.MatchingFields{constants.PolicyServerIndexKey: policyServer.Name}); err != nil {
+		return []reconcile.Request{}
+	}
+
+	requests := make([]reconcile.Request, 0, len(clusterAdmissionPolicies.Items))
+	for _, policy := range clusterAdmissionPolicies.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: client.ObjectKey{Name: policy.Name},
+		})
+	}
+	return requests
+}
+
+// findClusterAdmissionPolicyGroupsForPolicyServer maps a PolicyServer event to reconcile
+// requests for all ClusterAdmissionPolicyGroups that reference it by name.
+func findClusterAdmissionPolicyGroupsForPolicyServer(ctx context.Context, k8sClient client.Client, object client.Object) []reconcile.Request {
+	policyServer, ok := object.(*policiesv1.PolicyServer)
+	if !ok {
+		return []reconcile.Request{}
+	}
+
+	clusterAdmissionPolicyGroups := policiesv1.ClusterAdmissionPolicyGroupList{}
+	if err := k8sClient.List(ctx, &clusterAdmissionPolicyGroups, client.MatchingFields{constants.PolicyServerIndexKey: policyServer.Name}); err != nil {
+		return []reconcile.Request{}
+	}
+
+	requests := make([]reconcile.Request, 0, len(clusterAdmissionPolicyGroups.Items))
+	for _, policy := range clusterAdmissionPolicyGroups.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: client.ObjectKey{Name: policy.Name},
+		})
+	}
+	return requests
+}
+
 func hasKubewardenLabel(labels map[string]string) bool {
 	// Pre v1.16.0
 	kubewardenLabel := labels["kubewarden"]

--- a/internal/controller/policyserver_controller.go
+++ b/internal/controller/policyserver_controller.go
@@ -20,14 +20,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -103,18 +106,18 @@ func (r *PolicyServerReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
+	if policyServer.ObjectMeta.DeletionTimestamp != nil {
+		return r.reconcileDeletion(ctx, &policyServer)
+	}
+
+	err := r.reconcilePolicyServerCertSecret(ctx, &policyServer)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	policies, err := r.getPolicies(ctx, &policyServer)
 	if err != nil {
 		return ctrl.Result{}, errors.Join(errors.New("could not get policies"), err)
-	}
-
-	if policyServer.ObjectMeta.DeletionTimestamp != nil {
-		return r.reconcileDeletion(ctx, &policyServer, policies)
-	}
-
-	err = r.reconcilePolicyServerCertSecret(ctx, &policyServer)
-	if err != nil {
-		return ctrl.Result{}, err
 	}
 
 	if err = r.reconcilePolicyServerConfigMap(ctx, &policyServer, policies); err != nil {
@@ -359,15 +362,76 @@ func (r *PolicyServerReconciler) getPolicies(ctx context.Context, policyServer *
 	return policies, nil
 }
 
-func (r *PolicyServerReconciler) reconcileDeletion(ctx context.Context, policyServer *policiesv1.PolicyServer, policies []policiesv1.Policy) (ctrl.Result, error) {
-	if len(policies) != 0 {
-		// There are still policies scheduled on the PolicyServer, we have to
-		// wait for them to be completely removed before going further with the cleanup
-		return r.deletePoliciesAndRequeue(ctx, policyServer, policies)
+// reconcileDeletion waits for the webhook configurations of all bound policies
+// to be removed before releasing the PolicyServer finalizers. The
+// PolicyWebhooksCleanedUp condition tracks progress:
+//   - False: webhooks still exist; requeue with a short delay.
+//   - True: all webhooks gone; remove finalizers on the next reconcile loop so
+//     the fresh resourceVersion from the status update is used.
+func (r *PolicyServerReconciler) reconcileDeletion(ctx context.Context, policyServer *policiesv1.PolicyServer) (ctrl.Result, error) {
+	// If the condition is already True the previous reconcile already confirmed
+	// all webhooks are gone. Remove the finalizers using the freshly-fetched
+	// object (guaranteed by Reconcile calling r.Get before reaching here).
+	if apimeta.IsStatusConditionTrue(policyServer.Status.Conditions, string(policiesv1.PolicyServerPolicyWebhooksCleanedUp)) {
+		return r.removeFinalizers(ctx, policyServer)
 	}
 
+	policies, err := r.getPolicies(ctx, policyServer)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Check policies assigned to this PolicyServer and wait until their
+	// WebhookConfiguration is gone. Retry by returning and requeuing; cheaper
+	// than adding a watch on WebhookConfigurations on PolicyServers.
+	remaining := []string{}
+	for _, policy := range policies {
+		name := policy.GetUniqueName()
+		var validatingFound bool
+		validatingFound, err = r.webhookExists(ctx, name, &admissionregistrationv1.ValidatingWebhookConfiguration{})
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("cannot check ValidatingWebhookConfiguration %q: %w", name, err)
+		}
+		if validatingFound {
+			remaining = append(remaining, name)
+			continue
+		}
+		var mutatingFound bool
+		mutatingFound, err = r.webhookExists(ctx, name, &admissionregistrationv1.MutatingWebhookConfiguration{})
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("cannot check MutatingWebhookConfiguration %q: %w", name, err)
+		}
+		if mutatingFound {
+			remaining = append(remaining, name)
+		}
+	}
+	if len(remaining) > 0 {
+		setFalseConditionType(
+			&policyServer.Status.Conditions,
+			string(policiesv1.PolicyServerPolicyWebhooksCleanedUp),
+			fmt.Sprintf("Waiting for webhook cleanup of policies: %s", strings.Join(remaining, ", ")),
+		)
+		if err = r.Client.Status().Update(ctx, policyServer); err != nil {
+			return ctrl.Result{}, fmt.Errorf("cannot update policy server status: %w", err)
+		}
+		return ctrl.Result{RequeueAfter: constants.TimeToRequeuePolicyReconciliation}, nil
+	}
+
+	setTrueConditionType(
+		&policyServer.Status.Conditions,
+		string(policiesv1.PolicyServerPolicyWebhooksCleanedUp),
+	)
+	if err = r.Client.Status().Update(ctx, policyServer); err != nil {
+		return ctrl.Result{}, fmt.Errorf("cannot update policy server status: %w", err)
+	}
+	// Requeue so the next reconcile fetches the object with the updated
+	// resourceVersion before calling r.Update to remove the finalizers.
+	return ctrl.Result{Requeue: true}, nil
+}
+
+func (r *PolicyServerReconciler) removeFinalizers(ctx context.Context, policyServer *policiesv1.PolicyServer) (ctrl.Result, error) {
 	// Remove the old finalizer used to ensure that the policy server created
-	// before this controller version is delete as well. As the upgrade path
+	// before this controller version is deleted as well. As the upgrade path
 	// supported by the Kubewarden project does not allow jumping versions, we
 	// can safely remove this line of code after a few releases.
 	controllerutil.RemoveFinalizer(policyServer, constants.KubewardenFinalizerPre114)
@@ -383,24 +447,17 @@ func (r *PolicyServerReconciler) reconcileDeletion(ctx context.Context, policySe
 	return ctrl.Result{}, nil
 }
 
-func (r *PolicyServerReconciler) deletePoliciesAndRequeue(ctx context.Context, policyServer *policiesv1.PolicyServer, policies []policiesv1.Policy) (ctrl.Result, error) {
-	deleteError := make([]error, 0)
-	for _, policy := range policies {
-		if policy.GetDeletionTimestamp() != nil {
-			// the policy is already pending deletion
-			continue
-		}
-		if err := r.Delete(ctx, policy); err != nil && !apierrors.IsNotFound(err) {
-			deleteError = append(deleteError, err)
-		}
+// webhookExists returns true if a webhook configuration with the given name
+// exists, false if it does not exist, and an error for any transient API error.
+func (r *PolicyServerReconciler) webhookExists(ctx context.Context, name string, obj client.Object) (bool, error) {
+	err := r.Client.Get(ctx, types.NamespacedName{Name: name}, obj)
+	if err == nil {
+		return true, nil
 	}
-
-	if len(deleteError) != 0 {
-		r.Log.Error(errors.Join(deleteError...), "could not remove all policies bound to policy server", "policy-server", policyServer.Name)
-		return ctrl.Result{}, fmt.Errorf("could not remove all policies bound to policy server %s", policyServer.Name)
+	if apierrors.IsNotFound(err) {
+		return false, nil
 	}
-
-	return ctrl.Result{Requeue: true}, nil
+	return false, fmt.Errorf("cannot get %T %q: %w", obj, name, err)
 }
 
 func setFalseConditionType(

--- a/internal/controller/policyserver_controller_test.go
+++ b/internal/controller/policyserver_controller_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8spoliciesv1 "k8s.io/api/policy/v1"
@@ -1822,90 +1823,96 @@ var _ = Describe("PolicyServer controller", func() {
 				)
 			})
 
-			It("should delete assigned policies", func() {
+			It("should set assigned policies as scheduled and remove their webhook configuration", func() {
+				policy, err := getTestClusterAdmissionPolicy(ctx, policyName)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Manually create the ValidatingWebhookConfiguration to simulate
+				// the policy being active. In envtest there are no running pods so
+				// policies never reach the active status and the webhook is never
+				// created by the controller.
+				webhook := &admissionregistrationv1.ValidatingWebhookConfiguration{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: policy.GetUniqueName(),
+						Labels: map[string]string{
+							constants.PartOfLabelKey: constants.PartOfLabelValue,
+						},
+					},
+					Webhooks: []admissionregistrationv1.ValidatingWebhook{
+						{
+							Name:                    policy.GetUniqueName() + ".kubewarden.admission",
+							AdmissionReviewVersions: []string{"v1"},
+							SideEffects: func() *admissionregistrationv1.SideEffectClass {
+								s := admissionregistrationv1.SideEffectClassNone
+								return &s
+							}(),
+							ClientConfig: admissionregistrationv1.WebhookClientConfig{
+								Service: &admissionregistrationv1.ServiceReference{
+									Namespace: deploymentsNamespace,
+									Name:      policyServerName,
+								},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, webhook)).To(Succeed())
+
 				Expect(
 					k8sClient.Delete(ctx, policiesv1.NewPolicyServerFactory().WithName(policyServerName).Build()),
 				).To(Succeed())
 
+				// Policy should transition to scheduled.
 				Eventually(func() (*policiesv1.ClusterAdmissionPolicy, error) {
 					return getTestClusterAdmissionPolicy(ctx, policyName)
+				}, timeout, pollInterval).Should(
+					HaveField("Status.PolicyStatus", Equal(policiesv1.PolicyStatusScheduled)),
+				)
+
+				// The ValidatingWebhookConfiguration must be removed so orphaned
+				// webhooks don't block admission requests.
+				Eventually(func() error {
+					got := admissionregistrationv1.ValidatingWebhookConfiguration{}
+					return k8sClient.Get(ctx, types.NamespacedName{Name: policy.GetUniqueName()}, &got)
+				}, timeout, pollInterval).ShouldNot(Succeed())
+
+				// Once the webhook is gone the PolicyWebhooksCleanedUp condition
+				// must be True and the finalizer must be removed.
+				Eventually(func() (*policiesv1.PolicyServer, error) {
+					return getTestPolicyServer(ctx, policyServerName)
+				}, timeout, pollInterval).Should(And(
+					HaveField("Finalizers", Not(ContainElement(constants.KubewardenFinalizer))),
+					HaveField("Status.Conditions", ContainElement(And(
+						HaveField("Type", string(policiesv1.PolicyServerPolicyWebhooksCleanedUp)),
+						HaveField("Status", metav1.ConditionTrue),
+					))),
+				))
+			})
+
+			It("should not delete assigned policies", func() {
+				Expect(
+					k8sClient.Delete(ctx, policiesv1.NewPolicyServerFactory().WithName(policyServerName).Build()),
+				).To(Succeed())
+
+				// No webhook exists so the finalizer should be removed once the
+				// controller confirms there are no outstanding webhook configurations.
+				Eventually(func() (*policiesv1.PolicyServer, error) {
+					return getTestPolicyServer(ctx, policyServerName)
 				}, timeout, pollInterval).ShouldNot(
+					HaveField("Finalizers", ContainElement(constants.KubewardenFinalizer)),
+				)
+
+				// Assigned policies should NOT be deleted by the controller
+				Consistently(func() (*policiesv1.ClusterAdmissionPolicy, error) {
+					return getTestClusterAdmissionPolicy(ctx, policyName)
+				}, "5s", pollInterval).Should(
 					HaveField("DeletionTimestamp", BeNil()),
 				)
 			})
 
-			It("should get its old not domain-qualidied finalizer removed from policies", func() {
-				Eventually(func() error {
-					policy, err := getTestClusterAdmissionPolicy(ctx, policyName)
-					if err != nil {
-						return err
-					}
-					controllerutil.AddFinalizer(policy, constants.KubewardenFinalizerPre114)
-					return k8sClient.Update(ctx, policy)
-				}, timeout, pollInterval).Should(Succeed())
-				Eventually(func() error {
-					policy, err := getTestClusterAdmissionPolicy(ctx, policyName)
-					if err != nil {
-						return err
-					}
-					if controllerutil.ContainsFinalizer(policy, constants.KubewardenFinalizerPre114) {
-						return nil
-					}
-					return errors.New("old finalizer not found")
-				}, timeout, pollInterval).Should(Succeed())
-
-				Expect(
-					k8sClient.Delete(ctx, policiesv1.NewPolicyServerFactory().WithName(policyServerName).Build()),
-				).To(Succeed())
-
-				Eventually(func() (*policiesv1.ClusterAdmissionPolicy, error) {
-					return getTestClusterAdmissionPolicy(ctx, policyName)
-				}, timeout, pollInterval).Should(And(
-					HaveField("DeletionTimestamp", Not(BeNil())),
-					HaveField("Finalizers", Not(ContainElement(constants.KubewardenFinalizer))),
-					HaveField("Finalizers", Not(ContainElement(constants.KubewardenFinalizerPre114))),
-					HaveField("Finalizers", ContainElement(integrationTestsFinalizer)),
-				))
-			})
-
-			It("should not delete its managed resources until all the scheduled policies are gone", func() {
-				Expect(
-					k8sClient.Delete(ctx, policiesv1.NewPolicyServerFactory().WithName(policyServerName).Build()),
-				).To(Succeed())
-
-				Eventually(func() (*policiesv1.ClusterAdmissionPolicy, error) {
-					return getTestClusterAdmissionPolicy(ctx, policyName)
-				}).Should(And(
-					HaveField("DeletionTimestamp", Not(BeNil())),
-					HaveField("Finalizers", Not(ContainElement(constants.KubewardenFinalizer))),
-					HaveField("Finalizers", ContainElement(integrationTestsFinalizer)),
-				))
-
-				Eventually(func() error {
-					_, err := getTestPolicyServerService(ctx, policyServerName)
-					return err
-				}).Should(Succeed())
-			})
-
 			It(fmt.Sprintf("should get its %q finalizer removed", constants.KubewardenFinalizer), func() {
-				Eventually(func() error {
-					policy, err := getTestClusterAdmissionPolicy(ctx, policyName)
-					if err != nil {
-						return err
-					}
-					controllerutil.RemoveFinalizer(policy, integrationTestsFinalizer)
-					return k8sClient.Update(ctx, policy)
-				}).Should(Succeed())
-
 				Expect(
 					k8sClient.Delete(ctx, policiesv1.NewPolicyServerFactory().WithName(policyServerName).Build()),
 				).To(Succeed())
-
-				// wait for the reconciliation loop of the ClusterAdmissionPolicy to remove the resource
-				Eventually(func() error {
-					_, err := getTestClusterAdmissionPolicy(ctx, policyName)
-					return err
-				}, timeout, pollInterval).ShouldNot(Succeed())
 
 				Eventually(func() (*policiesv1.PolicyServer, error) {
 					return getTestPolicyServer(ctx, policyServerName)


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Part of https://github.com/kubewarden/adm-controller/issues/1700

Instead of deleting the policies belonging to a PolicyServer when the PolicyServer is deleted, let them be.
Use the policy subreconcilers to set them as Scheduled, as:
- They must not have a webhook configuration registered, or we brick the cluster.
- No admission requests should be forwarded to the policy
- The policy is not audited by the audit scanner

When deleting the PolicyServer, the policy subrecondiler was finding the PolicyServer (so it set the policy as *pending*) as at that moment it still exists with a `DeletionTimestamp` until all Finalizers are removed.
Hence, treat a PolicyServer that has a DeletionTimestamp as "not found" in `getPolicyServer()`.

Amend integration tests.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
