### PR TITLE
fix: handle docker credential files missing auth field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,6 +1893,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker_credential"
+version = "1.3.3"
+source = "git+https://github.com/flavio/docker_credential.git?branch=fix-handle-config-without-auth-field#b3b60f5c8df32a439badc76d8610a88878c56597"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4760,7 +4770,7 @@ dependencies = [
  "base64 0.22.1",
  "cfg-if",
  "directories",
- "docker_credential",
+ "docker_credential 1.3.3 (git+https://github.com/flavio/docker_credential.git?branch=fix-handle-config-without-auth-field)",
  "futures",
  "hex",
  "lazy_static",
@@ -6819,7 +6829,7 @@ dependencies = [
  "bollard",
  "bytes",
  "conquer-once",
- "docker_credential",
+ "docker_credential 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "either",
  "etcetera",
  "ferroid",

--- a/crates/policy-fetcher/Cargo.toml
+++ b/crates/policy-fetcher/Cargo.toml
@@ -17,8 +17,9 @@ async-trait = "0.1"
 base64 = { workspace = true }
 cfg-if = "1.0"
 directories = "6.0"
-docker_credential = "1.3"
+docker_credential = { git = "https://github.com/flavio/docker_credential.git", branch = "fix-handle-config-without-auth-field" }
 futures = { workspace = true }
+hex = { workspace = true }
 lazy_static = { workspace = true }
 oci-client = { version = "0.16", default-features = false, features = [
   "rustls-tls",
@@ -34,7 +35,6 @@ serde_bytes = "0.11"
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 sha2 = { workspace = true }
-hex = { workspace = true }
 sigstore = { version = "0.13", default-features = false, features = [
   "cached-client",
   "cosign",


### PR DESCRIPTION
This is required to fix https://github.com/kubewarden/adm-controller/issues/1734

This is required until https://github.com/keirlawson/docker_credential/pull/24 is merged and a new version of the crate is tagged.
