### PR TITLE
fix: Add controller finalizer when policy is active state only

### DIFF
--- a/api/policies/v1/admissionpolicy_webhook.go
+++ b/api/policies/v1/admissionpolicy_webhook.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/go-logr/logr"
@@ -55,9 +54,6 @@ type admissionPolicyDefaulter struct {
 func (d *admissionPolicyDefaulter) Default(_ context.Context, admissionPolicy *AdmissionPolicy) error {
 	if admissionPolicy.Spec.PolicyServer == "" {
 		admissionPolicy.Spec.PolicyServer = constants.DefaultPolicyServer
-	}
-	if admissionPolicy.ObjectMeta.DeletionTimestamp == nil {
-		controllerutil.AddFinalizer(admissionPolicy, constants.KubewardenFinalizer)
 	}
 
 	return nil

--- a/api/policies/v1/admissionpolicy_webhook_test.go
+++ b/api/policies/v1/admissionpolicy_webhook_test.go
@@ -33,7 +33,7 @@ func TestAdmissionPolicyDefault(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, constants.DefaultPolicyServer, policy.GetPolicyServer())
-	assert.Contains(t, policy.GetFinalizers(), constants.KubewardenFinalizer)
+	assert.NotContains(t, policy.GetFinalizers(), constants.KubewardenFinalizer)
 }
 
 func TestAdmissionPolicyValidateCreate(t *testing.T) {

--- a/api/policies/v1/admissionpolicygroup_webhook.go
+++ b/api/policies/v1/admissionpolicygroup_webhook.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/go-logr/logr"
@@ -58,9 +57,6 @@ func (d *admissionPolicyGroupDefaulter) Default(_ context.Context, admissionPoli
 
 	if admissionPolicyGroup.Spec.PolicyServer == "" {
 		admissionPolicyGroup.Spec.PolicyServer = constants.DefaultPolicyServer
-	}
-	if admissionPolicyGroup.ObjectMeta.DeletionTimestamp == nil {
-		controllerutil.AddFinalizer(admissionPolicyGroup, constants.KubewardenFinalizer)
 	}
 
 	return nil

--- a/api/policies/v1/admissionpolicygroup_webhook_test.go
+++ b/api/policies/v1/admissionpolicygroup_webhook_test.go
@@ -34,7 +34,7 @@ func TestAdmissionPolicyGroupDefault(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, constants.DefaultPolicyServer, policy.GetPolicyServer())
-	assert.Contains(t, policy.GetFinalizers(), constants.KubewardenFinalizer)
+	assert.NotContains(t, policy.GetFinalizers(), constants.KubewardenFinalizer)
 }
 
 func TestAdmissionPolicyGroupValidateCreate(t *testing.T) {

--- a/api/policies/v1/clusteradmissionpolicy_webhook.go
+++ b/api/policies/v1/clusteradmissionpolicy_webhook.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -59,9 +58,6 @@ func (d *clusterAdmissionPolicyDefaulter) Default(_ context.Context, clusterAdmi
 
 	if clusterAdmissionPolicy.Spec.PolicyServer == "" {
 		clusterAdmissionPolicy.Spec.PolicyServer = constants.DefaultPolicyServer
-	}
-	if clusterAdmissionPolicy.ObjectMeta.DeletionTimestamp == nil {
-		controllerutil.AddFinalizer(clusterAdmissionPolicy, constants.KubewardenFinalizer)
 	}
 
 	return nil

--- a/api/policies/v1/clusteradmissionpolicy_webhook_test.go
+++ b/api/policies/v1/clusteradmissionpolicy_webhook_test.go
@@ -34,7 +34,7 @@ func TestClusterAdmissionPolicyDefault(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, constants.DefaultPolicyServer, policy.GetPolicyServer())
-	assert.Contains(t, policy.GetFinalizers(), constants.KubewardenFinalizer)
+	assert.NotContains(t, policy.GetFinalizers(), constants.KubewardenFinalizer)
 }
 
 func TestClusterAdmissionPolicyValidateCreate(t *testing.T) {

--- a/api/policies/v1/clusteradmissionpolicygroup_webhook.go
+++ b/api/policies/v1/clusteradmissionpolicygroup_webhook.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -58,9 +57,6 @@ func (d *clusterAdmissionPolicyGroupDefaulter) Default(_ context.Context, cluste
 
 	if clusterAdmissionPolicyGroup.Spec.PolicyServer == "" {
 		clusterAdmissionPolicyGroup.Spec.PolicyServer = constants.DefaultPolicyServer
-	}
-	if clusterAdmissionPolicyGroup.ObjectMeta.DeletionTimestamp == nil {
-		controllerutil.AddFinalizer(clusterAdmissionPolicyGroup, constants.KubewardenFinalizer)
 	}
 
 	return nil

--- a/api/policies/v1/clusteradmissionpolicygroup_webhook_test.go
+++ b/api/policies/v1/clusteradmissionpolicygroup_webhook_test.go
@@ -33,7 +33,7 @@ func TestClusterAdmissionPolicyGroupDefault(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, constants.DefaultPolicyServer, policy.GetPolicyServer())
-	assert.Contains(t, policy.GetFinalizers(), constants.KubewardenFinalizer)
+	assert.NotContains(t, policy.GetFinalizers(), constants.KubewardenFinalizer)
 }
 
 func TestClusterAdmissionPolicyGroupValidateCreate(t *testing.T) {

--- a/api/policies/v1/factories.go
+++ b/api/policies/v1/factories.go
@@ -110,12 +110,9 @@ func (f *AdmissionPolicyFactory) Build() *AdmissionPolicy {
 			Name:      f.name,
 			Namespace: f.namespace,
 			Finalizers: []string{
-				// On a real cluster the Kubewarden finalizer is added by our mutating
-				// webhook. This is not running now, hence we have to manually add the finalizer
-				constants.KubewardenFinalizer,
-				// By adding this finalizer automatically, we ensure that when
-				// testing removal of finalizers on deleted objects, that they will
-				// exist at all times
+				// Safety-net finalizer that prevents the API server from garbage-
+				// collecting the object during integration tests, so test assertions
+				// can observe the controller's behavior before deletion completes.
 				integrationTestsFinalizer,
 			},
 		},
@@ -224,12 +221,9 @@ func (f *ClusterAdmissionPolicyFactory) Build() *ClusterAdmissionPolicy {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: f.name,
 			Finalizers: []string{
-				// On a real cluster the Kubewarden finalizer is added by our mutating
-				// webhook. This is not running now, hence we have to manually add the finalizer
-				constants.KubewardenFinalizer,
-				// By adding this finalizer automatically, we ensure that when
-				// testing removal of finalizers on deleted objects, that they will
-				// exist at all times
+				// Safety-net finalizer that prevents the API server from garbage-
+				// collecting the object during integration tests, so test assertions
+				// can observe the controller's behavior before deletion completes.
 				integrationTestsFinalizer,
 			},
 		},
@@ -328,12 +322,9 @@ func (f *AdmissionPolicyGroupFactory) Build() *AdmissionPolicyGroup {
 			Name:      f.name,
 			Namespace: f.namespace,
 			Finalizers: []string{
-				// On a real cluster the Kubewarden finalizer is added by our mutating
-				// webhook. This is not running now, hence we have to manually add the finalizer
-				constants.KubewardenFinalizer,
-				// By adding this finalizer automatically, we ensure that when
-				// testing removal of finalizers on deleted objects, that they will
-				// exist at all times
+				// Safety-net finalizer that prevents the API server from garbage-
+				// collecting the object during integration tests, so test assertions
+				// can observe the controller's behavior before deletion completes.
 				integrationTestsFinalizer,
 			},
 		},
@@ -455,12 +446,9 @@ func (f *ClusterAdmissionPolicyGroupFactory) Build() *ClusterAdmissionPolicyGrou
 		ObjectMeta: metav1.ObjectMeta{
 			Name: f.name,
 			Finalizers: []string{
-				// On a real cluster the Kubewarden finalizer is added by our mutating
-				// webhook. This is not running now, hence we have to manually add the finalizer
-				constants.KubewardenFinalizer,
-				// By adding this finalizer automatically, we ensure that when
-				// testing removal of finalizers on deleted objects, that they will
-				// exist at all times
+				// Safety-net finalizer that prevents the API server from garbage-
+				// collecting the object during integration tests, so test assertions
+				// can observe the controller's behavior before deletion completes.
 				integrationTestsFinalizer,
 			},
 		},

--- a/charts/kubewarden-controller/templates/pre-delete-hook.yaml
+++ b/charts/kubewarden-controller/templates/pre-delete-hook.yaml
@@ -36,7 +36,7 @@ spec:
       containers:
         - name: pre-delete-job
           image: '{{ template "system_default_registry" . }}{{ .Values.preDeleteJob.image.repository }}:{{ .Values.preDeleteJob.image.tag }}'
-          command: ["kubectl", "delete", "--all", "policyservers.policies.kubewarden.io"]
+          command: ["kubectl", "delete", "--all", "--wait", "policyservers.policies.kubewarden.io"]
           env:
             - name: KUBERLR_ALLOWDOWNLOAD
               value: "1"

--- a/e2e/clusteradmissionpolicy_test.go
+++ b/e2e/clusteradmissionpolicy_test.go
@@ -265,6 +265,10 @@ func TestClusterAdmissionPolicyController(t *testing.T) {
 			policy := ctx.Value(policyKey).(*policiesv1.ClusterAdmissionPolicy)
 			webhookName := policy.GetUniqueName()
 
+			// Verify policy has finalizer before deletion
+			require.True(t, containsFinalizer(policy.GetFinalizers(), constants.KubewardenFinalizer),
+				"Policy should have finalizer before deletion")
+
 			// Delete the policy
 			err := cfg.Client().Resources().Delete(ctx, policy)
 			require.NoError(t, err)
@@ -274,6 +278,11 @@ func TestClusterAdmissionPolicyController(t *testing.T) {
 				&admissionregistrationv1.ValidatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: webhookName}},
 			), wait.WithTimeout(testTimeout), wait.WithInterval(testPollInterval))
 			require.NoError(t, err, "ValidatingWebhookConfiguration should be deleted")
+
+			// Wait for policy to be deleted (finalizer removed)
+			err = wait.For(conditions.New(cfg.Client().Resources()).ResourceDeleted(policy),
+				wait.WithTimeout(testTimeout), wait.WithInterval(testPollInterval))
+			require.NoError(t, err, "Policy should be deleted (finalizer removed)")
 
 			return ctx
 		}).
@@ -457,6 +466,10 @@ func TestClusterAdmissionPolicyController(t *testing.T) {
 			policy := ctx.Value(policyKey).(*policiesv1.ClusterAdmissionPolicy)
 			webhookName := policy.GetUniqueName()
 
+			// Verify policy has finalizer before deletion
+			require.True(t, containsFinalizer(policy.GetFinalizers(), constants.KubewardenFinalizer),
+				"Policy should have finalizer before deletion")
+
 			// Delete the policy
 			err := cfg.Client().Resources().Delete(ctx, policy)
 			require.NoError(t, err)
@@ -466,6 +479,11 @@ func TestClusterAdmissionPolicyController(t *testing.T) {
 				&admissionregistrationv1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: webhookName}},
 			), wait.WithTimeout(testTimeout), wait.WithInterval(testPollInterval))
 			require.NoError(t, err, "MutatingWebhookConfiguration should be deleted")
