### PR TITLE
feat(helm): generate kubewarden-defaults values schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,8 +171,9 @@ manifests: ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefin
 	sed -i 's/  namespace: kubewarden/  namespace: {{ .Release.Namespace }}/' charts/kubewarden-controller/templates/controller-rbac-roles.yaml
 
 .PHONY: generate-chart
-generate-chart: ## Generate Helm chart values schema.
+generate-chart: ## Generate Helm chart values schemas.
 	$(HELM_SCHEMA) --values charts/kubewarden-controller/values.yaml --output charts/kubewarden-controller/values.schema.json
+	cd charts/kubewarden-defaults && $(HELM_SCHEMA) --bundle --bundle-without-id --values values.yaml --output values.schema.json
 
 .PHONY: check-generate
 check-generate: generate

--- a/charts/kubewarden-defaults/.helmignore
+++ b/charts/kubewarden-defaults/.helmignore
@@ -24,3 +24,6 @@
 
 # dev files
 chart-values.yaml
+
+# schema fragments bundled into values.schema.json at generation time
+schemas/

--- a/charts/kubewarden-defaults/schemas/namespacedPoliciesCapabilitiesItem.schema.json
+++ b/charts/kubewarden-defaults/schemas/namespacedPoliciesCapabilitiesItem.schema.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string",
+    "minLength": 1,
+    "anyOf": [
+        {
+            "description": "Global wildcard",
+            "const": "*"
+        },
+        {
+            "description": "Category wildcard: <category>/*",
+            "pattern": "^[a-z0-9_-]+/\\*$"
+        },
+        {
+            "description": "Sub-category wildcard: <category>/<path...>/*",
+            "pattern": "^[a-z0-9_-]+(/[a-z0-9_-]+)+/\\*$"
+        },
+        {
+            "description": "Fully-qualified capability path: <category>/<path...>",
+            "pattern": "^[a-z0-9_-]+(/[a-z0-9_-]+)+$"
+        }
+    ]
+}

--- a/charts/kubewarden-defaults/tests/policyserver_schema_test.yaml
+++ b/charts/kubewarden-defaults/tests/policyserver_schema_test.yaml
@@ -1,0 +1,82 @@
+suite: policyServer values schema validation
+templates:
+  - policyserver-default.yaml
+tests:
+  # --- minAvailable / maxUnavailable disjunction ---
+  - it: "should accept default (both minAvailable and maxUnavailable unset)"
+    asserts:
+      - notExists:
+          path: spec.minAvailable
+      - notExists:
+          path: spec.maxUnavailable
+
+  - it: "should accept minAvailable on its own"
+    set:
+      policyServer.minAvailable: "30%"
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: "30%"
+      - notExists:
+          path: spec.maxUnavailable
+
+  - it: "should accept maxUnavailable on its own"
+    set:
+      policyServer.maxUnavailable: "50%"
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: "50%"
+      - notExists:
+          path: spec.minAvailable
+
+  - it: "should reject minAvailable and maxUnavailable set together"
+    set:
+      policyServer.minAvailable: "30%"
+      policyServer.maxUnavailable: "50%"
+    asserts:
+      - failedTemplate:
+          errorPattern: "anyOf"
+
+  - it: "should reject an empty minAvailable string"
+    set:
+      policyServer.minAvailable: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "minAvailable"
+
+  - it: "should reject an empty maxUnavailable string"
+    set:
+      policyServer.maxUnavailable: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "maxUnavailable"
+
+  # --- Port range validation ---
+  - it: "should reject webhookPort below 1"
+    set:
+      policyServer.webhookPort: 0
+    asserts:
+      - failedTemplate:
+          errorPattern: "webhookPort"
+
+  - it: "should reject webhookPort above 65535"
+    set:
+      policyServer.webhookPort: 70000
+    asserts:
+      - failedTemplate:
+          errorPattern: "webhookPort"
+
+  - it: "should reject readinessProbePort out of range"
+    set:
+      policyServer.readinessProbePort: 0
+    asserts:
+      - failedTemplate:
+          errorPattern: "readinessProbePort"
+
+  - it: "should reject metricsPort out of range"
+    set:
+      policyServer.metricsPort: 65536
+    asserts:
+      - failedTemplate:
+          errorPattern: "metricsPort"

