### PR TITLE
feat(kubewarden-controller): Delete all CRs in pre-delete hook

### DIFF
--- a/charts/kubewarden-controller/templates/pre-delete-hook.yaml
+++ b/charts/kubewarden-controller/templates/pre-delete-hook.yaml
@@ -36,7 +36,16 @@ spec:
       containers:
         - name: pre-delete-job
           image: '{{ template "system_default_registry" . }}{{ .Values.preDeleteJob.image.repository }}:{{ .Values.preDeleteJob.image.tag }}'
-          command: ["kubectl", "delete", "--all", "policyservers.policies.kubewarden.io"]
+          command:
+            - /bin/sh
+            - -c
+            - |
+              kubectl delete --wait --all clusteradmissionpolicies.policies.kubewarden.io &
+              kubectl delete --wait --all --all-namespaces admissionpolicies.policies.kubewarden.io &
+              kubectl delete --wait --all clusteradmissionpolicygroups.policies.kubewarden.io &
+              kubectl delete --wait --all --all-namespaces admissionpolicygroups.policies.kubewarden.io &
+              wait &&
+              kubectl delete --wait --all policyservers.policies.kubewarden.io
           env:
             - name: KUBERLR_ALLOWDOWNLOAD
               value: "1"


### PR DESCRIPTION
## Description

On 1.36, without this change:
- Deleting a PolicyServer sets its policies as scheduled.
- Recommended policies are managed via Helm and removed when `kubewarden-defaults` is uninstalled.
- User-managed policies will never be deleted, and linger after the removal of the CRDs, as they have finalizers.

With this change:
All CRs will be removed when uninstalling the `kubewarden-controller` chart. This includes charts of downstream consumers that use a single chart approach.

The used image, kuberlr/kubectl, has busybox, hence `ash` as shell. Use the shell to remove all CRs. Removing all CRs in potentially all namespaces is costly; do backgrounds jobs with `&`, wait, and only then remove the policyservers.


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

Tested locally by deploying charts with recommended policies, a user-managed policy and policy server, and uninstalling the charts one by one.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
