### PR TITLE
tests(helm): Annotated crds_test.yml for helm unittest >= 1.1.0

### DIFF
--- a/charts/kubewarden-crds/tests/crds_test.yaml
+++ b/charts/kubewarden-crds/tests/crds_test.yaml
@@ -1,7 +1,7 @@
 suite: Kubewarden CRDs
 tests:
   - it: "admissionpolicies CRD should be a CustomResourceDefinition"
-    template: crds/policies.kubewarden.io_admissionpolicies.yaml
+    template: templates/crds/policies.kubewarden.io_admissionpolicies.yaml
     asserts:
       - equal:
           path: kind
@@ -14,7 +14,7 @@ tests:
           value: policies.kubewarden.io
 
   - it: "admissionpolicygroups CRD should be a CustomResourceDefinition"
-    template: crds/policies.kubewarden.io_admissionpolicygroups.yaml
+    template: templates/crds/policies.kubewarden.io_admissionpolicygroups.yaml
     asserts:
       - equal:
           path: kind
@@ -27,7 +27,7 @@ tests:
           value: policies.kubewarden.io
 
   - it: "clusteradmissionpolicies CRD should be a CustomResourceDefinition"
-    template: crds/policies.kubewarden.io_clusteradmissionpolicies.yaml
+    template: templates/crds/policies.kubewarden.io_clusteradmissionpolicies.yaml
     asserts:
       - equal:
           path: kind
@@ -40,7 +40,7 @@ tests:
           value: policies.kubewarden.io
 
   - it: "clusteradmissionpolicygroups CRD should be a CustomResourceDefinition"
-    template: crds/policies.kubewarden.io_clusteradmissionpolicygroups.yaml
+    template: templates/crds/policies.kubewarden.io_clusteradmissionpolicygroups.yaml
     asserts:
       - equal:
           path: kind
@@ -53,7 +53,7 @@ tests:
           value: policies.kubewarden.io
 
   - it: "policyservers CRD should be a CustomResourceDefinition"
-    template: crds/policies.kubewarden.io_policyservers.yaml
+    template: templates/crds/policies.kubewarden.io_policyservers.yaml
     asserts:
       - equal:
           path: kind


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Helm unittest >= 1.1.0 doesn't automatically prepend the `templates/` prefix to the path, hence the tests were failing to find the correct files.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

CI.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
