### PR TITLE
chore(deps): move back to official release of docker_credentials crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,16 +1883,6 @@ dependencies = [
 
 [[package]]
 name = "docker_credential"
-version = "1.3.3"
-source = "git+https://github.com/flavio/docker_credential.git?branch=fix-handle-config-without-auth-field#11b55173dea8784f68dc9e24e6977173fb2165ac"
-dependencies = [
- "base64 0.22.1",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "docker_credential"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29547a1dc60885a552306986316bc9701ba120c1a8db6769fa68691529ad373d"
@@ -4790,7 +4780,7 @@ dependencies = [
  "base64 0.22.1",
  "cfg-if",
  "directories",
- "docker_credential 1.3.3",
+ "docker_credential",
  "futures",
  "hex",
  "lazy_static",
@@ -6878,7 +6868,7 @@ dependencies = [
  "bollard",
  "bytes",
  "conquer-once",
- "docker_credential 1.4.0",
+ "docker_credential",
  "either",
  "etcetera",
  "ferroid",

--- a/crates/policy-fetcher/Cargo.toml
+++ b/crates/policy-fetcher/Cargo.toml
@@ -17,7 +17,7 @@ async-trait = "0.1"
 base64 = { workspace = true }
 cfg-if = "1.0"
 directories = "6.0"
-docker_credential = { git = "https://github.com/flavio/docker_credential.git", branch = "fix-handle-config-without-auth-field" }
+docker_credential = "1.4"
 futures = { workspace = true }
 hex = { workspace = true }
 lazy_static = { workspace = true }


### PR DESCRIPTION
The patch we submitted got merged and a new version got tagged.
