### PR TITLE
fix(kwctl): malformatted markdown installing text

### DIFF
--- a/crates/policy-evaluator/src/policy_artifacthub.rs
+++ b/crates/policy-evaluator/src/policy_artifacthub.rs
@@ -387,7 +387,7 @@ fn parse_links(
 
 fn compose_install(oci_url: String) -> String {
     format!(
-        r#"The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
+        r#"The policy can be obtained using [kwctl](https://docs.kubewarden.io/howtos/install-kwctl):
 ```console
 kwctl pull {oci_url}
 ```
@@ -866,7 +866,7 @@ mod tests {
                 "kubewarden/rules": "[]\n",
                 "kubewarden/resources": "Pod, Deployment",
             },
-            "install": r#"The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
+            "install": r#"The policy can be obtained using [kwctl](https://docs.kubewarden.io/howtos/install-kwctl):
 ```console
 kwctl pull ghcr.io/ocirepo/namespace/verify-image-signatures:v0.2.1
 ```
@@ -932,7 +932,7 @@ kwctl scaffold manifest -t ClusterAdmissionPolicy registry://ghcr.io/ocirepo/nam
                 "url": "https://github.com/repo"
             }
             ],
-            "install": r#"The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
+            "install": r#"The policy can be obtained using [kwctl](https://docs.kubewarden.io/howtos/install-kwctl):
 ```console
 kwctl pull ghcr.io/ocirepo/namespace/verify-image-signatures:v0.2.1
 ```


### PR DESCRIPTION
## Description

Updates the installation markdown text used by kwctl in the Artifacthub file generation. The text generated a weird text formatting in the web interface with the `kwctl` used in a link.

Example of the issue in the web interface:

<img width="834" height="665" alt="image" src="https://github.com/user-attachments/assets/d3971188-36c9-451d-baa8-678ab2770f11" />