+
+			// Wait for policy to be deleted (finalizer removed)
+			err = wait.For(conditions.New(cfg.Client().Resources()).ResourceDeleted(policy),
+				wait.WithTimeout(testTimeout), wait.WithInterval(testPollInterval))
+			require.NoError(t, err, "Policy should be deleted (finalizer removed)")
 
 			return ctx
 		}).
@@ -507,6 +525,13 @@ func TestClusterAdmissionPolicyController(t *testing.T) {
 			), wait.WithTimeout(testTimeout), wait.WithInterval(testPollInterval))
 			require.NoError(t, err, "Policy should have scheduled status")
 
+			// Verify policy does NOT have finalizer when scheduled (not active)
+			var policy policiesv1.ClusterAdmissionPolicy
+			err = cfg.Client().Resources().Get(ctx, policyName, "", &policy)
+			require.NoError(t, err)
+			require.False(t, containsFinalizer(policy.GetFinalizers(), constants.KubewardenFinalizer),
+				"Policy should NOT have finalizer when scheduled (not active)")
+
 			return ctx
 		}).
 		Assess("should set the policy status to active when the PolicyServer is created", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -546,5 +571,154 @@ func TestClusterAdmissionPolicyController(t *testing.T) {
 		}).
 		Feature()
 
-	testenv.Test(t, timeoutValidationFeature, validatingFeature, mutatingFeature, scheduledFeature)
+	policyServerDeletionFeature := features.New("PolicyServer deletion with active policies").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// Add scheme
+			err := policiesv1.AddToScheme(cfg.Client().Resources().GetScheme())
+			require.NoError(t, err)
+
+			// Create PolicyServer
+			policyServerName := policiesv1.NewPolicyServerFactory().Build().Name
+			policyServer := policiesv1.NewPolicyServerFactory().
+				WithName(policyServerName).
+				Build()
+			err = createPolicyServerAndWaitForItsService(ctx, cfg, policyServer)
+			require.NoError(t, err)
+
+			// Create policy and wait for it to become active
+			policyName := policiesv1.NewClusterAdmissionPolicyFactory().Build().Name
+			policy := policiesv1.NewClusterAdmissionPolicyFactory().
+				WithName(policyName).
+				WithPolicyServer(policyServerName).
+				Build()
+			err = cfg.Client().Resources().Create(ctx, policy)
+			require.NoError(t, err)
+
+			// Wait for active status (implies finalizer is added)
+			err = wait.For(conditions.New(cfg.Client().Resources()).ResourceMatch(
+				&policiesv1.ClusterAdmissionPolicy{ObjectMeta: metav1.ObjectMeta{Name: policyName}},
+				func(object k8s.Object) bool {
+					p := object.(*policiesv1.ClusterAdmissionPolicy)
+					return p.Status.PolicyStatus == policiesv1.PolicyStatusActive
+				},
+			), wait.WithTimeout(testTimeout), wait.WithInterval(testPollInterval))
+			require.NoError(t, err, "Policy should transition to active status")
+
+			ctx = context.WithValue(ctx, policyServerNameKey, policyServerName)
+			ctx = context.WithValue(ctx, policyNameKey, policyName)
+
+			return ctx
+		}).
+		Assess("should have finalizer when policy is active", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			policyName := ctx.Value(policyNameKey).(string)
+
+			// Verify policy has finalizer when active
+			var policy policiesv1.ClusterAdmissionPolicy
+			err := cfg.Client().Resources().Get(ctx, policyName, "", &policy)
+			require.NoError(t, err)
+			require.True(t, containsFinalizer(policy.GetFinalizers(), constants.KubewardenFinalizer),
+				"Policy should have finalizer when active")
+
+			return ctx
+		}).
+		Assess("should remove finalizer when PolicyServer is deleted", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			policyServerName := ctx.Value(policyServerNameKey).(string)
+			policyName := ctx.Value(policyNameKey).(string)
+
+			// Delete the PolicyServer
+			policyServer := &policiesv1.PolicyServer{
+				ObjectMeta: metav1.ObjectMeta{Name: policyServerName, Namespace: namespace},
+			}
+			err := cfg.Client().Resources().Delete(ctx, policyServer)
+			require.NoError(t, err)
+
+			// Verify finalizer is removed from policy
+			err = wait.For(conditions.New(cfg.Client().Resources()).ResourceMatch(
+				&policiesv1.ClusterAdmissionPolicy{ObjectMeta: metav1.ObjectMeta{Name: policyName}},
+				func(object k8s.Object) bool {
+					p := object.(*policiesv1.ClusterAdmissionPolicy)
+					return !containsFinalizer(p.GetFinalizers(), constants.KubewardenFinalizer)
+				},
+			), wait.WithTimeout(testTimeout), wait.WithInterval(testPollInterval))
+			require.NoError(t, err, "Finalizer should be removed when PolicyServer is deleted")
+
+			// Verify policy status transitioned to scheduled
+			var policy policiesv1.ClusterAdmissionPolicy
+			err = cfg.Client().Resources().Get(ctx, policyName, "", &policy)
+			require.NoError(t, err)
+			require.Equal(t, policiesv1.PolicyStatusScheduled, policy.Status.PolicyStatus,
+				"Policy should be scheduled after PolicyServer deletion")
+
+			return ctx
+		}).
+		Assess("should remove old finalizer from upgrade scenario", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// Create a new PolicyServer for the upgrade test
+			upgradePSName := policiesv1.NewPolicyServerFactory().Build().Name
+			upgradePolicyName := policiesv1.NewPolicyServerFactory().Build().Name
+
+			policyServer := policiesv1.NewPolicyServerFactory().
+				WithName(upgradePSName).
+				Build()
+			err := createPolicyServerAndWaitForItsService(ctx, cfg, policyServer)
+			require.NoError(t, err)
+
+			// Create policy with BOTH old and new finalizers (simulating upgrade from pre-1.14)
+			policy := policiesv1.NewClusterAdmissionPolicyFactory().
+				WithName(upgradePolicyName).
+				WithPolicyServer(upgradePSName).
+				Build()
+
+			// Manually add both finalizers to simulate upgrade scenario
+			policy.SetFinalizers([]string{constants.KubewardenFinalizer, constants.KubewardenFinalizerPre114})
+			err = cfg.Client().Resources().Create(ctx, policy)
+			require.NoError(t, err)
+
+			// Wait for policy to become active
+			err = wait.For(conditions.New(cfg.Client().Resources()).ResourceMatch(
+				&policiesv1.ClusterAdmissionPolicy{ObjectMeta: metav1.ObjectMeta{Name: upgradePolicyName}},
+				func(object k8s.Object) bool {
+					p := object.(*policiesv1.ClusterAdmissionPolicy)
+					return p.Status.PolicyStatus == policiesv1.PolicyStatusActive
+				},
+			), wait.WithTimeout(testTimeout), wait.WithInterval(testPollInterval))
+			require.NoError(t, err)
+
+			// Delete the PolicyServer
+			err = cfg.Client().Resources().Delete(ctx, &policiesv1.PolicyServer{
+				ObjectMeta: metav1.ObjectMeta{Name: upgradePSName, Namespace: namespace},
+			})
+			require.NoError(t, err)
+
+			// Verify BOTH finalizers are removed (backward compatibility)
+			err = wait.For(conditions.New(cfg.Client().Resources()).ResourceMatch(
+				&policiesv1.ClusterAdmissionPolicy{ObjectMeta: metav1.ObjectMeta{Name: upgradePolicyName}},
+				func(object k8s.Object) bool {
+					p := object.(*policiesv1.ClusterAdmissionPolicy)
+					return !containsFinalizer(p.GetFinalizers(), constants.KubewardenFinalizer) &&
+						!containsFinalizer(p.GetFinalizers(), constants.KubewardenFinalizerPre114)
+				},
+			), wait.WithTimeout(testTimeout), wait.WithInterval(testPollInterval))
+			require.NoError(t, err, "Both old and new finalizers should be removed (upgrade scenario)")
+
+			// Cleanup
+			_ = cfg.Client().Resources().Delete(ctx, &policiesv1.ClusterAdmissionPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: upgradePolicyName},
+			})
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			policyName := ctx.Value(policyNameKey).(string)
+
+			// Cleanup policy
+			policy := &policiesv1.ClusterAdmissionPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: policyName},
+			}
+			_ = cfg.Client().Resources().Delete(ctx, policy)
+
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, timeoutValidationFeature, validatingFeature, mutatingFeature, scheduledFeature, policyServerDeletionFeature)
 }