--- a/charts/kubewarden-defaults/values.schema.json
+++ b/charts/kubewarden-defaults/values.schema.json
@@ -1,93 +1,462 @@
 {
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "type": "object",
-  "properties": {
-    "policyServer": {
-      "type": "object",
-      "properties": {
-        "maxUnavailable": {
-          "type": "string",
-          "minLength": 1
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "additionalAnnotations": {
+            "type": "object"
         },
-        "minAvailable": {
-          "type": "string",
-          "minLength": 1
+        "additionalLabels": {
+            "type": "object"
         },
-        "webhookPort": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 65535,
-          "description": "Port for the PolicyServer webhook listener. When omitted, the controller uses the default (8443)."
+        "crdVersion": {
+            "type": "string"
         },
-        "readinessProbePort": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 65535,
-          "description": "Port for the PolicyServer readiness probe. When omitted, the controller uses the default (8081)."
-        },
-        "metricsPort": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 65535,
-          "description": "Port for the PolicyServer metrics endpoint. When omitted, the controller uses the default (8080)."
-        },
-        "affinity": {
-          "type": "object",
-          "description": "Affinity rules for the default PolicyServer. Takes precedence over global.affinity."
-        },
-        "namespacedPoliciesCapabilities": {
-          "description": "Host capability paths allowed for namespaced policies on this PolicyServer. Catch obvious errors",
-          "type": ["array", "null"],
-          "items": {
-            "type": "string",
-            "minLength": 1,
-            "anyOf": [
-              {
-                "description": "Global wildcard",
-                "const": "*"
-              },
-              {
-                "description": "Category wildcard: <category>/*",
-                "pattern": "^[a-z0-9_-]+/\\*$"
-              },
-              {
-                "description": "Sub-category wildcard: <category>/<path...>/*",
-                "pattern": "^[a-z0-9_-]+(/[a-z0-9_-]+)+/\\*$"
-              },
-              {
-                "description": "Fully-qualified capability path: <category>/<path...>",
-                "pattern": "^[a-z0-9_-]+(/[a-z0-9_-]+)+$"
-              }
-            ]
-          }
-        }
-      },
-      "anyOf": [
-        {
-          "oneOf": [
-            {
-              "required": ["minAvailable"]
-            },
-            {
-              "required": ["maxUnavailable"]
+        "global": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "cattle": {
+                    "type": "object",
+                    "properties": {
+                        "systemDefaultRegistry": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "skipNamespaces": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "tolerations": {
+                    "type": "array"
+                }
             }
-          ]
         },
-        {
-          "not": {
-            "allOf": [
-              {
-                "required": ["minAvailable"]
-              },
-              {
-                "required": ["maxUnavailable"]
-              }
-            ]
-          }
+        "policyServer": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "minAvailable": {
+                            "type": "null"
+                        }
+                    }
+                },
+                {
+                    "properties": {
+                        "maxUnavailable": {
+                            "type": "null"
+                        }
+                    }
+                }
+            ],
+            "properties": {
+                "affinity": {
+                    "description": "Affinity rules for the default PolicyServer. Takes precedence over global.affinity.",
+                    "type": "object"
+                },
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "env": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "imagePullSecret": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "insecureSources": {
+                    "type": [
+                        "array",
+                        "null"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "limits": {
+                    "type": "object"
+                },
+                "maxUnavailable": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "minLength": 1
+                },
+                "metricsPort": {
+                    "description": "Port for the PolicyServer metrics endpoint. When omitted, the controller uses the default (8080).",
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "maximum": 65535,
+                    "minimum": 1
+                },
+                "minAvailable": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "minLength": 1
+                },
+                "namespacedPoliciesCapabilities": {
+                    "description": "Host capability paths allowed for namespaced policies on this PolicyServer. Catch obvious errors.",
+                    "type": [
+                        "array",
+                        "null"
+                    ],
+                    "items": {
+                        "$ref": "#/$defs/namespacedPoliciesCapabilitiesItem.schema.json",
+                        "type": "string"
+                    }
+                },
+                "permissions": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "apiGroup": {
+                                "type": "string"
+                            },
+                            "resources": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "verbs": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "readinessProbePort": {
+                    "description": "Port for the PolicyServer readiness probe. When omitted, the controller uses the default (8081).",
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "maximum": 65535,
+                    "minimum": 1
+                },
+                "replicaCount": {
+                    "type": "integer"
+                },
+                "requests": {
+                    "type": "object"
+                },
+                "securityContexts": {
+                    "type": "object"
+                },
+                "serviceAccountName": {
+                    "type": "string"
+                },
+                "sourceAuthorities": {
+                    "type": "object"
+                },
+                "webhookPort": {
+                    "description": "Port for the PolicyServer webhook listener. When omitted, the controller uses the default (8443).",
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "maximum": 65535,
+                    "minimum": 1
+                }
+            }
+        },
+        "recommendedPolicies": {
+            "type": "object",
+            "properties": {
+                "allowPrivilegeEscalationPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "module": {
+                            "type": "object",
+                            "properties": {
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "settings": {
+                            "type": "object",
+                            "properties": {
+                                "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                },
+                "capabilitiesPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "module": {
+                            "type": "object",
+                            "properties": {
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "settings": {
+                            "type": "object",
+                            "properties": {
+                                "allowed_capabilities": {
+                                    "type": "array"
+                                },
+                                "default_add_capabilities": {
+                                    "type": "array"
+                                },
+                                "required_drop_capabilities": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "defaultPoliciesRegistry": {
+                    "type": "string"
+                },
+                "defaultPolicyMode": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "hostNamespacePolicy": {
+                    "type": "object",
+                    "properties": {
+                        "module": {
+                            "type": "object",
+                            "properties": {
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "settings": {
+                            "type": "object",
+                            "properties": {
+                                "allow_host_ipc": {
+                                    "type": "boolean"
+                                },
+                                "allow_host_network": {
+                                    "type": "boolean"
+                                },
+                                "allow_host_pid": {
+                                    "type": "boolean"
+                                },
+                                "allow_host_ports": {
+                                    "type": "array"
+                                }
+                            }
+                        }
+                    }
+                },
+                "hostPathsPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "module": {
+                            "type": "object",
+                            "properties": {
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "settings": {
+                            "type": "object",
+                            "properties": {
+                                "allowedHostPaths": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "pathPrefix": {
+                                                "type": "string"
+                                            },
+                                            "readOnly": {
+                                                "type": "boolean"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "podPrivilegedPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "module": {
+                            "type": "object",
+                            "properties": {
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "settings": {
+                            "type": "object",
+                            "properties": {
+                                "skip_ephemeral_containers": {
+                                    "type": "boolean"
+                                },
+                                "skip_init_containers": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                },
+                "skipAdditionalNamespaces": {
+                    "type": "array"
+                },
+                "userGroupPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "module": {
+                            "type": "object",
+                            "properties": {
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "settings": {
+                            "type": "object",
+                            "properties": {
+                                "run_as_group": {
+                                    "type": "object",
+                                    "properties": {
+                                        "rule": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "run_as_user": {
+                                    "type": "object",
+                                    "properties": {
+                                        "rule": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "supplemental_groups": {
+                                    "type": "object",
+                                    "properties": {
+                                        "rule": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "validate_container_image_configuration": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
-      ],
-      "additionalProperties": true
+    },
+    "$defs": {
+        "namespacedPoliciesCapabilitiesItem.schema.json": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "anyOf": [
+                {
+                    "description": "Global wildcard",
+                    "const": "*"
+                },
+                {
+                    "description": "Category wildcard: \u003ccategory\u003e/*",
+                    "pattern": "^[a-z0-9_-]+/\\*$"
+                },
+                {
+                    "description": "Sub-category wildcard: \u003ccategory\u003e/\u003cpath...\u003e/*",
+                    "pattern": "^[a-z0-9_-]+(/[a-z0-9_-]+)+/\\*$"
+                },
+                {
+                    "description": "Fully-qualified capability path: \u003ccategory\u003e/\u003cpath...\u003e",
+                    "pattern": "^[a-z0-9_-]+(/[a-z0-9_-]+)+$"
+                }
+            ],
+            "minLength": 1
+        }
     }
-  },
-  "additionalProperties": true
 }

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -110,12 +110,15 @@ additionalLabels: {}
 additionalAnnotations: {}
 # owner: IT-group1
 # Policy Server settings
+# @schema anyOf: [{properties: {minAvailable: {type: "null"}}}, {properties: {maxUnavailable: {type: "null"}}}]
 policyServer:
   enabled: true
   replicaCount: 1
   # Only one of minAvailable,maxUnavailable can be enabled:
   # minAvailable: 30%
   # maxUnavailable: 1
+  minAvailable: null # @schema type:[string,null]; minLength:1
+  maxUnavailable: null # @schema type:[string,null]; minLength:1
   image:
     # The registry is defined in the global.cattle.systemDefaultRegistry value
     repository: "kubewarden/adm-controller/policy-server"
@@ -159,14 +162,14 @@ policyServer:
   #
   # Example of usage:
   # imagePullSecret: "mysecret"
-  imagePullSecret: null
+  imagePullSecret: null # @schema type:[string,null]
   # insecureSources stores a list of allowed insecure registries.
   #
   # Example of usage:
   #insecureSources:
   #  - "source1"
   #  - "source2"
-  insecureSources: null
+  insecureSources: null # @schema type:[array,null]; item: string
   # sourceAuthorities is a list of the URIs and their PEM encoded certificates
   # used to authenticate them
   #
@@ -191,6 +194,7 @@ policyServer:
   # namespacedPoliciesCapabilities:
   #   - "oci/*"
   #   - "net/v1/dns_lookup_host"
+  # @schema type:[array,null]; description: Host capability paths allowed for namespaced policies on this PolicyServer. Catch obvious errors.; itemRef: schemas/namespacedPoliciesCapabilitiesItem.schema.json
   namespacedPoliciesCapabilities:
     - "*" # all host capabilities are granted
   # limits and requests, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -205,11 +209,10 @@ policyServer:
   # - webhookPort: 8443
   # - readinessProbePort: 8081
   # - metricsPort: default value defined in the controller (8080)
-  #
-  # webhookPort: 9443
-  # readinessProbePort: 9081
-  # metricsPort: 9080
-  
+  webhookPort: null # @schema type:[integer,null]; minimum:1; maximum:65535; description: Port for the PolicyServer webhook listener. When omitted, the controller uses the default (8443).
+  readinessProbePort: null # @schema type:[integer,null]; minimum:1; maximum:65535; description: Port for the PolicyServer readiness probe. When omitted, the controller uses the default (8081).
+  metricsPort: null # @schema type:[integer,null]; minimum:1; maximum:65535; description: Port for the PolicyServer metrics endpoint. When omitted, the controller uses the default (8080).
+
   # affinity configures affinity rules for the default PolicyServer.
   # This takes precedence over global.affinity when set.
   # When hostNetwork is enabled, users should set appropriate podAntiAffinity
@@ -221,7 +224,7 @@ policyServer:
   #         matchLabels:
   #           kubewarden/policy-server: default
   #       topologyKey: kubernetes.io/hostname
-  affinity: {}
+  affinity: {} # @schema description: Affinity rules for the default PolicyServer. Takes precedence over global.affinity.
 crdVersion: "policies.kubewarden.io/v1"
 recommendedPolicies:
   enabled: False


### PR DESCRIPTION
## Summary

Closes #1240.

Generates `charts/kubewarden-defaults/values.schema.json` from annotations on
`charts/kubewarden-defaults/values.yaml`, using the
[`helm-values-schema-json`](https://github.com/losisin/helm-values-schema-json) tool already wired
into `make generate-chart` for the `kubewarden-controller` chart. The previously hand-maintained
schema is dropped, but every validation it performed is preserved in the regenerated output.

## What changes

- **`charts/kubewarden-defaults/values.yaml`**: adds `@schema` annotations on the optional
  PolicyServer fields so the generator emits the same constraints the manual schema had.
- **`charts/kubewarden-defaults/schemas/namespacedPoliciesCapabilitiesItem.schema.json`**: holds
  the item schema for `namespacedPoliciesCapabilities` (global wildcard, category wildcard,
  sub-category wildcard, fully-qualified path). The generator bundles this into the final
  `values.schema.json` with `--bundle --bundle-without-id`, and the new
  `.helmignore` entry keeps the `schemas/` folder out of the packaged chart.
- **`Makefile`**: extends `generate-chart` to also produce the `kubewarden-defaults` schema.
- **`charts/kubewarden-defaults/values.schema.json`**: regenerated output.
- **`charts/kubewarden-defaults/tests/policyserver_schema_test.yaml`**: new helm-unittest suite that
  locks in the constraints the manual schema enforced (port range, `minAvailable` / `maxUnavailable`
  disjunction, `minLength` on each PDB string field).

## Validations preserved

| Field | Constraint | Where it lives now |
|-------|------------|--------------------|
| `policyServer.minAvailable` | `type: string` or `null`, `minLength: 1` | inline `@schema` annotation |
| `policyServer.maxUnavailable` | `type: string` or `null`, `minLength: 1` | inline `@schema` annotation |
| `policyServer` (parent) | mutually exclusive `minAvailable` / `maxUnavailable` | `anyOf` annotation on `policyServer` (each clause asserts one of the two fields is `null`) |
| `policyServer.webhookPort` | `1 <= int <= 65535`, with description | inline `@schema` annotation |
| `policyServer.readinessProbePort` | `1 <= int <= 65535`, with description | inline `@schema` annotation |
| `policyServer.metricsPort` | `1 <= int <= 65535`, with description | inline `@schema` annotation |
| `policyServer.affinity` | object, with description | inline `@schema` annotation |
| `policyServer.namespacedPoliciesCapabilities` | `array` or `null` whose items match one of the four documented capability path forms | `itemRef` to `schemas/namespacedPoliciesCapabilitiesItem.schema.json`, bundled into `values.schema.json` via `--bundle --bundle-without-id` |
| `policyServer.imagePullSecret` | `string` or `null` (was effectively `string` only, but the default is `null`) | inline `@schema` annotation |
| `policyServer.insecureSources` | `array` of `string` or `null` (was reported as `string` because of the `null` default) | inline `@schema` annotation |

## Test plan

- [x] `make generate-chart` regenerates both `kubewarden-controller` and `kubewarden-defaults` schemas
- [x] `make generate-chart` is idempotent (running twice produces no diff)
- [x] `make helm-unittest` passes (62 + 35 tests across the three charts, with the new
  `policyserver_schema_test.yaml` suite covering the previously implicit validations)
- [x] `helm lint charts/kubewarden-defaults/` passes
- [x] `helm package charts/kubewarden-defaults/` produces a chart tarball that contains
  `values.schema.json` but excludes the `schemas/` source folder via `.helmignore`
- [x] Existing `namespacedPoliciesCapabilities_test.yaml` (which exercises pattern matching on
  the items) continues to pass against the generated schema

Manual sanity checks against the rendered template:

```
$ helm template foo charts/kubewarden-defaults/ \
    --set policyServer.minAvailable=30% --set policyServer.maxUnavailable=50%
Error: values don't meet the specifications of the schema(s) in the following chart(s):
kubewarden-defaults:
- at '/policyServer': 'anyOf' failed

$ helm template foo charts/kubewarden-defaults/ --set policyServer.webhookPort=70000
Error: values don't meet the specifications of the schema(s) in the following chart(s):
kubewarden-defaults:
- at '/policyServer/webhookPort': maximum: got 70,000, want 65,535
```