### PR TITLE
feat: Asciidoc CLI reference documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,24 +441,6 @@ jobs:
       - name: Run validation script
         run: ./scripts/validate-hauler-manifest.sh
 
-  kwctl-docs:
-    name: Check if the kwctl reference documentation is up to date
-    needs: changes
-    if: needs.changes.outputs.rust == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-
-      - run: |
-          make -C crates/kwctl build-docs
-          if ! git diff --quiet crates/kwctl/cli-docs.md; then
-            echo "Changes detected in cli-docs.md. Please run `make -C crates/kwctl build-docs` and commit the changes."
-            gh run cancel ${{ github.run_id }}
-          fi
-
   check-kwctl-cross-platform:
     name: Check kwctl (${{ matrix.os }})
     needs: changes
@@ -516,7 +498,6 @@ jobs:
       - spelling
       - charts
       - validate-hauler-manifest
-      - kwctl-docs
       - check-kwctl-cross-platform
       - check-generated-code
     runs-on: ubuntu-latest

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,6 +18,7 @@ jobs:
     name: zizmor
     runs-on: ubuntu-latest
     permissions:
+      security-events: write
       contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,9 +958,8 @@ dependencies = [
 
 [[package]]
 name = "clap-markdown"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2a2617956a06d4885b490697b5307ebb09fec10b088afc18c81762d848c2339"
+version = "0.2.0"
+source = "git+https://github.com/jvanz/clap-markdown?rev=2f4dcb0e131db8d1d1c786e1c91adfc2ec2c9480#2f4dcb0e131db8d1d1c786e1c91adfc2ec2c9480"
 dependencies = [
  "clap",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,9 +957,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap-markdown"
-version = "0.2.0"
-source = "git+https://github.com/jvanz/clap-markdown?rev=2f4dcb0e131db8d1d1c786e1c91adfc2ec2c9480#2f4dcb0e131db8d1d1c786e1c91adfc2ec2c9480"
+name = "clap-documentation"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7ae1e9d21ecf24ca8403c144408061db065bf98350ede6e77e7050eaf5c8b53"
 dependencies = [
  "clap",
 ]
@@ -3602,7 +3603,7 @@ dependencies = [
  "assert_cmd",
  "backon",
  "clap",
- "clap-markdown",
+ "clap-documentation",
  "clap_complete",
  "color-print",
  "directories",
@@ -4843,7 +4844,7 @@ dependencies = [
  "axum-server",
  "backon",
  "clap",
- "clap-markdown",
+ "clap-documentation",
  "daemonize",
  "futures",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,9 @@ resolver = "2"
 [workspace.dependencies]
 anyhow = "1.0"
 base64 = "0.22"
-clap = { version = "4.5", features = ["cargo", "env"] }
-clap-markdown = "0.1.5"
+clap   = { version = "4.5", features = ["cargo", "env"] }
+# Customized crate that generate CLI reference documentation in Asciidoc format
+clap-markdown = { git = "https://github.com/jvanz/clap-markdown", rev = "2f4dcb0e131db8d1d1c786e1c91adfc2ec2c9480" }
 futures = "0.3"
 hex = "0.4"
 itertools = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ anyhow = "1.0"
 base64 = "0.22"
 clap   = { version = "4.5", features = ["cargo", "env"] }
 # Customized crate that generate CLI reference documentation in Asciidoc format
-clap-markdown = { git = "https://github.com/jvanz/clap-markdown", rev = "2f4dcb0e131db8d1d1c786e1c91adfc2ec2c9480" }
+clap-documentation = "0.1.0"
 futures = "0.3"
 hex = "0.4"
 itertools = "0.14.0"

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ kwctl: $(KWCTL_SRCS) lint-rust
 	cp ./target/$(RUST_TARGET)/release/kwctl ./bin/kwctl
 
 .PHONY: generate
-generate: generate-controller generate-chart generate-crd-docs generate-kwctl-cli-docs
+generate: generate-controller generate-chart generate-crd-docs generate-kwctl-cli-docs generate-policyserver-cli-docs
 
 .PHONY: generate-controller
 generate-controller: manifests  ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
@@ -156,6 +156,10 @@ generate-crd-docs:
 .PHONY: generate-kwctl-cli-docs
 generate-kwctl-cli-docs:
 	$(MAKE) -C crates/kwctl build-docs
+	
+.PHONY: generate-policyserver-cli-docs
+generate-policyserver-cli-docs:
+	$(MAKE) -C crates/policy-server build-docs
 
 .PHONY: manifests
 manifests: ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.

--- a/crates/kwctl/Cargo.toml
+++ b/crates/kwctl/Cargo.toml
@@ -10,7 +10,7 @@ version     = "1.36.0"
 [dependencies]
 anyhow             = { workspace = true }
 clap               = { workspace = true }
-clap-markdown      = { workspace = true }
+clap-documentation = { workspace = true }
 clap_complete      = "4.5"
 color-print        = "0.3"
 directories        = "6.0.0"

--- a/crates/kwctl/Makefile
+++ b/crates/kwctl/Makefile
@@ -7,7 +7,7 @@ build-release:
 
 .PHONY:build-docs
 build-docs:
-	cargo run --release -- docs --output cli-docs.md
+	cargo run --release -- docs --output cli-docs.adoc
 
 .PHONY: fmt
 fmt:

--- a/crates/kwctl/cli-docs.adoc
+++ b/crates/kwctl/cli-docs.adoc
@@ -1,45 +1,46 @@
-# Command-Line Help for `kwctl`
+= Command-Line Help for `kwctl`
 
 This document contains the help content for the `kwctl` command-line program.
 
-**Command Overview:**
+*Command Overview:*
 
-* [`kwctl`↴](#kwctl)
-* [`kwctl annotate`↴](#kwctl-annotate)
-* [`kwctl bench`↴](#kwctl-bench)
-* [`kwctl completions`↴](#kwctl-completions)
-* [`kwctl digest`↴](#kwctl-digest)
-* [`kwctl docs`↴](#kwctl-docs)
-* [`kwctl info`↴](#kwctl-info)
-* [`kwctl inspect`↴](#kwctl-inspect)
-* [`kwctl load`↴](#kwctl-load)
-* [`kwctl policies`↴](#kwctl-policies)
-* [`kwctl pull`↴](#kwctl-pull)
-* [`kwctl push`↴](#kwctl-push)
-* [`kwctl rm`↴](#kwctl-rm)
-* [`kwctl run`↴](#kwctl-run)
-* [`kwctl save`↴](#kwctl-save)
-* [`kwctl scaffold`↴](#kwctl-scaffold)
-* [`kwctl scaffold admission-request`↴](#kwctl-scaffold-admission-request)
-* [`kwctl scaffold artifacthub`↴](#kwctl-scaffold-artifacthub)
-* [`kwctl scaffold manifest`↴](#kwctl-scaffold-manifest)
-* [`kwctl scaffold vap`↴](#kwctl-scaffold-vap)
-* [`kwctl scaffold verification-config`↴](#kwctl-scaffold-verification-config)
-* [`kwctl verify`↴](#kwctl-verify)
+* <<kwctl,`kwctl`>>
+* <<kwctl-annotate,`kwctl annotate`>>
+* <<kwctl-bench,`kwctl bench`>>
+* <<kwctl-completions,`kwctl completions`>>
+* <<kwctl-digest,`kwctl digest`>>
+* <<kwctl-docs,`kwctl docs`>>
+* <<kwctl-info,`kwctl info`>>
+* <<kwctl-inspect,`kwctl inspect`>>
+* <<kwctl-load,`kwctl load`>>
+* <<kwctl-policies,`kwctl policies`>>
+* <<kwctl-pull,`kwctl pull`>>
+* <<kwctl-push,`kwctl push`>>
+* <<kwctl-rm,`kwctl rm`>>
+* <<kwctl-run,`kwctl run`>>
+* <<kwctl-save,`kwctl save`>>
+* <<kwctl-scaffold,`kwctl scaffold`>>
+* <<kwctl-scaffold-admission-request,`kwctl scaffold admission-request`>>
+* <<kwctl-scaffold-artifacthub,`kwctl scaffold artifacthub`>>
+* <<kwctl-scaffold-manifest,`kwctl scaffold manifest`>>
+* <<kwctl-scaffold-vap,`kwctl scaffold vap`>>
+* <<kwctl-scaffold-verification-config,`kwctl scaffold verification-config`>>
+* <<kwctl-verify,`kwctl verify`>>
 
-## `kwctl`
+[[kwctl]]
+== `kwctl`
 
 Tool to manage Kubewarden policies
 
-**Usage:** `kwctl [OPTIONS] <COMMAND>`
+*Usage:* `kwctl [OPTIONS] <COMMAND>`
 
-###### **Subcommands:**
+=== *Subcommands:*
 
 * `annotate` — Add Kubewarden metadata to a WebAssembly module
 * `bench` — Benchmarks a Kubewarden policy
 * `completions` — Generate shell completions
 * `digest` — Fetch digest from the OCI manifest of a policy
-* `docs` — Generates the markdown documentation for kwctl commands
+* `docs` — Generates the AsciiDoc documentation for kwctl commands
 * `info` — Display system information
 * `inspect` — Inspect Kubewarden policy
 * `load` — load policies from a tar.gz file
@@ -52,24 +53,25 @@ Tool to manage Kubewarden policies
 * `scaffold` — Scaffold a Kubernetes resource or configuration file
 * `verify` — Verify a Kubewarden policy from a given URI using Sigstore
 
-###### **Options:**
+=== *Options:*
 
 * `-v`, `--verbose <VERBOSE>` — Increase verbosity
 * `--no-color <NO-COLOR>` — Disable colorful output
 
 
 
-## `kwctl annotate`
+[[kwctl-annotate]]
+== `kwctl annotate`
 
 Add Kubewarden metadata to a WebAssembly module
 
-**Usage:** `kwctl annotate [OPTIONS] --metadata-path <PATH> --output-path <PATH> <wasm-path>`
+*Usage:* `kwctl annotate [OPTIONS] --metadata-path <PATH> --output-path <PATH> <wasm-path>`
 
-###### **Arguments:**
+=== *Arguments:*
 
 * `<WASM-PATH>` — Path to WebAssembly module to be annotated
 
-###### **Options:**
+=== *Options:*
 
 * `-m`, `--metadata-path <PATH>` — File containing the metadata
 * `-o`, `--output-path <PATH>` — Output file
@@ -77,7 +79,8 @@ Add Kubewarden metadata to a WebAssembly module
 
 
 
-## `kwctl bench`
+[[kwctl-bench]]
+== `kwctl bench`
 
 Benchmarks a Kubewarden policy.
 
@@ -106,26 +109,26 @@ A YAML file may contain multiple Custom Resource declarations. In this case, `kw
 each policy in the file using the same request during each evaluation.
 
 
-**Usage:** `kwctl bench [OPTIONS] --request-path <PATH> <uri_or_sha_prefix_or_yaml_file>`
+*Usage:* `kwctl bench [OPTIONS] --request-path <PATH> <uri_or_sha_prefix_or_yaml_file>`
 
-###### **Arguments:**
+=== *Arguments:*
 
 * `<URI_OR_SHA_PREFIX_OR_YAML_FILE>` — Policy URI, SHA prefix or YAML file containing Kubewarden policy resources. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.
 
-###### **Options:**
+=== *Options:*
 
 * `--allow-context-aware <ALLOW-CONTEXT-AWARE>` — Grant access to the Kubernetes resources defined inside of the policy's `contextAwareResources` section. Warning: review the list of resources carefully to avoid abuses. Disabled by default
 * `--allowed-host-capabilities <ALLOWED-HOST-CAPABILITIES>` — Host capabilities the policy is allowed to use. Use '*' to allow all. Can be repeated multiple times. Examples: 'oci/*', 'net/v1/dns_lookup_host'
-
-  Default value: `*`
++
+Default value: `*`
 * `--cert-email <VALUE>` — Expected email in Fulcio certificate
 * `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
 * `--disable-wasmtime-cache <DISABLE-WASMTIME-CACHE>` — Turn off usage of wasmtime cache
 * `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
 * `--dump-results-to-disk <DUMP_RESULTS_TO_DISK>` — Puts results in target/tiny-bench/label/.. if target can be found. used for comparing previous runs
 * `-e`, `--execution-mode <MODE>` — The runtime to use to execute this policy
-
-  Possible values: `opa`, `gatekeeper`, `kubewarden`, `wasi`
++
+Possible values: `opa`, `gatekeeper`, `kubewarden`, `wasi`
 
 * `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
 * `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
@@ -133,8 +136,8 @@ each policy in the file using the same request during each evaluation.
 * `--num-resamples <NUM>` — How many resamples should be done
 * `--num-samples <NUM>` — How many resamples should be done. Recommended at least 50, above 100 doesn't seem to yield a significantly different result
 * `--raw <RAW>` — Validate a raw request
-
-  Default value: `false`
++
+Default value: `false`
 * `--record-host-capabilities-interactions <FILE>` — Record all the policy and host capabilities
    communications to the given file.
    Useful to be combined later with '--replay-host-capabilities-interactions' flag
@@ -154,116 +157,124 @@ each policy in the file using the same request during each evaluation.
 
 
 
-## `kwctl completions`
+[[kwctl-completions]]
+== `kwctl completions`
 
 Generate shell completions
 
-**Usage:** `kwctl completions --shell <VALUE>`
+*Usage:* `kwctl completions --shell <VALUE>`
 
-###### **Options:**
+=== *Options:*
 
 * `-s`, `--shell <VALUE>` — Shell type
-
-  Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
-
-
++
+Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
 
 
-## `kwctl digest`
+
+
+[[kwctl-digest]]
+== `kwctl digest`
 
 Fetch digest from the OCI manifest of a policy
 
-**Usage:** `kwctl digest [OPTIONS] <uri>`
+*Usage:* `kwctl digest [OPTIONS] <uri>`
 
-###### **Arguments:**
+=== *Arguments:*
 
 * `<URI>` — Policy URI
 
-###### **Options:**
+=== *Options:*
 
 * `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
 * `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
 
 
 
-## `kwctl docs`
+[[kwctl-docs]]
+== `kwctl docs`
 
-Generates the markdown documentation for kwctl commands
+Generates the AsciiDoc documentation for kwctl commands
 
-**Usage:** `kwctl docs --output <FILE>`
+*Usage:* `kwctl docs --output <FILE>`
 
-###### **Options:**
+=== *Options:*
 
 * `-o`, `--output <FILE>` — path where the documentation file will be stored
 
 
 
-## `kwctl info`
+[[kwctl-info]]
+== `kwctl info`
 
 Display system information
 
-**Usage:** `kwctl info`
+*Usage:* `kwctl info`
 
 
 
-## `kwctl inspect`
+[[kwctl-inspect]]
+== `kwctl inspect`
 
 Inspect Kubewarden policy
 
-**Usage:** `kwctl inspect [OPTIONS] <uri_or_sha_prefix>`
+*Usage:* `kwctl inspect [OPTIONS] <uri_or_sha_prefix>`
 
-###### **Arguments:**
+=== *Arguments:*
 
 * `<URI_OR_SHA_PREFIX>` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.
 
-###### **Options:**
+=== *Options:*
 
 * `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
 * `-o`, `--output <FORMAT>` — Output format
-
-  Possible values: `yaml`
++
+Possible values: `yaml`
 
 * `--show-signatures <SHOW-SIGNATURES>` — Show sigstore signatures
 * `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
 
 
 
-## `kwctl load`
+[[kwctl-load]]
+== `kwctl load`
 
 load policies from a tar.gz file
 
-**Usage:** `kwctl load --input <input>`
+*Usage:* `kwctl load --input <input>`
 
-###### **Options:**
+=== *Options:*
 
 * `--input <INPUT>` — load policies from tarball
 
 
 
-## `kwctl policies`
+[[kwctl-policies]]
+== `kwctl policies`
 
 Lists all downloaded policies
 
-**Usage:** `kwctl policies`
+*Usage:* `kwctl policies`
 
 
 
-## `kwctl pull`
+[[kwctl-pull]]
+== `kwctl pull`
 
 Pulls a Kubewarden policy from a given URI
 
-**Usage:** `kwctl pull [OPTIONS] <uri>`
+*Usage:* `kwctl pull [OPTIONS] <uri>`
 
 It respects standard proxy environment variables when downloading policies:
 - HTTP_PROXY or http_proxy: proxy server for HTTP requests
 - HTTPS_PROXY or https_proxy: proxy server for HTTPS requests
 - NO_PROXY or no_proxy: comma-separated list of hosts to exclude from proxying
 
-###### **Arguments:**
+=== *Arguments:*
 
 * `<URI>` — Policy URI. Supported schemes: registry://, https://, file://
 
-###### **Options:**
+=== *Options:*
 
 * `--cert-email <VALUE>` — Expected email in Fulcio certificate
 * `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
@@ -279,11 +290,12 @@ It respects standard proxy environment variables when downloading policies:
 
 
 
-## `kwctl push`
+[[kwctl-push]]
+== `kwctl push`
 
 Pushes a Kubewarden policy to an OCI registry
 
-**Usage:** `kwctl push [OPTIONS] <policy> <uri>`
+*Usage:* `kwctl push [OPTIONS] <policy> <uri>`
 
 The annotations found inside of policy's metadata are going to be part of the OCI manifest.
 The multi-line annotations are skipped because they are not compatible with the OCI specification.
@@ -295,38 +307,40 @@ It respects standard proxy environment variables when downloading policies:
 - HTTPS_PROXY or https_proxy: proxy server for HTTPS requests
 - NO_PROXY or no_proxy: comma-separated list of hosts to exclude from proxying
 
-###### **Arguments:**
+=== *Arguments:*
 
 * `<POLICY>` — Policy to push. Can be the path to a local file, a policy URI or the SHA prefix of a policy in the store.
 * `<URI>` — Policy URI. Supported schemes: registry://
 
-###### **Options:**
+=== *Options:*
 
 * `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
 * `-f`, `--force <FORCE>` — Push also a policy that is not annotated
 * `-o`, `--output <PATH>` — Output format
-
-  Default value: `text`
-
-  Possible values: `text`, `json`
++
+Default value: `text`
++
+Possible values: `text`, `json`
 
 * `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
 
 
 
-## `kwctl rm`
+[[kwctl-rm]]
+== `kwctl rm`
 
 Removes a Kubewarden policy from the store
 
-**Usage:** `kwctl rm <uri_or_sha_prefix>`
+*Usage:* `kwctl rm <uri_or_sha_prefix>`
 
-###### **Arguments:**
+=== *Arguments:*
 
 * `<URI_OR_SHA_PREFIX>` — Policy URI or SHA prefix
 
 
 
-## `kwctl run`
+[[kwctl-run]]
+== `kwctl run`
 
 Run one or more Kubewarden policies locally.
 
@@ -355,36 +369,36 @@ A YAML file may contain multiple Custom Resource declarations. In this case, `kw
 each policy in the file using the same request during each evaluation.
 
 
-**Usage:** `kwctl run [OPTIONS] --request-path <PATH> <uri_or_sha_prefix_or_yaml_file>`
+*Usage:* `kwctl run [OPTIONS] --request-path <PATH> <uri_or_sha_prefix_or_yaml_file>`
 
 It respects standard proxy environment variables when downloading policies:
 - HTTP_PROXY or http_proxy: proxy server for HTTP requests
 - HTTPS_PROXY or https_proxy: proxy server for HTTPS requests
 - NO_PROXY or no_proxy: comma-separated list of hosts to exclude from proxying
 
-###### **Arguments:**
+=== *Arguments:*
 
 * `<URI_OR_SHA_PREFIX_OR_YAML_FILE>` — Policy URI, SHA prefix or YAML file containing Kubewarden policy resources. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.
 
-###### **Options:**
+=== *Options:*
 
 * `--allow-context-aware <ALLOW-CONTEXT-AWARE>` — Grant access to the Kubernetes resources defined inside of the policy's `contextAwareResources` section. Warning: review the list of resources carefully to avoid abuses. Disabled by default
 * `--allowed-host-capabilities <ALLOWED-HOST-CAPABILITIES>` — Host capabilities the policy is allowed to use. Use '*' to allow all. Can be repeated multiple times. Examples: 'oci/*', 'net/v1/dns_lookup_host'
-
-  Default value: `*`
++
+Default value: `*`
 * `--cert-email <VALUE>` — Expected email in Fulcio certificate
 * `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
 * `--disable-wasmtime-cache <DISABLE-WASMTIME-CACHE>` — Turn off usage of wasmtime cache
 * `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
 * `-e`, `--execution-mode <MODE>` — The runtime to use to execute this policy
-
-  Possible values: `opa`, `gatekeeper`, `kubewarden`, `wasi`
++
+Possible values: `opa`, `gatekeeper`, `kubewarden`, `wasi`
 
 * `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
 * `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
 * `--raw <RAW>` — Validate a raw request
-
-  Default value: `false`
++
+Default value: `false`
 * `--record-host-capabilities-interactions <FILE>` — Record all the policy and host capabilities
    communications to the given file.
    Useful to be combined later with '--replay-host-capabilities-interactions' flag
@@ -403,29 +417,31 @@ It respects standard proxy environment variables when downloading policies:
 
 
 
-## `kwctl save`
+[[kwctl-save]]
+== `kwctl save`
 
 save policies to a tar.gz file
 
-**Usage:** `kwctl save --output <FILE> <policies>...`
+*Usage:* `kwctl save --output <FILE> <policies>...`
 
-###### **Arguments:**
+=== *Arguments:*
 
 * `<POLICIES>` — list of policies to save
 
-###### **Options:**
+=== *Options:*
 
 * `-o`, `--output <FILE>` — path where the file will be stored
 
 
 
-## `kwctl scaffold`
+[[kwctl-scaffold]]
+== `kwctl scaffold`
 
 Scaffold a Kubernetes resource or configuration file
 
-**Usage:** `kwctl scaffold <COMMAND>`
+*Usage:* `kwctl scaffold <COMMAND>`
 
-###### **Subcommands:**
+=== *Subcommands:*
 
 * `admission-request` — Scaffold an AdmissionRequest object
 * `artifacthub` — Output an artifacthub-pkg.yml file from a metadata.yml file
@@ -435,30 +451,32 @@ Scaffold a Kubernetes resource or configuration file
 
 
 
-## `kwctl scaffold admission-request`
+[[kwctl-scaffold-admission-request]]
+== `kwctl scaffold admission-request`
 
 Scaffold an AdmissionRequest object
 
-**Usage:** `kwctl scaffold admission-request [OPTIONS] --operation <TYPE>`
+*Usage:* `kwctl scaffold admission-request [OPTIONS] --operation <TYPE>`
 
-###### **Options:**
+=== *Options:*
 
 * `--object <PATH>` — The file containing the new object being admitted
 * `--old-object <PATH>` — The file containing the existing object
 * `-o`, `--operation <TYPE>` — Kubewarden Custom Resource type
-
-  Possible values: `CREATE`
-
-
++
+Possible values: `CREATE`
 
 
-## `kwctl scaffold artifacthub`
+
+
+[[kwctl-scaffold-artifacthub]]
+== `kwctl scaffold artifacthub`
 
 Output an artifacthub-pkg.yml file from a metadata.yml file
 
-**Usage:** `kwctl scaffold artifacthub [OPTIONS]`
+*Usage:* `kwctl scaffold artifacthub [OPTIONS]`
 
-###### **Options:**
+=== *Options:*
 
 * `-m`, `--metadata-path <PATH>` — File containing the metadata of the policy
 * `-o`, `--output <FILE>` — Path where the artifact-pkg.yml file will be stored
@@ -467,17 +485,18 @@ Output an artifacthub-pkg.yml file from a metadata.yml file
 
 
 
-## `kwctl scaffold manifest`
+[[kwctl-scaffold-manifest]]
+== `kwctl scaffold manifest`
 
 Output a Kubernetes resource manifest
 
-**Usage:** `kwctl scaffold manifest [OPTIONS] --type <VALUE> <uri_or_sha_prefix>`
+*Usage:* `kwctl scaffold manifest [OPTIONS] --type <VALUE> <uri_or_sha_prefix>`
 
-###### **Arguments:**
+=== *Arguments:*
 
 * `<URI_OR_SHA_PREFIX>` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.
 
-###### **Options:**
+=== *Options:*
 
 * `--allow-context-aware <ALLOW-CONTEXT-AWARE>` — Uses the policy metadata to define which Kubernetes resources can be accessed by the policy. Warning: review the list of resources carefully to avoid abuses. Disabled by default
 * `--cert-email <VALUE>` — Expected email in Fulcio certificate
@@ -491,8 +510,8 @@ Output a Kubernetes resource manifest
 * `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
 * `--title <VALUE>` — Policy title
 * `-t`, `--type <VALUE>` — Kubewarden Custom Resource type
-
-  Possible values: `ClusterAdmissionPolicy`, `AdmissionPolicy`
++
+Possible values: `ClusterAdmissionPolicy`, `AdmissionPolicy`
 
 * `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
 * `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
@@ -500,46 +519,49 @@ Output a Kubernetes resource manifest
 
 
 
-## `kwctl scaffold vap`
+[[kwctl-scaffold-vap]]
+== `kwctl scaffold vap`
 
 Convert a Kubernetes `ValidatingAdmissionPolicy` into a Kubewarden `ClusterAdmissionPolicy`
 
-**Usage:** `kwctl scaffold vap [OPTIONS] --binding <VALIDATING-ADMISSION-POLICY-BINDING.yaml> --policy <VALIDATING-ADMISSION-POLICY.yaml>`
+*Usage:* `kwctl scaffold vap [OPTIONS] --binding <VALIDATING-ADMISSION-POLICY-BINDING.yaml> --policy <VALIDATING-ADMISSION-POLICY.yaml>`
 
-###### **Options:**
+=== *Options:*
 
 * `-b`, `--binding <VALIDATING-ADMISSION-POLICY-BINDING.yaml>` — The file containing the ValidatingAdmissionPolicyBinding definition
 * `--cel-policy <URI>` — The CEL policy module to use
-
-  Default value: `ghcr.io/kubewarden/policies/cel-policy:latest`
++
+Default value: `ghcr.io/kubewarden/policies/cel-policy:latest`
 * `-p`, `--policy <VALIDATING-ADMISSION-POLICY.yaml>` — The file containing the ValidatingAdmissionPolicy definition
 
 
 
-## `kwctl scaffold verification-config`
+[[kwctl-scaffold-verification-config]]
+== `kwctl scaffold verification-config`
 
 Output a default Sigstore verification configuration file
 
-**Usage:** `kwctl scaffold verification-config`
+*Usage:* `kwctl scaffold verification-config`
 
 
 
-## `kwctl verify`
+[[kwctl-verify]]
+== `kwctl verify`
 
 Verify a Kubewarden policy from a given URI using Sigstore
 
-**Usage:** `kwctl verify [OPTIONS] <uri>`
+*Usage:* `kwctl verify [OPTIONS] <uri>`
 
 It respects standard proxy environment variables when downloading policies:
 - HTTP_PROXY or http_proxy: proxy server for HTTP requests
 - HTTPS_PROXY or https_proxy: proxy server for HTTPS requests
 - NO_PROXY or no_proxy: comma-separated list of hosts to exclude from proxying
 
-###### **Arguments:**
+=== *Arguments:*
 
 * `<URI>` — Policy URI. Supported schemes: registry://
 
-###### **Options:**
+=== *Options:*
 
 * `--cert-email <VALUE>` — Expected email in Fulcio certificate
 * `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
@@ -554,9 +576,3 @@ It respects standard proxy environment variables when downloading policies:
 
 
 
-<hr/>
-
-<small><i>
-    This document was generated automatically by
-    <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
-</i></small>

--- a/crates/kwctl/cli-docs.adoc
+++ b/crates/kwctl/cli-docs.adoc
@@ -40,7 +40,7 @@ Tool to manage Kubewarden policies
 * `bench` — Benchmarks a Kubewarden policy
 * `completions` — Generate shell completions
 * `digest` — Fetch digest from the OCI manifest of a policy
-* `docs` — Generates the AsciiDoc documentation for kwctl commands
+* `docs` — Generates documentation for kwctl commands. The output format is determined by the file extension: .md for Markdown, AsciiDoc otherwise
 * `info` — Display system information
 * `inspect` — Inspect Kubewarden policy
 * `load` — load policies from a tar.gz file
@@ -194,7 +194,7 @@ Fetch digest from the OCI manifest of a policy
 [[kwctl-docs]]
 == `kwctl docs`
 
-Generates the AsciiDoc documentation for kwctl commands
+Generates documentation for kwctl commands. The output format is determined by the file extension: .md for Markdown, AsciiDoc otherwise
 
 *Usage:* `kwctl docs --output <FILE>`
 

--- a/crates/kwctl/src/cli.rs
+++ b/crates/kwctl/src/cli.rs
@@ -676,7 +676,7 @@ fn subcommand_save() -> Command {
 
 fn subcommand_docs() -> Command {
     Command::new("docs")
-        .about("Generates the markdown documentation for kwctl commands")
+        .about("Generates the AsciiDoc documentation for kwctl commands")
         .arg(
             Arg::new("output")
                 .long("output")

--- a/crates/kwctl/src/cli.rs
+++ b/crates/kwctl/src/cli.rs
@@ -676,7 +676,7 @@ fn subcommand_save() -> Command {
 
 fn subcommand_docs() -> Command {
     Command::new("docs")
-        .about("Generates the AsciiDoc documentation for kwctl commands")
+        .about("Generates documentation for kwctl commands. The output format is determined by the file extension: .md for Markdown, AsciiDoc otherwise")
         .arg(
             Arg::new("output")
                 .long("output")

--- a/crates/kwctl/src/main.rs
+++ b/crates/kwctl/src/main.rs
@@ -373,7 +373,7 @@ async fn main() -> Result<()> {
                 let output = matches.get_one::<String>("output").unwrap();
                 let mut file = std::fs::File::create(output)
                     .map_err(|e| anyhow!("cannot create file {}: {}", output, e))?;
-                let docs_content = clap_markdown::help_markdown_command(&cli::build_cli());
+                let docs_content = clap_markdown::help_asciidoc_command(&cli::build_cli());
                 file.write_all(docs_content.as_bytes())
                     .map_err(|e| anyhow!("cannot write to file {}: {}", output, e))?;
             }

--- a/crates/kwctl/src/main.rs
+++ b/crates/kwctl/src/main.rs
@@ -374,9 +374,9 @@ async fn main() -> Result<()> {
                 let mut file = std::fs::File::create(output)
                     .map_err(|e| anyhow!("cannot create file {}: {}", output, e))?;
                 let docs_content = if output.ends_with(".md") {
-                    clap_markdown::help_markdown_command(&cli::build_cli())
+                    clap_documentation::help_markdown_command(&cli::build_cli())
                 } else {
-                    clap_markdown::help_asciidoc_command(&cli::build_cli())
+                    clap_documentation::help_asciidoc_command(&cli::build_cli())
                 };
                 file.write_all(docs_content.as_bytes())
                     .map_err(|e| anyhow!("cannot write to file {}: {}", output, e))?;

--- a/crates/kwctl/src/main.rs
+++ b/crates/kwctl/src/main.rs
@@ -373,7 +373,11 @@ async fn main() -> Result<()> {
                 let output = matches.get_one::<String>("output").unwrap();
                 let mut file = std::fs::File::create(output)
                     .map_err(|e| anyhow!("cannot create file {}: {}", output, e))?;
-                let docs_content = clap_markdown::help_asciidoc_command(&cli::build_cli());
+                let docs_content = if output.ends_with(".md") {
+                    clap_markdown::help_markdown_command(&cli::build_cli())
+                } else {
+                    clap_markdown::help_asciidoc_command(&cli::build_cli())
+                };
                 file.write_all(docs_content.as_bytes())
                     .map_err(|e| anyhow!("cannot write to file {}: {}", output, e))?;
             }

--- a/crates/policy-server/Cargo.toml
+++ b/crates/policy-server/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = { workspace = true }
 axum = { version = "0.8.8", features = ["macros", "query"] }
 axum-server = { version = "0.8.0", features = ["tls-rustls"] }
 clap = { workspace = true }
-clap-markdown = { workspace = true }
+clap-documentation = { workspace = true }
 daemonize = "0.5"
 futures = { workspace = true }
 hex = { workspace = true }

--- a/crates/policy-server/Makefile
+++ b/crates/policy-server/Makefile
@@ -74,4 +74,4 @@ docker-build: test ## Build docker image with the manager.
 
 .PHONY:build-docs
 build-docs:
-	cargo run --release -- docs --output cli-docs.md
+	cargo run --release -- docs --output cli-docs.adoc

--- a/crates/policy-server/cli-docs.adoc
+++ b/crates/policy-server/cli-docs.adoc
@@ -1,34 +1,35 @@
-# Command-Line Help for `policy-server`
+= Command-Line Help for `policy-server`
 
 This document contains the help content for the `policy-server` command-line program.
 
-**Command Overview:**
+*Command Overview:*
 
-* [`policy-server`↴](#policy-server)
-* [`policy-server docs`↴](#policy-server-docs)
+* <<policy-server,`policy-server`>>
+* <<policy-server-docs,`policy-server docs`>>
 
-## `policy-server`
+[[policy-server]]
+== `policy-server`
 
 
 
-**Usage:** `policy-server [OPTIONS] [COMMAND]`
+*Usage:* `policy-server [OPTIONS] [COMMAND]`
 
-###### **Subcommands:**
+=== *Subcommands:*
 
-* `docs` — Generates the markdown documentation for policy-server commands
+* `docs` — Generates the AsciiDoc documentation for policy-server commands
 
-###### **Options:**
+=== *Options:*
 
 * `--addr <BIND_ADDRESS>` — Bind against ADDRESS
-
-  Default value: `0.0.0.0`
++
+Default value: `0.0.0.0`
 * `--always-accept-admission-reviews-on-namespace <NAMESPACE>` — Always accept AdmissionReviews that target the given namespace
 * `--cert-file <CERT_FILE>` — Path to an X.509 certificate file for HTTPS
 * `--client-ca-file <CLIENT_CA_FILE>` — Path to an CA certificate file that issued the client certificate. Required to enable mTLS
 * `--daemon` — If set, runs policy-server in detached mode as a daemon
 * `--daemon-pid-file <DAEMON-PID-FILE>` — Path to the PID file, used only when running in daemon mode
-
-  Default value: `policy-server.pid`
++
+Default value: `policy-server.pid`
 * `--daemon-stderr-file <DAEMON-STDERR-FILE>` — Path to the file holding stderr, used only when running in daemon mode
 * `--daemon-stdout-file <DAEMON-STDOUT-FILE>` — Path to the file holding stdout, used only when running in daemon mode
 * `--disable-timeout-protection` — Disable policy timeout protection
@@ -38,57 +39,53 @@ This document contains the help content for the `policy-server` command-line pro
 * `--ignore-kubernetes-connection-failure` — Do not exit with an error if the Kubernetes connection fails. This will cause context-aware policies to break when there's no connection with Kubernetes.
 * `--key-file <KEY_FILE>` — Path to an X.509 private key file for HTTPS
 * `--log-fmt <LOG_FMT>` — Log output format
-
-  Default value: `text`
-
-  Possible values: `text`, `json`, `otlp`
++
+Default value: `text`
++
+Possible values: `text`, `json`, `otlp`
 
 * `--log-level <LOG_LEVEL>` — Log level
-
-  Default value: `info`
-
-  Possible values: `trace`, `debug`, `info`, `warn`, `error`
++
+Default value: `info`
++
+Possible values: `trace`, `debug`, `info`, `warn`, `error`
 
 * `--log-no-color` — Disable colored output for logs
 * `--policies <POLICIES_FILE>` — YAML file holding the policies to be loaded and their settings
-
-  Default value: `policies.yml`
++
+Default value: `policies.yml`
 * `--policies-download-dir <POLICIES_DOWNLOAD_DIR>` — Download path for the policies
-
-  Default value: `.`
++
+Default value: `.`
 * `--policy-timeout <MAXIMUM_EXECUTION_TIME_SECONDS>` — Interrupt policy evaluation after the given time
-
-  Default value: `2`
++
+Default value: `2`
 * `--port <PORT>` — Listen on PORT
-
-  Default value: `3000`
++
+Default value: `3000`
 * `--readiness-probe-port <READINESS_PROBE_PORT>` — Expose readiness endpoint on READINESS_PROBE_PORT
-
-  Default value: `8081`
++
+Default value: `8081`
 * `--sigstore-cache-dir <SIGSTORE_CACHE_DIR>` — Directory used to cache sigstore data
-
-  Default value: `sigstore-data`
++
+Default value: `sigstore-data`
+* `--sigstore-trust-config <SIGSTORE_TRUST_CONFIG_PATH>` — Path to a JSON Sigstore ClientTrustConfig file
 * `--sources-path <SOURCES_PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
 * `--verification-path <VERIFICATION_CONFIG_PATH>` — YAML file holding verification information (URIs, keys, annotations...)
 * `--workers <WORKERS_NUMBER>` — Number of worker threads to create
 
 
 
-## `policy-server docs`
+[[policy-server-docs]]
+== `policy-server docs`
 
-Generates the markdown documentation for policy-server commands
+Generates the AsciiDoc documentation for policy-server commands
 
-**Usage:** `policy-server docs --output <FILE>`
+*Usage:* `policy-server docs --output <FILE>`
 
-###### **Options:**
+=== *Options:*
 
 * `-o`, `--output <FILE>` — path where the documentation file will be stored
 
 
 
-<hr/>
-
-<small><i>
-    This document was generated automatically by
-    <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
-</i></small>

--- a/crates/policy-server/cli-docs.adoc
+++ b/crates/policy-server/cli-docs.adoc
@@ -16,7 +16,7 @@ This document contains the help content for the `policy-server` command-line pro
 
 === *Subcommands:*
 
-* `docs` — Generates the AsciiDoc documentation for policy-server commands
+* `docs` — Generates documentation for policy-server commands. The output format is determined by the file extension: .md for Markdown, AsciiDoc otherwise
 
 === *Options:*
 
@@ -79,7 +79,7 @@ Default value: `sigstore-data`
 [[policy-server-docs]]
 == `policy-server docs`
 
-Generates the AsciiDoc documentation for policy-server commands
+Generates documentation for policy-server commands. The output format is determined by the file extension: .md for Markdown, AsciiDoc otherwise
 
 *Usage:* `policy-server docs --output <FILE>`
 

--- a/crates/policy-server/src/cli.rs
+++ b/crates/policy-server/src/cli.rs
@@ -228,7 +228,7 @@ pub(crate) fn build_cli() -> Command {
         .args(args)
         .subcommand(
             Command::new("docs")
-                .about("Generates the markdown documentation for policy-server commands")
+                .about("Generates the AsciiDoc documentation for policy-server commands")
                 .arg(
                     Arg::new("output")
                         .long("output")

--- a/crates/policy-server/src/cli.rs
+++ b/crates/policy-server/src/cli.rs
@@ -228,7 +228,7 @@ pub(crate) fn build_cli() -> Command {
         .args(args)
         .subcommand(
             Command::new("docs")
-                .about("Generates the AsciiDoc documentation for policy-server commands")
+                .about("Generates documentation for policy-server commands. The output format is determined by the file extension: .md for Markdown, AsciiDoc otherwise")
                 .arg(
                     Arg::new("output")
                         .long("output")

--- a/crates/policy-server/src/main.rs
+++ b/crates/policy-server/src/main.rs
@@ -69,13 +69,13 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-/// Handle the docs subcommand and generates markdown documentation for the CLI
+/// Handle the docs subcommand and generates AsciiDoc documentation for the CLI
 fn run_docs_subcommand(matches: Option<&ArgMatches>) -> Result<()> {
     if let Some(matches) = matches {
         let output = matches.get_one::<String>("output").unwrap();
         let mut file = std::fs::File::create(output)
             .map_err(|e| anyhow!("cannot create file {}: {}", output, e))?;
-        let docs_content = clap_markdown::help_markdown_command(&cli::build_cli());
+        let docs_content = clap_markdown::help_asciidoc_command(&cli::build_cli());
         file.write_all(docs_content.as_bytes())
             .map_err(|e| anyhow!("cannot write to file {}: {}", output, e))?;
     }

--- a/crates/policy-server/src/main.rs
+++ b/crates/policy-server/src/main.rs
@@ -76,9 +76,9 @@ fn run_docs_subcommand(matches: Option<&ArgMatches>) -> Result<()> {
         let mut file = std::fs::File::create(output)
             .map_err(|e| anyhow!("cannot create file {}: {}", output, e))?;
         let docs_content = if output.ends_with(".md") {
-            clap_markdown::help_markdown_command(&cli::build_cli())
+            clap_documentation::help_markdown_command(&cli::build_cli())
         } else {
-            clap_markdown::help_asciidoc_command(&cli::build_cli())
+            clap_documentation::help_asciidoc_command(&cli::build_cli())
         };
         file.write_all(docs_content.as_bytes())
             .map_err(|e| anyhow!("cannot write to file {}: {}", output, e))?;

--- a/crates/policy-server/src/main.rs
+++ b/crates/policy-server/src/main.rs
@@ -69,13 +69,17 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-/// Handle the docs subcommand and generates AsciiDoc documentation for the CLI
+/// Handle the docs subcommand and generates documentation for the CLI
 fn run_docs_subcommand(matches: Option<&ArgMatches>) -> Result<()> {
     if let Some(matches) = matches {
         let output = matches.get_one::<String>("output").unwrap();
         let mut file = std::fs::File::create(output)
             .map_err(|e| anyhow!("cannot create file {}: {}", output, e))?;
-        let docs_content = clap_markdown::help_asciidoc_command(&cli::build_cli());
+        let docs_content = if output.ends_with(".md") {
+            clap_markdown::help_markdown_command(&cli::build_cli())
+        } else {
+            clap_markdown::help_asciidoc_command(&cli::build_cli())
+        };
         file.write_all(docs_content.as_bytes())
             .map_err(|e| anyhow!("cannot write to file {}: {}", output, e))?;
     }


### PR DESCRIPTION
## Description

Updates the docs command from kwctl and policy server to generate the documentation file in Asciidoc format. 

An example of the file rendered in our documentation website is:

<img width="1614" height="953" alt="image" src="https://github.com/user-attachments/assets/367f6b4d-4670-4d5c-be24-8c79679fef0b" />

<img width="1614" height="953" alt="image" src="https://github.com/user-attachments/assets/282110c3-80f9-47c6-a18c-35a72713d3ae" />