--- a/e2e/clusteradmissionpolicy_test.go
+++ b/e2e/clusteradmissionpolicy_test.go
@@ -265,12 +265,18 @@ func TestClusterAdmissionPolicyController(t *testing.T) {
 			policy := ctx.Value(policyKey).(*policiesv1.ClusterAdmissionPolicy)
 			webhookName := policy.GetUniqueName()
 
+			// Fetch the latest policy state from the API. The object stored in
+			// context was captured before the controller added the finalizer.
+			var latestPolicy policiesv1.ClusterAdmissionPolicy
+			err := cfg.Client().Resources().Get(ctx, policy.GetName(), "", &latestPolicy)
+			require.NoError(t, err)
+
 			// Verify policy has finalizer before deletion
-			require.True(t, containsFinalizer(policy.GetFinalizers(), constants.KubewardenFinalizer),
+			require.True(t, containsFinalizer(latestPolicy.GetFinalizers(), constants.KubewardenFinalizer),
 				"Policy should have finalizer before deletion")
 
 			// Delete the policy
-			err := cfg.Client().Resources().Delete(ctx, policy)
+			err = cfg.Client().Resources().Delete(ctx, &latestPolicy)
 			require.NoError(t, err)
 
 			// Wait for webhook to be deleted
@@ -461,12 +467,18 @@ func TestClusterAdmissionPolicyController(t *testing.T) {
 			policy := ctx.Value(policyKey).(*policiesv1.ClusterAdmissionPolicy)
 			webhookName := policy.GetUniqueName()
 
+			// Fetch the latest policy state from the API. The object stored in
+			// context was captured before the controller added the finalizer.
+			var latestPolicy policiesv1.ClusterAdmissionPolicy
+			err := cfg.Client().Resources().Get(ctx, policy.GetName(), "", &latestPolicy)
+			require.NoError(t, err)
+
 			// Verify policy has finalizer before deletion
-			require.True(t, containsFinalizer(policy.GetFinalizers(), constants.KubewardenFinalizer),
+			require.True(t, containsFinalizer(latestPolicy.GetFinalizers(), constants.KubewardenFinalizer),
 				"Policy should have finalizer before deletion")
 
 			// Delete the policy
-			err := cfg.Client().Resources().Delete(ctx, policy)
+			err = cfg.Client().Resources().Delete(ctx, &latestPolicy)
 			require.NoError(t, err)
 
 			// Wait for webhook to be deleted

--- a/e2e/clusteradmissionpolicy_test.go
+++ b/e2e/clusteradmissionpolicy_test.go
@@ -622,22 +622,19 @@ func TestClusterAdmissionPolicyController(t *testing.T) {
 			err := cfg.Client().Resources().Delete(ctx, policyServer)
 			require.NoError(t, err)
 
-			// Verify finalizer is removed from policy
+			// Verify finalizer is removed from policy and status transitioned
+			// to Scheduled. The finalizer removal (metadata Update) and the
+			// status transition are separate API writes, so we must wait for
+			// both to converge before asserting.
 			err = wait.For(conditions.New(cfg.Client().Resources()).ResourceMatch(
 				&policiesv1.ClusterAdmissionPolicy{ObjectMeta: metav1.ObjectMeta{Name: policyName}},
 				func(object k8s.Object) bool {
 					p := object.(*policiesv1.ClusterAdmissionPolicy)
-					return !containsFinalizer(p.GetFinalizers(), constants.KubewardenFinalizer)
+					return !containsFinalizer(p.GetFinalizers(), constants.KubewardenFinalizer) &&
+						p.Status.PolicyStatus == policiesv1.PolicyStatusScheduled
 				},
 			), wait.WithTimeout(testTimeout), wait.WithInterval(testPollInterval))
-			require.NoError(t, err, "Finalizer should be removed when PolicyServer is deleted")
-
-			// Verify policy status transitioned to scheduled
-			var policy policiesv1.ClusterAdmissionPolicy
-			err = cfg.Client().Resources().Get(ctx, policyName, "", &policy)
-			require.NoError(t, err)
-			require.Equal(t, policiesv1.PolicyStatusScheduled, policy.Status.PolicyStatus,
-				"Policy should be scheduled after PolicyServer deletion")
+			require.NoError(t, err, "Finalizer should be removed and policy should be Scheduled after PolicyServer deletion")
 
 			return ctx
 		}).

--- a/e2e/clusteradmissionpolicy_test.go
+++ b/e2e/clusteradmissionpolicy_test.go
@@ -279,11 +279,6 @@ func TestClusterAdmissionPolicyController(t *testing.T) {
 			), wait.WithTimeout(testTimeout), wait.WithInterval(testPollInterval))
 			require.NoError(t, err, "ValidatingWebhookConfiguration should be deleted")
 
-			// Wait for policy to be deleted (finalizer removed)
-			err = wait.For(conditions.New(cfg.Client().Resources()).ResourceDeleted(policy),
-				wait.WithTimeout(testTimeout), wait.WithInterval(testPollInterval))
-			require.NoError(t, err, "Policy should be deleted (finalizer removed)")
-
 			return ctx
 		}).
 		Feature()
