### PR TITLE
fix(controller): Append controller env vars last on policy-server

### DIFF
--- a/internal/controller/policyserver_controller_deployment.go
+++ b/internal/controller/policyserver_controller_deployment.go
@@ -694,7 +694,10 @@ func getPolicyServerContainer(policyServer *policiesv1.PolicyServer) corev1.Cont
 				MountPath: policyStoreVolumePath,
 			},
 		},
-		Env: append([]corev1.EnvVar{
+		// user-provided vars from Spec.Env come first, controller-managed vars are
+		// appended last so they always take precedence (kubelet applies
+		// "last wins" semantics when duplicate names are present)
+		Env: append(policyServer.Spec.Env, []corev1.EnvVar{
 			{
 				Name:  "KUBEWARDEN_CERT_FILE",
 				Value: filepath.Join(secretsContainerPath, constants.ServerCert),
@@ -723,7 +726,7 @@ func getPolicyServerContainer(policyServer *policiesv1.PolicyServer) corev1.Cont
 				Name:  "KUBEWARDEN_SIGSTORE_CACHE_DIR",
 				Value: sigstoreCacheDirPath,
 			},
-		}, policyServer.Spec.Env...),
+		}...),
 		ReadinessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{

--- a/internal/controller/policyserver_controller_deployment_test.go
+++ b/internal/controller/policyserver_controller_deployment_test.go
@@ -1,0 +1,51 @@
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	policiesv1 "github.com/kubewarden/adm-controller/api/policies/v1"
+)
+
+// TestGetPolicyServerContainerEnvOrdering verifies the env var precedence
+// contract for the policy-server container: user-provided vars (Spec.Env) come
+// first, and controller-managed vars are appended last so that, under
+// kubelet's "last wins" semantics for duplicate names, the controller's values
+// always take precedence.
+func TestGetPolicyServerContainerEnvOrdering(t *testing.T) {
+	const kubewardenPortEnv = "KUBEWARDEN_PORT"
+	const userOverrideValue = "9999"
+
+	ps := &policiesv1.PolicyServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		Spec: policiesv1.PolicyServerSpec{
+			Image: "ghcr.io/kubewarden/policy-server:latest",
+			Env: []corev1.EnvVar{
+				{Name: "USER_VAR", Value: "user-val"},
+				// Deliberately collides with a controller-managed var.
+				{Name: kubewardenPortEnv, Value: userOverrideValue},
+			},
+		},
+	}
+
+	container := getPolicyServerContainer(ps)
+
+	// User vars come first.
+	if len(container.Env) == 0 || container.Env[0].Name != "USER_VAR" {
+		t.Fatalf("expected first env var to be the user-provided USER_VAR, got %+v", container.Env)
+	}
+
+	// Controller-managed vars win: the LAST occurrence of KUBEWARDEN_PORT
+	// must be the controller's value, not the user's override.
+	var lastPort string
+	for _, e := range container.Env {
+		if e.Name == kubewardenPortEnv {
+			lastPort = e.Value
+		}
+	}
+	if lastPort == userOverrideValue {
+		t.Fatalf("expected controller-managed %s to override user value %q, but user value won", kubewardenPortEnv, userOverrideValue)
+	}
+}


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Be more defensive when setting env vars on policy-server Deployment.

User-provided vars come first, and the controller hardcoded variables are appended last.  In Kubernetes, when duplicate env var names exist in a container, the last definition wins (for most runtimes), so this ensures the controller's values always take precedence.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
