### PR TITLE
fix(chart): restrict restart hook to sidecar telemetry mode

### DIFF
--- a/charts/kubewarden-controller/templates/post-install-hook.yaml
+++ b/charts/kubewarden-controller/templates/post-install-hook.yaml
@@ -3,7 +3,11 @@
 # pod, it cannot find a valid collector configuration. Therefore, it is necessary
 # to recreate the controller pod after the installation. This ensures that the
 # controller pod will have the OTEL collector container.
-{{ if or .Values.telemetry.metrics .Values.telemetry.tracing }}
+# This restart hook is required only for sidecar telemetry mode to mitigate
+# occasional OTel sidecar injection races during install/upgrade.
+# In custom telemetry mode there is no sidecar injection, and forcing a restart
+# can deadlock single-node hostNetwork rollouts due to hostPort conflicts.
+{{ if and (or .Values.telemetry.metrics .Values.telemetry.tracing) (eq .Values.telemetry.mode "sidecar") }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/kubewarden-controller/tests/post_install_hook_test.yaml
+++ b/charts/kubewarden-controller/tests/post_install_hook_test.yaml
@@ -1,0 +1,44 @@
+suite: post-install hook rendering
+templates:
+  - post-install-hook.yaml
+tests:
+  - it: "should render post-install hook for sidecar telemetry"
+    set:
+      telemetry:
+        mode: sidecar
+        metrics: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-install,post-upgrade
+      - equal:
+          path: spec.template.spec.containers[0].command[0]
+          value: kubectl
+      - equal:
+          path: spec.template.spec.containers[0].command[4]
+          value: restart
+
+  - it: "should not render post-install hook for custom telemetry"
+    set:
+      telemetry:
+        mode: custom
+        metrics: true
+        tracing: true
+        custom:
+          endpoint: "http://my-collector-collector.kubewarden.svc:4317"
+          insecure: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: "should not render post-install hook when telemetry is disabled"
+    set:
+      telemetry:
+        mode: sidecar
+        metrics: false
+        tracing: false
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
## Description

Limit the post-install/post-upgrade restart hook to sidecar mode. This prevents a second rollout in custom telemetry mode that can cause hostPort deadlocks on single-node hostNetwork upgrades.

Found while I was testing https://github.com/kubewarden/kubewarden-end-to-end-tests/pull/285

