### PR TITLE
feat(policy-server): break out dashboard rejection panels by policy_mode

### DIFF
--- a/crates/policy-server/kubewarden-dashboard.json
+++ b/crates/policy-server/kubewarden-dashboard.json
@@ -176,7 +176,8 @@
         }
       ],
       "title": "Accepted requests rate",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "Rate of admission requests accepted by policy evaluations. Includes evaluations from both monitor- and protect-mode policies."
     },
     {
       "datasource": {
@@ -260,16 +261,17 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (accepted) (\n  rate(kubewarden_policy_evaluations_total{accepted=\"false\",request_origin=\"validate\"}[$__rate_interval])\n)",
+          "expr": "sum by (policy_mode) (\n  rate(kubewarden_policy_evaluations_total{accepted=\"false\",request_origin=\"validate\"}[$__rate_interval])\n)",
           "format": "time_series",
           "interval": "",
-          "legendFormat": "Reject requests",
+          "legendFormat": "{{policy_mode}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Rejected requests rate",
-      "type": "timeseries"
+      "title": "Rejected admission requests rate (by policy mode)",
+      "type": "timeseries",
+      "description": "Rate of policy evaluations that rejected the admission request, broken down by the policy's mode at the time of evaluation. policy_mode=protect: the request was actually blocked. policy_mode=monitor: the request was allowed through but would have been blocked if the policy was in protect mode."
     },
     {
       "datasource": {
@@ -361,7 +363,8 @@
         }
       ],
       "title": "Mutated requests rate",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "Rate of admission requests mutated by policy evaluations. policy_mode=monitor mutations are reported but the cluster does not apply them; only policy_mode=protect mutations are applied to the resource."
     },
     {
       "datasource": {
@@ -1079,15 +1082,16 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(kubewarden_policy_evaluations_total{accepted=\"false\",request_origin=\"validate\"})*100/sum(kubewarden_policy_evaluations_total{})",
+          "expr": "sum by (policy_mode) (kubewarden_policy_evaluations_total{accepted=\"false\",request_origin=\"validate\"})*100/sum(kubewarden_policy_evaluations_total{})",
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "{{policy_mode}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Request rejection percentage ",
-      "type": "stat"
+      "title": "Request rejection percentage (by policy mode)",
+      "type": "stat",
+      "description": "Share of all policy evaluations that rejected the admission request, broken down by the policy's mode. policy_mode=protect is the share that was actually blocked; policy_mode=monitor is the share that would have been blocked in protect mode."
     },
     {
       "datasource": {
@@ -1350,15 +1354,16 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(kubewarden_policy_evaluations_total{accepted=\"false\",request_origin=\"validate\"})",
+          "expr": "sum by (policy_mode) (kubewarden_policy_evaluations_total{accepted=\"false\",request_origin=\"validate\"})",
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "{{policy_mode}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Total rejected requests",
-      "type": "stat"
+      "title": "Rejected admission requests (by policy mode)",
+      "type": "stat",
+      "description": "Total policy evaluations that rejected the admission request, broken down by the policy's mode. policy_mode=protect requests were blocked; policy_mode=monitor requests were observed only (would have been blocked in protect mode)."
     },
     {
       "datasource": {
@@ -1548,15 +1553,16 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(kubewarden_policy_evaluations_total{accepted=\"false\",request_origin=\"validate\",resource_request_operation=\"CREATE\",resource_kind=\"Pod\"})",
+          "expr": "sum by (policy_mode) (kubewarden_policy_evaluations_total{accepted=\"false\",request_origin=\"validate\",resource_request_operation=\"CREATE\",resource_kind=\"Pod\"})",
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "{{policy_mode}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Pod creation rejections",
-      "type": "stat"
+      "title": "Pod creation rejections (by policy mode)",
+      "type": "stat",
+      "description": "Pod creation admission requests rejected by policy evaluations, broken down by the policy's mode at the time of evaluation."
     },
     {
       "datasource": {
@@ -2474,15 +2480,16 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(kubewarden_policy_evaluations_total{accepted=\"false\",request_origin=\"validate\", policy_name=\"$policy_name\" })*100/sum(kubewarden_policy_evaluations_total{policy_name=\"$policy_name\"})",
+          "expr": "sum by (policy_mode) (kubewarden_policy_evaluations_total{accepted=\"false\",request_origin=\"validate\", policy_name=\"$policy_name\" })*100/sum(kubewarden_policy_evaluations_total{policy_name=\"$policy_name\"})",
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "{{policy_mode}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "$policy_name policy request rejection percentage ",
-      "type": "stat"
+      "title": "$policy_name policy request rejection percentage (by policy mode)",
+      "type": "stat",
+      "description": "Share of $policy_name policy evaluations that rejected the admission request, broken down by the policy's mode. policy_mode=protect is the share that was actually blocked; policy_mode=monitor is the share that would have been blocked in protect mode."
     },
     {
       "datasource": {
@@ -2624,7 +2631,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "",
+      "description": "Total $policy_name policy evaluations that rejected the admission request, broken down by the policy's mode.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2676,14 +2683,14 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(kubewarden_policy_evaluations_total{accepted=\"false\",request_origin=\"validate\",policy_name=\"$policy_name\"})",
+          "expr": "sum by (policy_mode) (kubewarden_policy_evaluations_total{accepted=\"false\",request_origin=\"validate\",policy_name=\"$policy_name\"})",
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "{{policy_mode}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Total rejected requests by  $policy_name policy",
+      "title": "Rejected requests by $policy_name policy (by policy mode)",
       "type": "stat"
     },
     {
@@ -2838,15 +2845,16 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum  (\n  rate(kubewarden_policy_evaluations_total{policy_name=\"$policy_name\",request_origin=\"validate\"}[$__rate_interval])\n)",
+          "expr": "sum by (policy_mode) (\n  rate(kubewarden_policy_evaluations_total{policy_name=\"$policy_name\",request_origin=\"validate\"}[$__rate_interval])\n)",
           "interval": "",
-          "legendFormat": "Policy request rate",
+          "legendFormat": "{{policy_mode}}",
           "range": true,
           "refId": "A"
         }
       ],
       "title": "Rate of validate requests to $policy_name policy",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "Rate of admission requests evaluated by $policy_name, broken down by the policy's mode at the time of each evaluation."
     },
     {
       "collapsed": false,

--- a/crates/policy-server/kubewarden-dashboard.json
+++ b/crates/policy-server/kubewarden-dashboard.json
@@ -1082,7 +1082,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (policy_mode) (kubewarden_policy_evaluations_total{accepted=\"false\",request_origin=\"validate\"})*100/sum(kubewarden_policy_evaluations_total{})",
+          "expr": "sum by (policy_mode) (kubewarden_policy_evaluations_total{accepted=\"false\",request_origin=\"validate\"})*100/sum by (policy_mode) (kubewarden_policy_evaluations_total{request_origin=\"validate\"})",
           "interval": "",
           "legendFormat": "{{policy_mode}}",
           "range": true,
@@ -1091,7 +1091,7 @@
       ],
       "title": "Request rejection percentage (by policy mode)",
       "type": "stat",
-      "description": "Share of all policy evaluations that rejected the admission request, broken down by the policy's mode. policy_mode=protect is the share that was actually blocked; policy_mode=monitor is the share that would have been blocked in protect mode."
+      "description": "Share of validate admission evaluations that rejected the admission request, broken down by the policy's mode. policy_mode=protect is the share that was actually blocked; policy_mode=monitor is the share that would have been blocked in protect mode."
     },
     {
       "datasource": {
@@ -2480,7 +2480,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (policy_mode) (kubewarden_policy_evaluations_total{accepted=\"false\",request_origin=\"validate\", policy_name=\"$policy_name\" })*100/sum(kubewarden_policy_evaluations_total{policy_name=\"$policy_name\"})",
+          "expr": "sum by (policy_mode) (kubewarden_policy_evaluations_total{accepted=\"false\",request_origin=\"validate\",policy_name=\"$policy_name\"})*100/sum by (policy_mode) (kubewarden_policy_evaluations_total{request_origin=\"validate\",policy_name=\"$policy_name\"})",
           "interval": "",
           "legendFormat": "{{policy_mode}}",
           "range": true,
@@ -2489,7 +2489,7 @@
       ],
       "title": "$policy_name policy request rejection percentage (by policy mode)",
       "type": "stat",
-      "description": "Share of $policy_name policy evaluations that rejected the admission request, broken down by the policy's mode. policy_mode=protect is the share that was actually blocked; policy_mode=monitor is the share that would have been blocked in protect mode."
+      "description": "Share of $policy_name validate admission evaluations that rejected the admission request, broken down by the policy's mode. policy_mode=protect is the share that was actually blocked; policy_mode=monitor is the share that would have been blocked in protect mode."
     },
     {
       "datasource": {
@@ -2631,7 +2631,6 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Total $policy_name policy evaluations that rejected the admission request, broken down by the policy's mode.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2691,7 +2690,8 @@
         }
       ],
       "title": "Rejected requests by $policy_name policy (by policy mode)",
-      "type": "stat"
+      "type": "stat",
+      "description": "Total $policy_name policy evaluations that rejected the admission request, broken down by the policy's mode."
     },
     {
       "datasource": {


### PR DESCRIPTION
## Summary

Closes #1284.

The Kubewarden Grafana dashboard currently aggregates every `accepted=false` evaluation
into a single number, so it cannot distinguish:

- **`policy_mode=protect` + `accepted=false`**: the admission request was actually blocked
  by the cluster.
- **`policy_mode=monitor` + `accepted=false`**: the admission request was allowed through
  by the cluster, but would have been blocked if the policy was in protect mode.

The `policy_mode` label is already attached to `kubewarden_policy_evaluations_total` in
[`crates/policy-server/src/metrics.rs`](https://github.com/kubewarden/adm-controller/blob/main/crates/policy-server/src/metrics.rs#L53),
so the only thing missing was surfacing that dimension in the dashboard.

## What changes

The validate-origin rejection panels in `crates/policy-server/kubewarden-dashboard.json` now
group by `policy_mode` and carry explanatory descriptions:

| Panel id | Title (after) | What changed |
|---------:|----------------|--------------|
| `66` | `Rejected admission requests rate (by policy mode)` | query now `sum by (policy_mode) (rate(...))`, legend `{{policy_mode}}`, new description |
| `40` | `Rejected admission requests (by policy mode)` | query now `sum by (policy_mode) (...)`, new description |
| `48` | `Request rejection percentage (by policy mode)` | numerator now grouped by `policy_mode`, new description |
| `8` | `Pod creation rejections (by policy mode)` | query now `sum by (policy_mode) (...)`, new description |
| `32` | `Rejected requests by $policy_name policy (by policy mode)` | per-policy total grouped by `policy_mode` |
| `56` | `$policy_name policy request rejection percentage (by policy mode)` | per-policy percentage grouped by `policy_mode` |
| `34` | `Rate of validate requests to $policy_name policy` | grouped by `policy_mode` so this rate panel stays aligned with the rejection panels above |
| `67` | `Accepted requests rate` | no query change, new description noting that monitor- and protect-mode evaluations are both counted |
| `68` | `Mutated requests rate` | no query change, new description noting that monitor-mode mutations are reported but not applied by the cluster |

The audit-origin panels (`#96`, `#85`, `#89`, `#92`, `#75`, `#78`, `#70`) are intentionally
left untouched. Audit scans are background reports against existing resources and do not
block anything regardless of policy mode, so adding a `policy_mode` breakdown would add
noise without changing the operational meaning.

No template variables, panel ids, or `gridPos` values are touched, so the dashboard
re-imports cleanly without re-laying-out anything.

## Test plan

- [x] `jq -e . crates/policy-server/kubewarden-dashboard.json` parses successfully
- [x] `schemaVersion` and `version` fields are unchanged
- [x] Panel count is unchanged (49 panels), no `gridPos` values touched
- [x] Only the panel ids listed above are modified; all other panel JSON is byte-identical
- [x] Manual import into a Grafana instance shows the two `policy_mode` series on the
      time-series rejection panel, the two values side-by-side on the stat panels, and the
      description tooltip on each updated panel