@@ -479,11 +474,6 @@ func TestClusterAdmissionPolicyController(t *testing.T) {
 				&admissionregistrationv1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: webhookName}},
 			), wait.WithTimeout(testTimeout), wait.WithInterval(testPollInterval))
 			require.NoError(t, err, "MutatingWebhookConfiguration should be deleted")
-
-			// Wait for policy to be deleted (finalizer removed)
-			err = wait.For(conditions.New(cfg.Client().Resources()).ResourceDeleted(policy),
-				wait.WithTimeout(testTimeout), wait.WithInterval(testPollInterval))
-			require.NoError(t, err, "Policy should be deleted (finalizer removed)")
 
 			return ctx
 		}).

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"slices"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -93,4 +94,9 @@ func verifyWebhookMetadata(labels, annotations map[string]string, policyName, po
 		return false
 	}
 	return true
+}
+
+// containsFinalizer checks if a finalizer exists in the finalizers list.
+func containsFinalizer(finalizers []string, finalizer string) bool {
+	return slices.Contains(finalizers, finalizer)
 }

--- a/internal/controller/policy_subreconciler.go
+++ b/internal/controller/policy_subreconciler.go
@@ -132,6 +132,14 @@ func (r *policySubReconciler) reconcilePolicy(ctx context.Context, policy polici
 		return ctrl.Result{}, errors.Join(errors.New("cannot find policy server secret"), err)
 	}
 
