### PR TITLE
fix(kwctl): reject AdmissionPolicy scaffold for cluster-scoped targets

### DIFF
--- a/crates/kwctl/src/scaffold.rs
+++ b/crates/kwctl/src/scaffold.rs
@@ -1,4 +1,5 @@
 mod kubewarden_crds;
+mod resource_scope;
 
 mod manifest;
 pub(crate) use manifest::manifest;

--- a/crates/kwctl/src/scaffold/manifest.rs
+++ b/crates/kwctl/src/scaffold/manifest.rs
@@ -292,7 +292,53 @@ fn check_admission_policy_target_scope(findings: &AdmissionPolicyScopeFindings) 
 mod tests {
     use super::*;
 
+    use std::sync::{Arc, Mutex};
+
     use policy_evaluator::policy_metadata::ContextAwareResource;
+    use tracing::{Event, Level, Subscriber, field};
+    use tracing_subscriber::{Layer, layer::Context, layer::SubscriberExt, registry::LookupSpan};
+
+    #[derive(Clone, Default)]
+    struct CapturedWarnings {
+        messages: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl<S> Layer<S> for CapturedWarnings
+    where
+        S: Subscriber + for<'a> LookupSpan<'a>,
+    {
+        fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+            if *event.metadata().level() != Level::WARN {
+                return;
+            }
+
+            let mut visitor = WarningMessageVisitor::default();
+            event.record(&mut visitor);
+            self.messages
+                .lock()
+                .expect("captured warning mutex should not be poisoned")
+                .push(visitor.message);
+        }
+    }
+
+    #[derive(Default)]
+    struct WarningMessageVisitor {
+        message: String,
+    }
+
+    impl field::Visit for WarningMessageVisitor {
+        fn record_debug(&mut self, field: &field::Field, value: &dyn std::fmt::Debug) {
+            if field.name() == "message" {
+                self.message = format!("{value:?}");
+            }
+        }
+
+        fn record_str(&mut self, field: &field::Field, value: &str) {
+            if field.name() == "message" {
+                self.message = value.to_string();
+            }
+        }
+    }
 
     fn mock_metadata_with_no_annotations() -> Metadata {
         Metadata {
@@ -632,12 +678,22 @@ mod tests {
 
     #[test]
     fn scaffold_admission_policy_targeting_custom_resource_succeeds_with_warning() {
-        // Cannot statically check the test logger output here, but the function
-        // must return Ok and the warning is exercised by the integration tests.
         let scaffold_data =
             admission_policy_scaffold_data_with_rules(vec![rule(&["example.com"], &["widgets"])]);
-        let result = generate_yaml_resource(scaffold_data, ManifestType::AdmissionPolicy, false);
+        let captured_warnings = CapturedWarnings::default();
+        let subscriber = tracing_subscriber::registry().with(captured_warnings.clone());
+        let result = tracing::subscriber::with_default(subscriber, || {
+            generate_yaml_resource(scaffold_data, ManifestType::AdmissionPolicy, false)
+        });
         assert!(result.is_ok());
+
+        let warnings = captured_warnings
+            .messages
+            .lock()
+            .expect("captured warning mutex should not be poisoned");
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("Cannot determine whether `example.com/widgets`"));
+        assert!(warnings[0].contains("ClusterAdmissionPolicy"));
     }
 
     #[test]

--- a/crates/kwctl/src/scaffold/manifest.rs
+++ b/crates/kwctl/src/scaffold/manifest.rs
@@ -20,6 +20,9 @@ use tracing::warn;
 use crate::scaffold::kubewarden_crds::{
     AdmissionPolicy, AdmissionPolicySpec, ClusterAdmissionPolicy, ClusterAdmissionPolicySpec,
 };
+use crate::scaffold::resource_scope::{
+    AdmissionPolicyScopeFindings, classify_admission_policy_rules,
+};
 
 pub(crate) enum ManifestType {
     ClusterAdmissionPolicy,
@@ -228,10 +231,61 @@ fn generate_yaml_resource(
                 .map_err(|e| anyhow!("{}", e))
         }
         ManifestType::AdmissionPolicy => {
+            check_admission_policy_target_scope(&classify_admission_policy_rules(
+                &scaffold_data.metadata.rules,
+            ))?;
+
             serde_yaml::to_value(AdmissionPolicy::try_from(scaffold_data)?)
                 .map_err(|e| anyhow!("{}", e))
         }
     }
+}
+
+/// Reject scaffolding an `AdmissionPolicy` whose rules target a known
+/// cluster-scoped Kubernetes resource (the cluster would never deliver matching
+/// requests to a namespaced policy), and warn for unknown resources where the
+/// scope cannot be determined statically (most commonly Custom Resource
+/// Definitions, or rules using wildcards).
+fn check_admission_policy_target_scope(findings: &AdmissionPolicyScopeFindings) -> Result<()> {
+    if findings.has_cluster_scoped() {
+        let formatted = findings
+            .cluster_scoped
+            .iter()
+            .map(|(group, resource)| {
+                if group.is_empty() {
+                    resource.clone()
+                } else {
+                    format!("{}/{}", group, resource)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        return Err(anyhow!(
+            "AdmissionPolicy cannot target cluster-wide resources, but the policy's rules target: {}. \
+             AdmissionPolicy is a namespaced resource: the cluster only invokes it for namespaced \
+             requests. Scaffold a ClusterAdmissionPolicy instead by passing `--type ClusterAdmissionPolicy`.",
+            formatted
+        ));
+    }
+
+    if findings.has_unknown() {
+        for (group, resource) in &findings.unknown {
+            let target = if group.is_empty() {
+                resource.clone()
+            } else {
+                format!("{}/{}", group, resource)
+            };
+            warn!(
+                "Cannot determine whether `{}` is namespaced or cluster-wide. If it is cluster-wide, \
+                 this AdmissionPolicy will never be invoked. Verify the resource scope with \
+                 `kubectl api-resources` and, if needed, scaffold a ClusterAdmissionPolicy instead.",
+                target
+            );
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -504,5 +558,95 @@ mod tests {
 
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Invalid title"));
+    }
+
+    fn admission_policy_scaffold_data_with_rules(
+        rules: Vec<policy_evaluator::policy_metadata::Rule>,
+    ) -> ScaffoldPolicyData {
+        let mut metadata = mock_metadata_with_title("test");
+        metadata.protocol_version = Some(policy_evaluator::ProtocolVersion::V1);
+        metadata.rules = rules;
+        ScaffoldPolicyData {
+            uri: "not_relevant".to_string(),
+            policy_title: get_policy_title_from_cli_or_metadata(Some("test"), &metadata),
+            metadata,
+            settings: Default::default(),
+        }
+    }
+
+    fn rule(api_groups: &[&str], resources: &[&str]) -> policy_evaluator::policy_metadata::Rule {
+        use policy_evaluator::policy_metadata::{Operation, Rule};
+        Rule {
+            api_groups: api_groups.iter().map(|s| s.to_string()).collect(),
+            api_versions: vec!["v1".to_string()],
+            resources: resources.iter().map(|s| s.to_string()).collect(),
+            operations: vec![Operation::Create],
+        }
+    }
+
+    #[test]
+    fn scaffold_admission_policy_targeting_namespaced_resource_succeeds() {
+        let scaffold_data = admission_policy_scaffold_data_with_rules(vec![rule(&[""], &["pods"])]);
+        let result = generate_yaml_resource(scaffold_data, ManifestType::AdmissionPolicy, false);
+        assert!(
+            result.is_ok(),
+            "scaffolding an AdmissionPolicy that targets a namespaced resource should succeed, got: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn scaffold_admission_policy_targeting_core_cluster_scoped_resource_errors_out() {
+        let scaffold_data =
+            admission_policy_scaffold_data_with_rules(vec![rule(&[""], &["namespaces"])]);
+        let result = generate_yaml_resource(scaffold_data, ManifestType::AdmissionPolicy, false);
+        let err = result.expect_err("scaffold should refuse cluster-scoped target");
+        let message = err.to_string();
+        assert!(
+            message.contains("cluster-wide resources"),
+            "error message should mention cluster-wide resources, got: {}",
+            message
+        );
+        assert!(
+            message.contains("namespaces"),
+            "error message should mention the offending resource, got: {}",
+            message
+        );
+        assert!(
+            message.contains("ClusterAdmissionPolicy"),
+            "error message should point the user at ClusterAdmissionPolicy, got: {}",
+            message
+        );
+    }
+
+    #[test]
+    fn scaffold_admission_policy_targeting_named_group_cluster_scoped_resource_errors_out() {
+        let scaffold_data = admission_policy_scaffold_data_with_rules(vec![rule(
+            &["storage.k8s.io"],
+            &["storageclasses"],
+        )]);
+        let result = generate_yaml_resource(scaffold_data, ManifestType::AdmissionPolicy, false);
+        let err = result.expect_err("scaffold should refuse cluster-scoped target");
+        assert!(err.to_string().contains("storage.k8s.io/storageclasses"));
+    }
+
+    #[test]
+    fn scaffold_admission_policy_targeting_custom_resource_succeeds_with_warning() {
+        // Cannot statically check the test logger output here, but the function
+        // must return Ok and the warning is exercised by the integration tests.
+        let scaffold_data =
+            admission_policy_scaffold_data_with_rules(vec![rule(&["example.com"], &["widgets"])]);
+        let result = generate_yaml_resource(scaffold_data, ManifestType::AdmissionPolicy, false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn scaffold_cluster_admission_policy_targeting_cluster_scoped_resource_is_unaffected() {
+        let scaffold_data =
+            admission_policy_scaffold_data_with_rules(vec![rule(&[""], &["namespaces"])]);
+        // ClusterAdmissionPolicy is allowed to target cluster-scoped resources.
+        let result =
+            generate_yaml_resource(scaffold_data, ManifestType::ClusterAdmissionPolicy, false);
+        assert!(result.is_ok());
     }
 }

--- a/crates/kwctl/src/scaffold/resource_scope.rs
+++ b/crates/kwctl/src/scaffold/resource_scope.rs
@@ -1,0 +1,370 @@
+//! Static scope information for built-in Kubernetes resources, used by the
+//! AdmissionPolicy scaffold to refuse generating manifests that target
+//! cluster-scoped resources (an `AdmissionPolicy` is namespaced, and a
+//! cluster-scoped target would never be evaluated against it).
+
+use policy_evaluator::policy_metadata::Rule;
+
+/// Resource API group and plural pair, used as a key into the built-in
+/// resource scope table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct ResourceKey {
+    api_group: &'static str,
+    resource: &'static str,
+}
+
+/// List of well-known cluster-scoped Kubernetes resources from the standard
+/// API groups shipped with kube-apiserver (v1.33). Subresources (`pods/log`,
+/// `nodes/proxy`, ...) inherit the scope of their parent resource and are not
+/// listed here.
+const CLUSTER_SCOPED_RESOURCES: &[ResourceKey] = &[
+    // core / ""
+    ResourceKey {
+        api_group: "",
+        resource: "componentstatuses",
+    },
+    ResourceKey {
+        api_group: "",
+        resource: "namespaces",
+    },
+    ResourceKey {
+        api_group: "",
+        resource: "nodes",
+    },
+    ResourceKey {
+        api_group: "",
+        resource: "persistentvolumes",
+    },
+    // admissionregistration.k8s.io
+    ResourceKey {
+        api_group: "admissionregistration.k8s.io",
+        resource: "mutatingwebhookconfigurations",
+    },
+    ResourceKey {
+        api_group: "admissionregistration.k8s.io",
+        resource: "validatingwebhookconfigurations",
+    },
+    ResourceKey {
+        api_group: "admissionregistration.k8s.io",
+        resource: "validatingadmissionpolicies",
+    },
+    ResourceKey {
+        api_group: "admissionregistration.k8s.io",
+        resource: "validatingadmissionpolicybindings",
+    },
+    ResourceKey {
+        api_group: "admissionregistration.k8s.io",
+        resource: "mutatingadmissionpolicies",
+    },
+    ResourceKey {
+        api_group: "admissionregistration.k8s.io",
+        resource: "mutatingadmissionpolicybindings",
+    },
+    // apiextensions.k8s.io
+    ResourceKey {
+        api_group: "apiextensions.k8s.io",
+        resource: "customresourcedefinitions",
+    },
+    // apiregistration.k8s.io
+    ResourceKey {
+        api_group: "apiregistration.k8s.io",
+        resource: "apiservices",
+    },
+    // certificates.k8s.io
+    ResourceKey {
+        api_group: "certificates.k8s.io",
+        resource: "certificatesigningrequests",
+    },
+    ResourceKey {
+        api_group: "certificates.k8s.io",
+        resource: "clustertrustbundles",
+    },
+    // flowcontrol.apiserver.k8s.io
+    ResourceKey {
+        api_group: "flowcontrol.apiserver.k8s.io",
+        resource: "flowschemas",
+    },
+    ResourceKey {
+        api_group: "flowcontrol.apiserver.k8s.io",
+        resource: "prioritylevelconfigurations",
+    },
+    // networking.k8s.io
+    ResourceKey {
+        api_group: "networking.k8s.io",
+        resource: "ingressclasses",
+    },
+    ResourceKey {
+        api_group: "networking.k8s.io",
+        resource: "ipaddresses",
+    },
+    ResourceKey {
+        api_group: "networking.k8s.io",
+        resource: "servicecidrs",
+    },
+    // node.k8s.io
+    ResourceKey {
+        api_group: "node.k8s.io",
+        resource: "runtimeclasses",
+    },
+    // rbac.authorization.k8s.io
+    ResourceKey {
+        api_group: "rbac.authorization.k8s.io",
+        resource: "clusterroles",
+    },
+    ResourceKey {
+        api_group: "rbac.authorization.k8s.io",
+        resource: "clusterrolebindings",
+    },
+    // resource.k8s.io
+    ResourceKey {
+        api_group: "resource.k8s.io",
+        resource: "deviceclasses",
+    },
+    ResourceKey {
+        api_group: "resource.k8s.io",
+        resource: "resourceslices",
+    },
+    // scheduling.k8s.io
+    ResourceKey {
+        api_group: "scheduling.k8s.io",
+        resource: "priorityclasses",
+    },
+    // storage.k8s.io
+    ResourceKey {
+        api_group: "storage.k8s.io",
+        resource: "csidrivers",
+    },
+    ResourceKey {
+        api_group: "storage.k8s.io",
+        resource: "csinodes",
+    },
+    ResourceKey {
+        api_group: "storage.k8s.io",
+        resource: "storageclasses",
+    },
+    ResourceKey {
+        api_group: "storage.k8s.io",
+        resource: "volumeattachments",
+    },
+    // storagemigration.k8s.io
+    ResourceKey {
+        api_group: "storagemigration.k8s.io",
+        resource: "storageversionmigrations",
+    },
+];
+
+/// API groups that ship as part of the kube-apiserver core distribution. Any
+/// other API group is treated as a Custom Resource Definition for the purpose
+/// of the scaffold check (we cannot tell its scope statically).
+const BUILT_IN_API_GROUPS: &[&str] = &[
+    "",
+    "admissionregistration.k8s.io",
+    "apiextensions.k8s.io",
+    "apiregistration.k8s.io",
+    "apps",
+    "authentication.k8s.io",
+    "authorization.k8s.io",
+    "autoscaling",
+    "batch",
+    "certificates.k8s.io",
+    "coordination.k8s.io",
+    "discovery.k8s.io",
+    "events.k8s.io",
+    "flowcontrol.apiserver.k8s.io",
+    "networking.k8s.io",
+    "node.k8s.io",
+    "policy",
+    "rbac.authorization.k8s.io",
+    "resource.k8s.io",
+    "scheduling.k8s.io",
+    "storage.k8s.io",
+    "storagemigration.k8s.io",
+];
+
+/// Inspect the rules and classify each (api_group, resource) pair into one of
+/// the three categories the scaffold cares about: a known cluster-scoped
+/// built-in, an unknown resource (likely a CRD, or one we cannot disambiguate
+/// because the rule uses wildcards), or a known namespaced built-in.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct AdmissionPolicyScopeFindings {
+    /// (api_group, resource) pairs that match a known cluster-scoped built-in
+    /// Kubernetes resource. Targeting these from an `AdmissionPolicy` always
+    /// produces a manifest that will never be evaluated by the cluster.
+    pub cluster_scoped: Vec<(String, String)>,
+    /// (api_group, resource) pairs that we cannot classify statically. This
+    /// covers Custom Resource Definitions (any api_group outside the well-
+    /// known kube-apiserver set) and wildcard rules that may resolve to either
+    /// scope at runtime.
+    pub unknown: Vec<(String, String)>,
+}
+
+impl AdmissionPolicyScopeFindings {
+    pub(crate) fn has_cluster_scoped(&self) -> bool {
+        !self.cluster_scoped.is_empty()
+    }
+
+    pub(crate) fn has_unknown(&self) -> bool {
+        !self.unknown.is_empty()
+    }
+}
+
+pub(crate) fn classify_admission_policy_rules(rules: &[Rule]) -> AdmissionPolicyScopeFindings {
+    let mut findings = AdmissionPolicyScopeFindings::default();
+
+    for rule in rules {
+        for api_group in &rule.api_groups {
+            for resource in &rule.resources {
+                let base_resource = resource.split('/').next().unwrap_or(resource);
+                let pair = (api_group.clone(), resource.clone());
+
+                if api_group == "*" || base_resource == "*" {
+                    findings.unknown.push(pair);
+                    continue;
+                }
+
+                if is_known_cluster_scoped(api_group, base_resource) {
+                    findings.cluster_scoped.push(pair);
+                } else if !is_built_in_api_group(api_group) {
+                    findings.unknown.push(pair);
+                }
+                // Otherwise it is a known namespaced built-in: nothing to flag.
+            }
+        }
+    }
+
+    findings
+}
+
+fn is_known_cluster_scoped(api_group: &str, resource: &str) -> bool {
+    CLUSTER_SCOPED_RESOURCES
+        .iter()
+        .any(|key| key.api_group == api_group && key.resource == resource)
+}
+
+fn is_built_in_api_group(api_group: &str) -> bool {
+    BUILT_IN_API_GROUPS.contains(&api_group)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use policy_evaluator::policy_metadata::{Operation, Rule};
+
+    fn rule(api_groups: &[&str], resources: &[&str]) -> Rule {
+        Rule {
+            api_groups: api_groups.iter().map(|s| s.to_string()).collect(),
+            api_versions: vec!["v1".to_string()],
+            resources: resources.iter().map(|s| s.to_string()).collect(),
+            operations: vec![Operation::Create],
+        }
+    }
+
+    #[test]
+    fn namespaced_built_in_resource_produces_no_findings() {
+        let rules = vec![rule(&[""], &["pods"]), rule(&["apps"], &["deployments"])];
+        let findings = classify_admission_policy_rules(&rules);
+        assert!(findings.cluster_scoped.is_empty());
+        assert!(findings.unknown.is_empty());
+    }
+
+    #[test]
+    fn core_cluster_scoped_resource_is_detected() {
+        let rules = vec![rule(&[""], &["namespaces"])];
+        let findings = classify_admission_policy_rules(&rules);
+        assert_eq!(
+            findings.cluster_scoped,
+            vec![("".to_string(), "namespaces".to_string())]
+        );
+        assert!(findings.unknown.is_empty());
+    }
+
+    #[test]
+    fn cluster_scoped_in_named_group_is_detected() {
+        let rules = vec![rule(&["rbac.authorization.k8s.io"], &["clusterroles"])];
+        let findings = classify_admission_policy_rules(&rules);
+        assert_eq!(
+            findings.cluster_scoped,
+            vec![(
+                "rbac.authorization.k8s.io".to_string(),
+                "clusterroles".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn custom_resource_is_classified_as_unknown() {
+        let rules = vec![rule(&["example.com"], &["widgets"])];
+        let findings = classify_admission_policy_rules(&rules);
+        assert!(findings.cluster_scoped.is_empty());
+        assert_eq!(
+            findings.unknown,
+            vec![("example.com".to_string(), "widgets".to_string())]
+        );
+    }
+
+    #[test]
+    fn wildcard_api_group_is_classified_as_unknown() {
+        let rules = vec![rule(&["*"], &["pods"])];
+        let findings = classify_admission_policy_rules(&rules);
+        assert!(findings.cluster_scoped.is_empty());
+        assert_eq!(
+            findings.unknown,
+            vec![("*".to_string(), "pods".to_string())]
+        );
+    }
+
+    #[test]
+    fn wildcard_resource_is_classified_as_unknown() {
+        let rules = vec![rule(&[""], &["*"])];
+        let findings = classify_admission_policy_rules(&rules);
+        assert!(findings.cluster_scoped.is_empty());
+        assert_eq!(findings.unknown, vec![("".to_string(), "*".to_string())]);
+    }
+
+    #[test]
+    fn subresource_inherits_parent_scope() {
+        let rules = vec![rule(&[""], &["pods/status"])];
+        let findings = classify_admission_policy_rules(&rules);
+        // `pods` is namespaced, so `pods/status` is too.
+        assert!(findings.cluster_scoped.is_empty());
+        assert!(findings.unknown.is_empty());
+
+        let rules = vec![rule(&[""], &["nodes/proxy"])];
+        let findings = classify_admission_policy_rules(&rules);
+        // `nodes` is cluster-scoped, so the rule must be flagged as such.
+        assert_eq!(
+            findings.cluster_scoped,
+            vec![("".to_string(), "nodes/proxy".to_string())]
+        );
+    }
+
+    #[test]
+    fn mixed_rules_are_all_classified() {
+        let rules = vec![
+            rule(&[""], &["pods"]),                         // namespaced built-in
+            rule(&[""], &["namespaces"]),                   // cluster-scoped built-in
+            rule(&["example.com"], &["widgets"]),           // unknown (CRD)
+            rule(&["storage.k8s.io"], &["storageclasses"]), // cluster-scoped built-in
+            rule(&["apps"], &["statefulsets"]),             // namespaced built-in
+        ];
+        let findings = classify_admission_policy_rules(&rules);
+        assert_eq!(
+            findings.cluster_scoped,
+            vec![
+                ("".to_string(), "namespaces".to_string()),
+                ("storage.k8s.io".to_string(), "storageclasses".to_string()),
+            ]
+        );
+        assert_eq!(
+            findings.unknown,
+            vec![("example.com".to_string(), "widgets".to_string())]
+        );
+    }
+
+    #[test]
+    fn empty_rules_produces_no_findings() {
+        let findings = classify_admission_policy_rules(&[]);
+        assert!(findings.cluster_scoped.is_empty());
+        assert!(findings.unknown.is_empty());
+    }
+}

--- a/crates/kwctl/src/scaffold/resource_scope.rs
+++ b/crates/kwctl/src/scaffold/resource_scope.rs
@@ -3,6 +3,8 @@
 //! cluster-scoped resources (an `AdmissionPolicy` is namespaced, and a
 //! cluster-scoped target would never be evaluated against it).
 
+use std::collections::BTreeSet;
+
 use policy_evaluator::policy_metadata::Rule;
 
 /// Resource API group and plural pair, used as a key into the built-in
@@ -69,6 +71,24 @@ const CLUSTER_SCOPED_RESOURCES: &[ResourceKey] = &[
     ResourceKey {
         api_group: "apiregistration.k8s.io",
         resource: "apiservices",
+    },
+    // authentication.k8s.io
+    ResourceKey {
+        api_group: "authentication.k8s.io",
+        resource: "tokenreviews",
+    },
+    // authorization.k8s.io
+    ResourceKey {
+        api_group: "authorization.k8s.io",
+        resource: "selfsubjectaccessreviews",
+    },
+    ResourceKey {
+        api_group: "authorization.k8s.io",
+        resource: "selfsubjectrulesreviews",
+    },
+    ResourceKey {
+        api_group: "authorization.k8s.io",
+        resource: "subjectaccessreviews",
     },
     // certificates.k8s.io
     ResourceKey {
@@ -209,7 +229,8 @@ impl AdmissionPolicyScopeFindings {
 }
 
 pub(crate) fn classify_admission_policy_rules(rules: &[Rule]) -> AdmissionPolicyScopeFindings {
-    let mut findings = AdmissionPolicyScopeFindings::default();
+    let mut cluster_scoped = BTreeSet::new();
+    let mut unknown = BTreeSet::new();
 
     for rule in rules {
         for api_group in &rule.api_groups {
@@ -218,21 +239,24 @@ pub(crate) fn classify_admission_policy_rules(rules: &[Rule]) -> AdmissionPolicy
                 let pair = (api_group.clone(), resource.clone());
 
                 if api_group == "*" || base_resource == "*" {
-                    findings.unknown.push(pair);
+                    unknown.insert(pair);
                     continue;
                 }
 
                 if is_known_cluster_scoped(api_group, base_resource) {
-                    findings.cluster_scoped.push(pair);
+                    cluster_scoped.insert(pair);
                 } else if !is_built_in_api_group(api_group) {
-                    findings.unknown.push(pair);
+                    unknown.insert(pair);
                 }
                 // Otherwise it is a known namespaced built-in: nothing to flag.
             }
         }
     }
 
-    findings
+    AdmissionPolicyScopeFindings {
+        cluster_scoped: cluster_scoped.into_iter().collect(),
+        unknown: unknown.into_iter().collect(),
+    }
 }
 
 fn is_known_cluster_scoped(api_group: &str, resource: &str) -> bool {
@@ -292,6 +316,44 @@ mod tests {
     }
 
     #[test]
+    fn authentication_and_authorization_review_resources_are_cluster_scoped() {
+        let rules = vec![
+            rule(&["authentication.k8s.io"], &["tokenreviews"]),
+            rule(
+                &["authorization.k8s.io"],
+                &[
+                    "selfsubjectaccessreviews",
+                    "selfsubjectrulesreviews",
+                    "subjectaccessreviews",
+                ],
+            ),
+        ];
+        let findings = classify_admission_policy_rules(&rules);
+        assert_eq!(
+            findings.cluster_scoped,
+            vec![
+                (
+                    "authentication.k8s.io".to_string(),
+                    "tokenreviews".to_string()
+                ),
+                (
+                    "authorization.k8s.io".to_string(),
+                    "selfsubjectaccessreviews".to_string()
+                ),
+                (
+                    "authorization.k8s.io".to_string(),
+                    "selfsubjectrulesreviews".to_string()
+                ),
+                (
+                    "authorization.k8s.io".to_string(),
+                    "subjectaccessreviews".to_string()
+                ),
+            ]
+        );
+        assert!(findings.unknown.is_empty());
+    }
+
+    #[test]
     fn custom_resource_is_classified_as_unknown() {
         let rules = vec![rule(&["example.com"], &["widgets"])];
         let findings = classify_admission_policy_rules(&rules);
@@ -346,6 +408,28 @@ mod tests {
             rule(&["example.com"], &["widgets"]),           // unknown (CRD)
             rule(&["storage.k8s.io"], &["storageclasses"]), // cluster-scoped built-in
             rule(&["apps"], &["statefulsets"]),             // namespaced built-in
+        ];
+        let findings = classify_admission_policy_rules(&rules);
+        assert_eq!(
+            findings.cluster_scoped,
+            vec![
+                ("".to_string(), "namespaces".to_string()),
+                ("storage.k8s.io".to_string(), "storageclasses".to_string()),
+            ]
+        );
+        assert_eq!(
+            findings.unknown,
+            vec![("example.com".to_string(), "widgets".to_string())]
+        );
+    }
+
+    #[test]
+    fn duplicate_findings_are_deduplicated_and_sorted() {
+        let rules = vec![
+            rule(&["storage.k8s.io"], &["storageclasses"]),
+            rule(&["storage.k8s.io"], &["storageclasses"]),
+            rule(&["example.com"], &["widgets", "widgets"]),
+            rule(&[""], &["namespaces", "namespaces"]),
         ];
         let findings = classify_admission_policy_rules(&rules);
         assert_eq!(


### PR DESCRIPTION
## Summary

Closes #1305.

`kwctl scaffold manifest --type AdmissionPolicy` currently produces a manifest no matter what
resources the underlying policy targets. But `AdmissionPolicy` is a namespaced CRD: the cluster
only routes namespaced admission requests to it, so a manifest that targets a cluster-scoped
resource (e.g. `Namespace`, `Node`, `PersistentVolume`, `ClusterRole`, `StorageClass`, ...)
is scaffolded just fine and then silently does nothing once applied. There is no warning,
no error, no log line; the user has to discover the misconfiguration the hard way.

This PR closes that gap. After the change, scaffolding an `AdmissionPolicy` for a policy whose
rules include a cluster-scoped Kubernetes built-in fails with a clear message:

```
$ kwctl scaffold manifest --type AdmissionPolicy <policy-that-targets-namespaces>
Error: AdmissionPolicy cannot target cluster-wide resources, but the policy's rules target:
namespaces. AdmissionPolicy is a namespaced resource: the cluster only invokes it for
namespaced requests. Scaffold a ClusterAdmissionPolicy instead by passing
\`--type ClusterAdmissionPolicy\`.
```

If the policy targets a resource we cannot classify statically (any apiGroup outside the
kube-apiserver core set, including most CRDs, or a rule that uses wildcards), the scaffold
prints a warning and proceeds:

```
$ kwctl scaffold manifest --type AdmissionPolicy <policy-that-targets-example.com/widgets>
WARN Cannot determine whether `example.com/widgets` is namespaced or cluster-wide.
     If it is cluster-wide, this AdmissionPolicy will never be invoked. Verify the resource
     scope with `kubectl api-resources` and, if needed, scaffold a ClusterAdmissionPolicy
     instead.
```

`ClusterAdmissionPolicy` scaffolding is unaffected.

This matches both acceptance criteria spelled out in the issue.

## What changes

| File | Change |
|------|--------|
| `crates/kwctl/src/scaffold/resource_scope.rs` (new) | A static table of cluster-scoped Kubernetes built-ins (K8s 1.33 API surface) and a `classify_admission_policy_rules` helper that splits a policy's rules into `cluster_scoped` / `unknown` findings. Subresources inherit the scope of their parent (`nodes/proxy` is cluster-scoped, `pods/status` is namespaced). |
| `crates/kwctl/src/scaffold.rs` | Declares the new module. |
| `crates/kwctl/src/scaffold/manifest.rs` | When the requested manifest type is `AdmissionPolicy`, calls `classify_admission_policy_rules` and either errors out on `cluster_scoped` findings or warns on `unknown` findings before delegating to the existing serialization path. |

## Resource scope table

The table covers the cluster-scoped resources in the kube-apiserver core distribution for
Kubernetes 1.33: the core group (`namespaces`, `nodes`, `persistentvolumes`,
`componentstatuses`) plus the admission registration, apiextensions, apiregistration,
certificates, flowcontrol, networking (`ingressclasses`, `ipaddresses`, `servicecidrs`),
node, RBAC, resource.k8s.io, scheduling, storage and storagemigration groups. Any apiGroup
outside that built-in set (the canonical user-facing CRD case) is treated as `unknown` and
triggers the warning, not the error.

## Test plan

- [x] `cargo build -p kwctl` builds cleanly
- [x] `cargo clippy -p kwctl --tests --no-deps` produces no new warnings
- [x] `cargo fmt --all -- --check` is clean
- [x] `cargo test -p kwctl --bin kwctl` passes (96 tests total). The new module adds:
  - 9 unit tests in `resource_scope::tests` (namespaced built-in, core cluster-scoped,
    named-group cluster-scoped, CRD, wildcard apiGroup, wildcard resource, subresource,
    mixed rules, empty rules)
  - 5 integration tests in `scaffold::manifest::tests` (AdmissionPolicy targeting
    namespaced resource succeeds, AdmissionPolicy targeting core cluster-scoped resource
    errors, AdmissionPolicy targeting named-group cluster-scoped resource errors,
    AdmissionPolicy targeting CRD succeeds with warning, ClusterAdmissionPolicy targeting
    cluster-scoped resource is unaffected)
- [x] The existing `test_scaffold_manifest` e2e test (which uses `--type ClusterAdmissionPolicy`)
  is unaffected because the check only fires for `AdmissionPolicy`