+	// Add the controller's finalizer here to avoid webhook orphans
+	if !controllerutil.ContainsFinalizer(policy, constants.KubewardenFinalizer) {
+		controllerutil.AddFinalizer(policy, constants.KubewardenFinalizer)
+		if err = r.Update(ctx, policy); err != nil {
+			return ctrl.Result{}, fmt.Errorf("cannot add finalizer to policy: %w", err)
+		}
+	}
+
 	if err = r.reconcileWebhookConfiguration(ctx, policy, &secret, policyServer.NameWithPrefix()); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -148,7 +156,16 @@ func (r *policySubReconciler) reconcilePolicyServerUnavailable(ctx context.Conte
 	if err := r.deleteWebhookConfiguration(ctx, policy); err != nil {
 		return ctrl.Result{}, err
 	}
+
+	// The webhook is gone and the policy server is being deleted. We can remove
+	// the policy finalizer
+	controllerutil.RemoveFinalizer(policy, constants.KubewardenFinalizer)
+	controllerutil.RemoveFinalizer(policy, constants.KubewardenFinalizerPre114)
+	if err := r.Update(ctx, policy); err != nil {
+		return ctrl.Result{}, fmt.Errorf("cannot update policy: %w", err)
+	}
 	policy.SetStatus(policiesv1.PolicyStatusScheduled)
+
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/policy_subreconciler.go
+++ b/internal/controller/policy_subreconciler.go
@@ -48,7 +48,7 @@ type policySubReconciler struct {
 
 func (r *policySubReconciler) reconcile(ctx context.Context, policy policiesv1.Policy) (ctrl.Result, error) {
 	if policy.GetDeletionTimestamp() != nil {
-		return r.reconcilePolicyDeletion(ctx, policy)
+		return ctrl.Result{}, r.removePolicyWebhooksAndFinalizers(ctx, policy)
 	}
 
 	reconcileResult, reconcileErr := r.reconcilePolicy(ctx, policy)
@@ -153,17 +153,10 @@ func (r *policySubReconciler) reconcilePolicy(ctx context.Context, policy polici
 // It removes the webhook configuration to prevent orphaned webhooks from blocking
 // admission requests, then sets the policy status as scheduled.
 func (r *policySubReconciler) reconcilePolicyServerUnavailable(ctx context.Context, policy policiesv1.Policy) (ctrl.Result, error) {
-	if err := r.deleteWebhookConfiguration(ctx, policy); err != nil {
+	if err := r.removePolicyWebhooksAndFinalizers(ctx, policy); err != nil {
 		return ctrl.Result{}, err
 	}
 
-	// The webhook is gone and the policy server is being deleted. We can remove
-	// the policy finalizer
-	controllerutil.RemoveFinalizer(policy, constants.KubewardenFinalizer)
-	controllerutil.RemoveFinalizer(policy, constants.KubewardenFinalizerPre114)
-	if err := r.Update(ctx, policy); err != nil {
-		return ctrl.Result{}, fmt.Errorf("cannot update policy: %w", err)
-	}
 	policy.SetStatus(policiesv1.PolicyStatusScheduled)
 
 	return ctrl.Result{}, nil
@@ -193,21 +186,36 @@ func (r *policySubReconciler) deleteWebhookConfiguration(ctx context.Context, po
 	return r.reconcileValidatingWebhookConfigurationDeletion(ctx, policy)
 }
 
-func (r *policySubReconciler) reconcilePolicyDeletion(ctx context.Context, policy policiesv1.Policy) (ctrl.Result, error) {
+// removePolicyWebhooksAndFinalizers removes the webhook configurations, which
+// means that the policy can be safely deleted. Therefore, it also removes the
+// policy finalizers.
+func (r *policySubReconciler) removePolicyWebhooksAndFinalizers(ctx context.Context, policy policiesv1.Policy) error {
 	if err := r.deleteWebhookConfiguration(ctx, policy); err != nil {
-		return ctrl.Result{}, err
-	}
-	// Remove the old finalizer used to ensure that the policy server created
-	// before this controller version is delete as well. As the upgrade path
-	// supported by the Kubewarden project does not allow jumping versions, we
-	// can safely remove this line of code after a few releases.
-	controllerutil.RemoveFinalizer(policy, constants.KubewardenFinalizerPre114)
-	controllerutil.RemoveFinalizer(policy, constants.KubewardenFinalizer)
-	if err := r.Update(ctx, policy); err != nil {
-		return ctrl.Result{}, fmt.Errorf("cannot update admission policy: %w", err)
+		return err
 	}
 
-	return ctrl.Result{}, nil
+	finalizerRemoved := false
+	if controllerutil.ContainsFinalizer(policy, constants.KubewardenFinalizer) {
+		controllerutil.RemoveFinalizer(policy, constants.KubewardenFinalizer)
+		finalizerRemoved = true
+	}
+	// Remove the old finalizer used to ensure that the policy server created
+	// before this controller version is deleted as well.
+	// TODO:
+	// As the upgrade path supported by the Kubewarden project does not
+	// allow jumping versions, we can safely remove this line of code after a few
+	// releases.
+	if controllerutil.ContainsFinalizer(policy, constants.KubewardenFinalizerPre114) {
+		controllerutil.RemoveFinalizer(policy, constants.KubewardenFinalizerPre114)
+		finalizerRemoved = true
+	}
+	if finalizerRemoved {
+		if err := r.Update(ctx, policy); err != nil {
+			return fmt.Errorf("cannot update policy: %w", err)
+		}
+	}
+
+	return nil
 }
 
 func (r *policySubReconciler) setPolicyModeStatus(ctx context.Context, policy policiesv1.Policy) error {


### PR DESCRIPTION
## Description

This changes the controller reconciliation loop to ensure that the finalizer used by the controller will be added in the policy resource only when it is in active state. Therefore, after the `kubewarden-controller` uninstall, the policies can be removed with no issues.

In other words, when the policy is in:
- `Scheduled` status: no Finalizer (new), no {Validating,Mutating}WebhookConfiguration. Can be safely deleted. Will be garbage-collected if the CRD is removed.
- `Active` status: has an associated {Validating,Mutating}WebhookConfiguration, must not be garbage-collected away or we break the cluster. Therefore, it also has a Finalizer (as it already had prior to this change).

### Tests

Beyond the e2e tests,I have a bash script that simulate helm charts uninstall to see if this is working as expected:

<details>
<summary>Click to see the testing script</summary>

```bash
#!/bin/bash
set -e

# Colors for output
RED='\033[0;31m'
GREEN='\033[0;32m'
YELLOW='\033[1;33m'
BLUE='\033[0;34m'
NC='\033[0m' # No Color

log() {
    echo -e "${BLUE}==>${NC} $1"
}

success() {
    echo -e "${GREEN}✓${NC} $1"
}

error() {
    echo -e "${RED}✗${NC} $1"
}

warn() {
    echo -e "${YELLOW}!${NC} $1"
}

# Configuration
CLUSTER_NAME="${CLUSTER_NAME:-kubewarden-test}"
NAMESPACE="${NAMESPACE:-kubewarden}"
CONTROLLER_IMAGE="ghcr.io/kubewarden/adm-controller/controller:dev"
AUDIT_SCANNER_IMAGE="ghcr.io/kubewarden/adm-controller/audit-scanner:dev"
POLICY_SERVER_IMAGE="ghcr.io/kubewarden/adm-controller/policy-server:dev"

# Check if cluster exists
if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
    warn "Cluster ${CLUSTER_NAME} already exists"
    read -p "Delete and recreate? (y/N) " -n 1 -r
    echo
    if [[ $REPLY =~ ^[Yy]$ ]]; then
        log "Deleting existing cluster..."
        kind delete cluster --name "${CLUSTER_NAME}"
    else
        log "Using existing cluster"
        REUSE_CLUSTER=true
    fi
fi

# Create cluster if needed
if [[ "$REUSE_CLUSTER" != "true" ]]; then
    log "Creating kind cluster: ${CLUSTER_NAME}"
    kind create cluster --name "${CLUSTER_NAME}"
    success "Cluster created"
fi

# Set kubectl context
kubectl config use-context "kind-${CLUSTER_NAME}"

# Load images into cluster
log "Loading images into kind cluster..."
kind load docker-image "${CONTROLLER_IMAGE}" --name "${CLUSTER_NAME}"
kind load docker-image "${AUDIT_SCANNER_IMAGE}" --name "${CLUSTER_NAME}"
kind load docker-image "${POLICY_SERVER_IMAGE}" --name "${CLUSTER_NAME}"
success "Images loaded"

# Create namespace
log "Creating namespace: ${NAMESPACE}"
kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
kubectl label namespace "${NAMESPACE}" \
    pod-security.kubernetes.io/enforce=restricted \
    pod-security.kubernetes.io/enforce-version=latest \
    --overwrite

# Install CRDs chart
log "Installing kubewarden-crds chart..."
helm upgrade --install kubewarden-crds \
    ./charts/kubewarden-crds \
    --namespace "${NAMESPACE}" \
    --wait
success "kubewarden-crds installed"

# Install controller chart
log "Installing kubewarden-controller chart..."
helm upgrade --install kubewarden-controller \
    ./charts/kubewarden-controller \
    --namespace "${NAMESPACE}" \
    --set image.tag=dev \
    --set auditScanner.image.tag=dev \
    --set logLevel=debug \
    --wait \
    --timeout 5m
success "kubewarden-controller installed"

# Wait for controller to be ready
log "Waiting for controller deployment..."
kubectl wait --for=condition=available --timeout=300s \
    deployment/kubewarden-controller -n "${NAMESPACE}"
success "Controller is ready"

# Create a PolicyServer
log "Creating PolicyServer..."
cat <<EOF | kubectl apply -f -
apiVersion: policies.kubewarden.io/v1
kind: PolicyServer
metadata:
  name: default
  namespace: ${NAMESPACE}
spec:
  image: ${POLICY_SERVER_IMAGE}
  replicas: 1
  serviceAccountName: kubewarden-controller
EOF

# Wait for PolicyServer deployment
log "Waiting for PolicyServer deployment..."
kubectl wait --for=condition=available --timeout=300s \
    deployment/policy-server-default -n "${NAMESPACE}" 2>/dev/null || true
success "PolicyServer deployed"

# Create a sample ClusterAdmissionPolicy
log "Creating sample ClusterAdmissionPolicy..."
cat <<EOF | kubectl apply -f -
apiVersion: policies.kubewarden.io/v1
kind: ClusterAdmissionPolicy
metadata:
  name: privileged-pods
spec:
  module: registry://ghcr.io/kubewarden/policies/pod-privileged:v0.2.5
  rules:
    - apiGroups: [""]
      apiVersions: ["v1"]
      resources: ["pods"]
      operations: ["CREATE", "UPDATE"]
  mutating: false
  policyServer: default
EOF
success "Policy created"

# Show initial state
echo ""
log "Initial state:"
echo ""

echo -e "${BLUE}Policies:${NC}"
kubectl get clusteradmissionpolicies -o custom-columns=\
NAME:.metadata.name,\
STATUS:.status.policyStatus,\
FINALIZERS:.metadata.finalizers

echo ""
echo -e "${BLUE}PolicyServers:${NC}"
kubectl get policyservers -n "${NAMESPACE}"

echo ""
echo -e "${BLUE}ValidatingWebhookConfigurations:${NC}"
kubectl get validatingwebhookconfigurations -l app.kubernetes.io/part-of=kubewarden

echo ""
warn "Press Enter to uninstall kubewarden-controller chart..."
read

# Uninstall controller chart
log "Uninstalling kubewarden-controller chart..."
helm uninstall kubewarden-controller -n "${NAMESPACE}" --wait --timeout 2m
success "kubewarden-controller uninstalled"

# Check policy state after controller uninstall
echo ""
log "State after controller uninstall:"
echo ""

echo -e "${BLUE}Policies (checking finalizers):${NC}"
POLICIES=$(kubectl get clusteradmissionpolicies -o json)
if echo "$POLICIES" | jq -e '.items | length > 0' >/dev/null 2>&1; then
    echo "$POLICIES" | jq -r '.items[] |
        "\(.metadata.name):
          Status: \(.status.policyStatus // "unknown")
          Finalizers: \(.metadata.finalizers // [] | join(", ") | if . == "" then "NONE" else . end)"'

    # Check if any policies have finalizers
    HAS_FINALIZERS=$(echo "$POLICIES" | jq -r '.items[] | select(.metadata.finalizers != null and (.metadata.finalizers | length > 0)) | .metadata.name')
    if [ -z "$HAS_FINALIZERS" ]; then
        success "No policies have finalizers (expected behavior)"
    else
        error "Policies still have finalizers:"
        echo "$HAS_FINALIZERS"
    fi
else
    warn "No policies found"
fi

echo ""
echo -e "${BLUE}ValidatingWebhookConfigurations:${NC}"
WEBHOOKS=$(kubectl get validatingwebhookconfigurations -l app.kubernetes.io/part-of=kubewarden --no-headers 2>/dev/null | wc -l)
if [ "$WEBHOOKS" -eq 0 ]; then
    success "No webhooks remaining (expected behavior)"
else
    error "Webhooks still exist:"
    kubectl get validatingwebhookconfigurations -l app.kubernetes.io/part-of=kubewarden
fi

echo ""
warn "Press Enter to uninstall kubewarden-crds chart (this should NOT hang)..."
read

# Uninstall CRDs chart (this should complete quickly)
log "Uninstalling kubewarden-crds chart..."
START_TIME=$(date +%s)
if timeout 10s helm uninstall kubewarden-crds -n "${NAMESPACE}" --wait; then
    END_TIME=$(date +%s)
    DURATION=$((END_TIME - START_TIME))
    success "kubewarden-crds uninstalled in ${DURATION} seconds (expected: < 5s)"
else
    error "CRD uninstall timed out or failed (indicates finalizer blocking)"
fi

# Verify policies are deleted
echo ""
REMAINING_POLICIES=$(kubectl get clusteradmissionpolicies --no-headers 2>/dev/null | wc -l)
if [ "$REMAINING_POLICIES" -eq 0 ]; then
    success "All policies deleted"
else
    error "${REMAINING_POLICIES} policies still remain"
    kubectl get clusteradmissionpolicies
fi

echo ""
log "Test complete!"
echo ""
echo -e "${GREEN}Summary:${NC}"
echo "  - Controller chart uninstalled successfully"
echo "  - Policies should have NO finalizers after controller uninstall"
echo "  - Webhooks should be removed"
echo "  - CRD chart uninstall should complete in < 5 seconds"

echo ""
warn "Keep cluster for inspection? (y/N)"
read -n 1 -r
echo
if [[ ! $REPLY =~ ^[Yy]$ ]]; then
    log "Deleting cluster..."
    kind delete cluster --name "${CLUSTER_NAME}"
    success "Cluster deleted"
else
    echo ""
    echo -e "${BLUE}Cluster preserved. To inspect:${NC}"
    echo "  kubectl config use-context kind-${CLUSTER_NAME}"
    echo ""
    echo -e "${BLUE}To delete later:${NC}"
    echo "  kind delete cluster --name ${CLUSTER_NAME}"
fi
```


</details>
