### PR TITLE
feat(controller): add DefaultsApplierReconciler

### DIFF
--- a/api/policies/v1/factories.go
+++ b/api/policies/v1/factories.go
@@ -9,8 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-
-	"github.com/kubewarden/adm-controller/internal/constants"
 )
 
 const (
@@ -142,6 +140,7 @@ type ClusterAdmissionPolicyFactory struct {
 	mode                  PolicyMode
 	timeoutSeconds        *int32
 	timeoutEvalSeconds    *int32
+	withoutFinalizers     bool
 }
 
 func NewClusterAdmissionPolicyFactory() *ClusterAdmissionPolicyFactory {
@@ -216,16 +215,25 @@ func (f *ClusterAdmissionPolicyFactory) WithTimeoutEvalSeconds(timeout *int32) *
 	return f
 }
 
+func (f *ClusterAdmissionPolicyFactory) WithoutFinalizers() *ClusterAdmissionPolicyFactory {
+	f.withoutFinalizers = true
+	return f
+}
+
 func (f *ClusterAdmissionPolicyFactory) Build() *ClusterAdmissionPolicy {
+	var finalizers []string
+	if !f.withoutFinalizers {
+		finalizers = []string{
+			// Safety-net finalizer that prevents the API server from garbage-
+			// collecting the object during integration tests, so test assertions
+			// can observe the controller's behavior before deletion completes.
+			integrationTestsFinalizer,
+		}
+	}
 	clusterAdmissionPolicy := ClusterAdmissionPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: f.name,
-			Finalizers: []string{
-				// Safety-net finalizer that prevents the API server from garbage-
-				// collecting the object during integration tests, so test assertions
-				// can observe the controller's behavior before deletion completes.
-				integrationTestsFinalizer,
-			},
+			Name:       f.name,
+			Finalizers: finalizers,
 		},
 		Spec: ClusterAdmissionPolicySpec{
 			ContextAwareResources: f.contextAwareResources,
@@ -482,6 +490,7 @@ type PolicyServerBuilder struct {
 	webhookPort                    *int32
 	readinessProbePort             *int32
 	metricsPort                    *int32
+	withoutFinalizers              bool
 }
 
 func NewPolicyServerFactory() *PolicyServerBuilder {
@@ -545,19 +554,25 @@ func (f *PolicyServerBuilder) WithMetricsPort(port int32) *PolicyServerBuilder {
 	return f
 }
 
+func (f *PolicyServerBuilder) WithoutFinalizers() *PolicyServerBuilder {
+	f.withoutFinalizers = true
+	return f
+}
+
 func (f *PolicyServerBuilder) Build() *PolicyServer {
+	var finalizers []string
+	if !f.withoutFinalizers {
+		finalizers = []string{
+			// Safety-net finalizer that prevents the API server from garbage-
+			// collecting the object during integration tests, so test assertions
+			// can observe the controller's behavior before deletion completes.
+			integrationTestsFinalizer,
+		}
+	}
 	policyServer := PolicyServer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: f.name,
-			Finalizers: []string{
-				// On a real cluster the Kubewarden finalizer is added by our mutating
-				// webhook. This is not running now, hence we have to manually add the finalizer
-				constants.KubewardenFinalizer,
-				// By adding this finalizer automatically, we ensure that when
-				// testing removal of finalizers on deleted objects, that they will
-				// exist at all times
-				integrationTestsFinalizer,
-			},
+			Name:       f.name,
+			Finalizers: finalizers,
 		},
 		Spec: PolicyServerSpec{
 			Image:                          policyServerRepository() + ":" + policyServerVersion(),

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -86,6 +86,7 @@ type ManagerOptions struct {
 type Configuration struct {
 	AlwaysAcceptAdmissionReviewsOnDeploymentsNamespace bool
 	ClientCAConfigMapName                              string
+	DefaultsConfigMapName                              string
 	FeatureGateAdmissionWebhookMatchConditions         bool
 	WebhookServiceName                                 string
 	ImagePullSecrets                                   []corev1.LocalObjectReference
@@ -144,6 +145,10 @@ func main() {
 		false,
 		"Always accept admission reviews targeting the deployments-namespace.")
 	flag.StringVar(&config.ClientCAConfigMapName, "client-ca-configmap-name", "", "The name of the ConfigMap containing the client CA certificate. If provided, mTLS will be enabled.")
+	flag.StringVar(&config.DefaultsConfigMapName,
+		"defaults-configmap-name",
+		constants.DefaultDefaultsConfigMapName,
+		"Name of the ConfigMap that holds the rendered default Kubewarden resources.")
 	flag.StringVar(&imagePullSecretsFlag,
 		"image-pull-secrets",
 		"",
@@ -445,6 +450,16 @@ func setupReconcilers(mgr ctrl.Manager,
 		FeatureGateAdmissionWebhookMatchConditions: config.FeatureGateAdmissionWebhookMatchConditions,
 	}).SetupWithManager(mgr); err != nil {
 		return errors.Join(errors.New("unable to create ClusterAdmissionPolicyGroup controller"), err)
+	}
+
+	if err := (&controller.DefaultsApplierReconciler{
+		Client:               mgr.GetClient(),
+		Scheme:               mgr.GetScheme(),
+		Log:                  ctrl.Log.WithName("defaults-applier"),
+		DeploymentsNamespace: deploymentsNamespace,
+		ConfigMapName:        config.DefaultsConfigMapName,
+	}).SetupWithManager(mgr); err != nil {
+		return errors.Join(errors.New("unable to create DefaultsApplier controller"), err)
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/e2e-framework v0.7.0
 	sigs.k8s.io/wg-policy-prototypes v0.0.0-20230505033312-51c21979086a
+	sigs.k8s.io/yaml v1.6.0
 )
 
 // CEL needs to be pinned to the same version as the one used by the k8s.io/apiserver package
@@ -119,5 +120,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -46,7 +46,17 @@ const (
 	PartOfLabelValue                = "kubewarden"
 	ManagedByKey                    = "app.kubernetes.io/managed-by"
 
+	// DefaultsManagedByLabelKey is the label key for resources managed by DefaultsApplier.
+	DefaultsManagedByLabelKey = "kubewarden.io/managed-by"
+	// DefaultsManagedByLabelValue is the label value for resources managed by DefaultsApplier.
+	DefaultsManagedByLabelValue = "kubewarden-controller-defaults"
+
+	// DefaultDefaultsConfigMapName is the default name of the ConfigMap containing default resources.
+	DefaultDefaultsConfigMapName = "kubewarden-defaults"
+
 	PolicyServerIndexKey = ".spec.policyServer"
+
+	KubewardenPoliciesGroup = "policies.kubewarden.io"
 
 	KubewardenFinalizerPre114 = "kubewarden"
 	KubewardenFinalizer       = "kubewarden.io/finalizer"

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -65,19 +65,17 @@ const (
 
 	OptelInjectAnnotation = "sidecar.opentelemetry.io/inject"
 
-	// PolicyServerDeploymentManagedAnnotationKeysAnnotation is the annotation used to track
-	// which annotation keys on a Deployment/Pod template are managed by the controller (i.e.,
-	// came from spec.annotations). On each reconcile the controller removes keys that were
-	// previously managed but are no longer present in the spec, without touching annotations
-	// set by Kubernetes itself or other tooling.
-	PolicyServerDeploymentManagedAnnotationKeysAnnotation = "kubewarden.io/managed-annotation-keys"
+	// ManagedAnnotationKeysAnnotation is the annotation used to track which annotation keys on
+	// an object are managed by the controller. On each reconcile the controller removes keys
+	// that were previously managed but are no longer desired, without touching annotations set
+	// by Kubernetes itself or other tooling.
+	ManagedAnnotationKeysAnnotation = "kubewarden.io/managed-annotation-keys"
 
-	// PolicyServerDeploymentManagedLabelKeysAnnotation is the annotation used to track
-	// which label keys on a Deployment/Pod template are managed by the controller (i.e.,
-	// came from spec.labels). On each reconcile the controller removes keys that were
-	// previously managed but are no longer present in the spec, without touching labels
-	// set by Kubernetes itself or other tooling.
-	PolicyServerDeploymentManagedLabelKeysAnnotation = "kubewarden.io/managed-label-keys"
+	// ManagedLabelKeysAnnotation is the annotation used to track which label keys on an object
+	// are managed by the controller. On each reconcile the controller removes keys that were
+	// previously managed but are no longer desired, without touching labels set by Kubernetes
+	// itself or other tooling.
+	ManagedLabelKeysAnnotation = "kubewarden.io/managed-label-keys"
 
 	WebhookConfigurationPolicyNameAnnotationKey      = "kubewardenPolicyName"
 	WebhookConfigurationPolicyNamespaceAnnotationKey = "kubewardenPolicyNamespace"

--- a/internal/controller/defaults_applier.go
+++ b/internal/controller/defaults_applier.go
@@ -1,0 +1,249 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	policiesv1 "github.com/kubewarden/adm-controller/api/policies/v1"
+	"github.com/kubewarden/adm-controller/internal/constants"
+)
+
+// DefaultsApplierReconciler watches a ConfigMap containing default Kubewarden
+// resources (PolicyServer, ClusterAdmissionPolicy, etc.) and applies them to
+// the cluster. It injects ownership labels and cleans up stale managed resources.
+
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch,namespace=kubewarden
+//+kubebuilder:rbac:groups=policies.kubewarden.io,resources=policyservers;clusteradmissionpolicies;admissionpolicies;clusteradmissionpolicygroups;admissionpolicygroups,verbs=get;list;watch;create;update;patch;delete
+
+type DefaultsApplierReconciler struct {
+	client.Client
+	Scheme               *runtime.Scheme
+	Log                  logr.Logger
+	DeploymentsNamespace string
+	ConfigMapName        string
+}
+
+// Reconcile watches the defaults ConfigMap and applies the resources it contains.
+func (r *DefaultsApplierReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("configmap", req.NamespacedName)
+
+	var cm corev1.ConfigMap
+	if err := r.Get(ctx, req.NamespacedName, &cm); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("ConfigMap not found, cleaning up all managed resources")
+			if cleanupErr := r.cleanupAll(ctx); cleanupErr != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to cleanup all managed resources: %w", cleanupErr)
+			}
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to get ConfigMap: %w", err)
+	}
+
+	decoder := serializer.NewCodecFactory(r.Scheme).UniversalDeserializer()
+	desired := make(map[resourceKey]bool)
+
+	for key, yamlData := range cm.Data {
+		obj, gvk, err := decoder.Decode([]byte(yamlData), nil, nil)
+		if err != nil {
+			log.Error(err, "failed to decode resource from ConfigMap", "key", key)
+			// Don't fail the whole reconciliation for one bad entry
+			continue
+		}
+
+		clientObj, ok := obj.(client.Object)
+		if !ok {
+			log.Error(errors.New("decoded object is not a client.Object"), "skipping resource", "key", key, "gvk", gvk)
+			continue
+		}
+
+		if !isSupportedType(clientObj) {
+			log.Info("Unsupported resource type, skipping", "key", key, "type", fmt.Sprintf("%T", clientObj))
+			continue
+		}
+
+		// Track this resource as desired
+		rk := resourceKey{
+			gvk:       gvk.String(),
+			name:      clientObj.GetName(),
+			namespace: clientObj.GetNamespace(),
+		}
+		desired[rk] = true
+
+		// Apply the resource with ownership label injected
+		if applyErr := r.applyResource(ctx, clientObj); applyErr != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to apply resource %s: %w", rk, applyErr)
+		}
+	}
+
+	if err := r.cleanupStale(ctx, desired); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to cleanup stale resources: %w", err)
+	}
+
+	log.Info("Reconciliation complete", "appliedResources", len(desired))
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager registers the reconciler with the manager.
+func (r *DefaultsApplierReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.ConfigMap{}).
+		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
+			return object.GetName() == r.ConfigMapName &&
+				object.GetNamespace() == r.DeploymentsNamespace
+		})).
+		Complete(r); err != nil {
+		return fmt.Errorf("failed to create DefaultsApplier controller: %w", err)
+	}
+	return nil
+}
+
+// applyResource creates or updates the resource, managing user-defined metadata from ConfigMap.
+func (r *DefaultsApplierReconciler) applyResource(ctx context.Context, desired client.Object) error {
+	log := r.Log.WithValues("resource", client.ObjectKeyFromObject(desired), "kind", desired.GetObjectKind().GroupVersionKind().Kind)
+
+	// CreateOrPatch GETs the existing object into desired, overwriting the
+	// decoded state. Save a copy so the mutate function can restore everything.
+	desiredCopy, ok := desired.DeepCopyObject().(client.Object)
+	if !ok {
+		return errors.New("failed to cast deep copied object to client.Object")
+	}
+
+	_, err := controllerutil.CreateOrPatch(ctx, r.Client, desired, func() error {
+		copySpec(desiredCopy, desired)
+		applyManagedMetadata(desiredCopy, desired)
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create or patch resource: %w", err)
+	}
+
+	log.V(1).Info("Resource applied successfully")
+	return nil
+}
+
+// isSupportedType returns true if the object is a known Kubewarden resource type.
+func isSupportedType(obj client.Object) bool {
+	switch obj.(type) {
+	case *policiesv1.PolicyServer,
+		*policiesv1.ClusterAdmissionPolicy,
+		*policiesv1.AdmissionPolicy,
+		*policiesv1.ClusterAdmissionPolicyGroup,
+		*policiesv1.AdmissionPolicyGroup:
+		return true
+	default:
+		return false
+	}
+}
+
+// copySpec copies the Spec field from src to dst for all supported resource types.
+func copySpec(src, dst client.Object) {
+	switch d := dst.(type) {
+	case *policiesv1.PolicyServer:
+		if s, ok := src.(*policiesv1.PolicyServer); ok {
+			d.Spec = s.Spec
+		}
+	case *policiesv1.ClusterAdmissionPolicy:
+		if s, ok := src.(*policiesv1.ClusterAdmissionPolicy); ok {
+			d.Spec = s.Spec
+		}
+	case *policiesv1.AdmissionPolicy:
+		if s, ok := src.(*policiesv1.AdmissionPolicy); ok {
+			d.Spec = s.Spec
+		}
+	case *policiesv1.ClusterAdmissionPolicyGroup:
+		if s, ok := src.(*policiesv1.ClusterAdmissionPolicyGroup); ok {
+			d.Spec = s.Spec
+		}
+	case *policiesv1.AdmissionPolicyGroup:
+		if s, ok := src.(*policiesv1.AdmissionPolicyGroup); ok {
+			d.Spec = s.Spec
+		}
+	}
+}
+
+// applyManagedMetadata restores labels and annotations from the ConfigMap YAML
+// into the live object, and injects the ownership label.
+func applyManagedMetadata(desired, live client.Object) {
+	labels := desired.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[constants.DefaultsManagedByLabelKey] = constants.DefaultsManagedByLabelValue
+	live.SetLabels(labels)
+	live.SetAnnotations(desired.GetAnnotations())
+}
+
+// cleanupStale removes managed resources that are not in the desired set.
+func (r *DefaultsApplierReconciler) cleanupStale(ctx context.Context, desired map[resourceKey]bool) error {
+	managedSelector := client.MatchingLabels{
+		constants.DefaultsManagedByLabelKey: constants.DefaultsManagedByLabelValue,
+	}
+
+	gvks := []schema.GroupVersionKind{
+		{Group: constants.KubewardenPoliciesGroup, Version: "v1", Kind: "PolicyServerList"},
+		{Group: constants.KubewardenPoliciesGroup, Version: "v1", Kind: "ClusterAdmissionPolicyList"},
+		{Group: constants.KubewardenPoliciesGroup, Version: "v1", Kind: "AdmissionPolicyList"},
+		{Group: constants.KubewardenPoliciesGroup, Version: "v1", Kind: "ClusterAdmissionPolicyGroupList"},
+		{Group: constants.KubewardenPoliciesGroup, Version: "v1", Kind: "AdmissionPolicyGroupList"},
+	}
+
+	for _, gvk := range gvks {
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(gvk)
+
+		if err := r.List(ctx, list, managedSelector); err != nil {
+			return fmt.Errorf("failed to list managed resources: %w", err)
+		}
+
+		for i := range list.Items {
+			item := &list.Items[i]
+			rk := resourceKey{
+				gvk:       item.GetObjectKind().GroupVersionKind().String(),
+				name:      item.GetName(),
+				namespace: item.GetNamespace(),
+			}
+
+			if !desired[rk] {
+				r.Log.Info("Deleting stale managed resource", "resource", rk)
+				if deleteErr := r.Delete(ctx, item); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+					return fmt.Errorf("failed to delete stale resource %s: %w", rk, deleteErr)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// cleanupAll removes all managed resources (called when ConfigMap is absent).
+func (r *DefaultsApplierReconciler) cleanupAll(ctx context.Context) error {
+	return r.cleanupStale(ctx, make(map[resourceKey]bool))
+}
+
+// resourceKey uniquely identifies a Kubernetes resource.
+type resourceKey struct {
+	gvk       string
+	name      string
+	namespace string
+}
+
+func (rk resourceKey) String() string {
+	if rk.namespace == "" {
+		return fmt.Sprintf("%s/%s", rk.gvk, rk.name)
+	}
+	return fmt.Sprintf("%s/%s/%s", rk.gvk, rk.namespace, rk.name)
+}

--- a/internal/controller/defaults_applier.go
+++ b/internal/controller/defaults_applier.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -34,6 +35,7 @@ type DefaultsApplierReconciler struct {
 	Log                  logr.Logger
 	DeploymentsNamespace string
 	ConfigMapName        string
+	decoder              runtime.Decoder
 }
 
 // Reconcile watches the defaults ConfigMap and applies the resources it contains.
@@ -52,11 +54,10 @@ func (r *DefaultsApplierReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, fmt.Errorf("failed to get ConfigMap: %w", err)
 	}
 
-	decoder := serializer.NewCodecFactory(r.Scheme).UniversalDeserializer()
-	desired := make(map[resourceKey]bool)
+	desired := sets.New[resourceKey]()
 
 	for key, yamlData := range cm.Data {
-		obj, gvk, err := decoder.Decode([]byte(yamlData), nil, nil)
+		obj, gvk, err := r.decoder.Decode([]byte(yamlData), nil, nil)
 		if err != nil {
 			log.Error(err, "failed to decode resource from ConfigMap", "key", key)
 			// Don't fail the whole reconciliation for one bad entry
@@ -80,7 +81,7 @@ func (r *DefaultsApplierReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			name:      clientObj.GetName(),
 			namespace: clientObj.GetNamespace(),
 		}
-		desired[rk] = true
+		desired.Insert(rk)
 
 		// Apply the resource with ownership label injected
 		if applyErr := r.applyResource(ctx, clientObj); applyErr != nil {
@@ -98,6 +99,8 @@ func (r *DefaultsApplierReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 // SetupWithManager registers the reconciler with the manager.
 func (r *DefaultsApplierReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.decoder = serializer.NewCodecFactory(r.Scheme).UniversalDeserializer()
+
 	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.ConfigMap{}).
 		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
@@ -188,7 +191,7 @@ func applyManagedMetadata(desired, live client.Object) {
 }
 
 // cleanupStale removes managed resources that are not in the desired set.
-func (r *DefaultsApplierReconciler) cleanupStale(ctx context.Context, desired map[resourceKey]bool) error {
+func (r *DefaultsApplierReconciler) cleanupStale(ctx context.Context, desired sets.Set[resourceKey]) error {
 	managedSelector := client.MatchingLabels{
 		constants.DefaultsManagedByLabelKey: constants.DefaultsManagedByLabelValue,
 	}
@@ -217,7 +220,7 @@ func (r *DefaultsApplierReconciler) cleanupStale(ctx context.Context, desired ma
 				namespace: item.GetNamespace(),
 			}
 
-			if !desired[rk] {
+			if !desired.Has(rk) {
 				r.Log.Info("Deleting stale managed resource", "resource", rk)
 				if deleteErr := r.Delete(ctx, item); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
 					return fmt.Errorf("failed to delete stale resource %s: %w", rk, deleteErr)
@@ -231,7 +234,7 @@ func (r *DefaultsApplierReconciler) cleanupStale(ctx context.Context, desired ma
 
 // cleanupAll removes all managed resources (called when ConfigMap is absent).
 func (r *DefaultsApplierReconciler) cleanupAll(ctx context.Context) error {
-	return r.cleanupStale(ctx, make(map[resourceKey]bool))
+	return r.cleanupStale(ctx, sets.New[resourceKey]())
 }
 
 // resourceKey uniquely identifies a Kubernetes resource.

--- a/internal/controller/defaults_applier.go
+++ b/internal/controller/defaults_applier.go
@@ -178,16 +178,29 @@ func copySpec(src, dst client.Object) {
 	}
 }
 
-// applyManagedMetadata restores labels and annotations from the ConfigMap YAML
-// into the live object, and injects the ownership label.
+// applyManagedMetadata merges labels and annotations from the ConfigMap YAML into the live
+// object, preserving keys set by other controllers or tools. Previously managed keys that are
+// no longer present in the desired object are removed. The ownership label is always injected.
 func applyManagedMetadata(desired, live client.Object) {
-	labels := desired.GetLabels()
+	// Ensure annotation map exists on live (needed to store label-key tracking).
+	annotations := live.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	// Labels: merge desired keys, remove stale managed keys, then stamp the ownership label.
+	labels := live.GetLabels()
 	if labels == nil {
 		labels = make(map[string]string)
 	}
+	applyManagedKeys(labels, desired.GetLabels(), annotations, constants.ManagedLabelKeysAnnotation)
 	labels[constants.DefaultsManagedByLabelKey] = constants.DefaultsManagedByLabelValue
+
+	// Annotations: merge desired keys, remove stale managed keys.
+	applyManagedKeys(annotations, desired.GetAnnotations(), annotations, constants.ManagedAnnotationKeysAnnotation)
+
 	live.SetLabels(labels)
-	live.SetAnnotations(desired.GetAnnotations())
+	live.SetAnnotations(annotations)
 }
 
 // cleanupStale removes managed resources that are not in the desired set.

--- a/internal/controller/defaults_applier_test.go
+++ b/internal/controller/defaults_applier_test.go
@@ -1,0 +1,257 @@
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	sigsyaml "sigs.k8s.io/yaml"
+
+	policiesv1 "github.com/kubewarden/adm-controller/api/policies/v1"
+	"github.com/kubewarden/adm-controller/internal/constants"
+)
+
+func marshalPolicyServer(ps *policiesv1.PolicyServer) string {
+	ps.SetGroupVersionKind(policiesv1.GroupVersion.WithKind("PolicyServer"))
+	data, err := sigsyaml.Marshal(ps)
+	Expect(err).ToNot(HaveOccurred())
+	return string(data)
+}
+
+func marshalClusterAdmissionPolicy(policy *policiesv1.ClusterAdmissionPolicy) string {
+	policy.SetGroupVersionKind(policiesv1.GroupVersion.WithKind("ClusterAdmissionPolicy"))
+	data, err := sigsyaml.Marshal(policy)
+	Expect(err).ToNot(HaveOccurred())
+	return string(data)
+}
+
+var _ = Describe("DefaultsApplierReconciler", func() {
+	var (
+		ctx              context.Context
+		configMapName    string
+		configMapNsName  types.NamespacedName
+		policyServerName string
+		policyName       string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		configMapName = constants.DefaultDefaultsConfigMapName
+		configMapNsName = types.NamespacedName{
+			Name:      configMapName,
+			Namespace: deploymentsNamespace,
+		}
+		policyServerName = "test-default-policyserver"
+		policyName = "test-default-policy"
+	})
+
+	AfterEach(func() {
+		cm := &corev1.ConfigMap{}
+		err := k8sClient.Get(ctx, configMapNsName, cm)
+		if err == nil {
+			Expect(k8sClient.Delete(ctx, cm)).To(Succeed())
+		}
+
+		managedSelector := client.MatchingLabels{
+			constants.DefaultsManagedByLabelKey: constants.DefaultsManagedByLabelValue,
+		}
+		for _, obj := range []client.Object{
+			&policiesv1.PolicyServer{},
+			&policiesv1.ClusterAdmissionPolicy{},
+		} {
+			Expect(k8sClient.DeleteAllOf(ctx, obj, managedSelector)).To(Succeed())
+		}
+	})
+
+	Context("when ConfigMap does not exist", func() {
+		It("should delete all managed resources when they exist", func() {
+			ps := policiesv1.NewPolicyServerFactory().WithName(policyServerName).WithoutFinalizers().Build()
+			policyServerYAML := marshalPolicyServer(ps)
+
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: deploymentsNamespace,
+				},
+				Data: map[string]string{
+					"policyserver-default": policyServerYAML,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: policyServerName}, &policiesv1.PolicyServer{})
+			}, timeout, pollInterval).Should(Succeed())
+
+			Expect(k8sClient.Delete(ctx, cm)).To(Succeed())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: policyServerName}, &policiesv1.PolicyServer{})
+				return apierrors.IsNotFound(err)
+			}, timeout, pollInterval).Should(BeTrue(), "managed PolicyServer should be deleted")
+		})
+	})
+
+	Context("when ConfigMap has one PolicyServer", func() {
+		It("should create the PolicyServer with ownership label", func() {
+			ps := policiesv1.NewPolicyServerFactory().WithName(policyServerName).WithoutFinalizers().Build()
+			policyServerYAML := marshalPolicyServer(ps)
+
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: deploymentsNamespace,
+				},
+				Data: map[string]string{
+					"policyserver-default": policyServerYAML,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+
+			createdPS := &policiesv1.PolicyServer{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: policyServerName}, createdPS)
+			}, timeout, pollInterval).Should(Succeed())
+
+			Expect(createdPS.Labels).To(HaveKeyWithValue(constants.DefaultsManagedByLabelKey, constants.DefaultsManagedByLabelValue))
+			Expect(createdPS.Spec.Image).To(Equal(ps.Spec.Image))
+		})
+	})
+
+	Context("when ConfigMap is updated", func() {
+		It("should update the PolicyServer spec", func() {
+			initialPS := policiesv1.NewPolicyServerFactory().WithName(policyServerName).WithoutFinalizers().Build()
+			initialPS.Spec.Image = "ghcr.io/kubewarden/policy-server:v1.0.0"
+			initialYAML := marshalPolicyServer(initialPS)
+
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: deploymentsNamespace,
+				},
+				Data: map[string]string{
+					"policyserver-default": initialYAML,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+
+			createdPS := &policiesv1.PolicyServer{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: policyServerName}, createdPS)
+			}, timeout, pollInterval).Should(Succeed())
+			Expect(createdPS.Spec.Image).To(Equal("ghcr.io/kubewarden/policy-server:v1.0.0"))
+
+			updatedPS := policiesv1.NewPolicyServerFactory().WithName(policyServerName).WithoutFinalizers().Build()
+			updatedPS.Spec.Image = "ghcr.io/kubewarden/policy-server:v2.0.0"
+			updatedYAML := marshalPolicyServer(updatedPS)
+
+			Expect(k8sClient.Get(ctx, configMapNsName, cm)).To(Succeed())
+			cm.Data["policyserver-default"] = updatedYAML
+			Expect(k8sClient.Update(ctx, cm)).To(Succeed())
+
+			Eventually(func() string {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: policyServerName}, createdPS)
+				if err != nil {
+					return ""
+				}
+				return createdPS.Spec.Image
+			}, timeout, pollInterval).Should(Equal("ghcr.io/kubewarden/policy-server:v2.0.0"))
+		})
+	})
+
+	Context("when a key is removed from ConfigMap", func() {
+		It("should delete the corresponding managed resource", func() {
+			ps := policiesv1.NewPolicyServerFactory().WithName(policyServerName).WithoutFinalizers().Build()
+			policyServerYAML := marshalPolicyServer(ps)
+
+			clusterPolicy := policiesv1.NewClusterAdmissionPolicyFactory().WithName(policyName).WithoutFinalizers().Build()
+			policyYAML := marshalClusterAdmissionPolicy(clusterPolicy)
+
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: deploymentsNamespace,
+				},
+				Data: map[string]string{
+					"policyserver-default": policyServerYAML,
+					"policy":               policyYAML,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: policyServerName}, &policiesv1.PolicyServer{})
+			}, timeout, pollInterval).Should(Succeed())
+
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: policyName}, &policiesv1.ClusterAdmissionPolicy{})
+			}, timeout, pollInterval).Should(Succeed())
+
+			Expect(k8sClient.Get(ctx, configMapNsName, cm)).To(Succeed())
+			delete(cm.Data, "policy")
+			Expect(k8sClient.Update(ctx, cm)).To(Succeed())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: policyName}, &policiesv1.ClusterAdmissionPolicy{})
+				return apierrors.IsNotFound(err)
+			}, timeout, pollInterval).Should(BeTrue(), "managed policy should be deleted")
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: policyServerName}, &policiesv1.PolicyServer{})).To(Succeed())
+		})
+	})
+
+	Context("resource safety", func() {
+		It("should never delete resources without the ownership label", func() {
+			unmanagedPS := policiesv1.NewPolicyServerFactory().WithName("unmanaged-policyserver").WithoutFinalizers().Build()
+			Expect(k8sClient.Create(ctx, unmanagedPS)).To(Succeed())
+
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: deploymentsNamespace,
+				},
+				Data: map[string]string{},
+			}
+			Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+
+			Consistently(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: unmanagedPS.Name}, &policiesv1.PolicyServer{})
+			}, consistencyTimeout, pollInterval).Should(Succeed())
+
+			Expect(k8sClient.Delete(ctx, unmanagedPS)).To(Succeed())
+		})
+	})
+
+	Context("when ConfigMap has malformed YAML", func() {
+		It("should skip the malformed entry and continue with others", func() {
+			ps := policiesv1.NewPolicyServerFactory().WithName(policyServerName).WithoutFinalizers().Build()
+			policyServerYAML := marshalPolicyServer(ps)
+
+			malformedYAML := `this is not: valid: yaml: at: all`
+
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: deploymentsNamespace,
+				},
+				Data: map[string]string{
+					"policyserver-default": policyServerYAML,
+					"malformed":            malformedYAML,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+
+			createdPS := &policiesv1.PolicyServer{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: policyServerName}, createdPS)
+			}, timeout, pollInterval).Should(Succeed())
+
+			Expect(createdPS.Labels).To(HaveKeyWithValue(constants.DefaultsManagedByLabelKey, constants.DefaultsManagedByLabelValue))
+		})
+	})
+})

--- a/internal/controller/defaults_applier_test.go
+++ b/internal/controller/defaults_applier_test.go
@@ -68,8 +68,9 @@ var _ = Describe("DefaultsApplierReconciler", func() {
 		}
 	})
 
-	Context("when ConfigMap does not exist", func() {
-		It("should delete all managed resources when they exist", func() {
+	Context("when ConfigMap is deleted", func() {
+		It("should delete all managed resources", func() {
+			// First create all the managed resources by creating the ConfigMap with one entry
 			ps := policiesv1.NewPolicyServerFactory().WithName(policyServerName).WithoutFinalizers().Build()
 			policyServerYAML := marshalPolicyServer(ps)
 
@@ -88,6 +89,7 @@ var _ = Describe("DefaultsApplierReconciler", func() {
 				return k8sClient.Get(ctx, types.NamespacedName{Name: policyServerName}, &policiesv1.PolicyServer{})
 			}, timeout, pollInterval).Should(Succeed())
 
+			// Now delete the ConfigMap and verify that the managed PolicyServer is also deleted
 			Expect(k8sClient.Delete(ctx, cm)).To(Succeed())
 
 			Eventually(func() bool {
@@ -192,6 +194,9 @@ var _ = Describe("DefaultsApplierReconciler", func() {
 				return k8sClient.Get(ctx, types.NamespacedName{Name: policyName}, &policiesv1.ClusterAdmissionPolicy{})
 			}, timeout, pollInterval).Should(Succeed())
 
+			// Now remove the "policy" key from the ConfigMap and verify that the
+			// corresponding ClusterAdmissionPolicy is deleted while the PolicyServer
+			// remains
 			Expect(k8sClient.Get(ctx, configMapNsName, cm)).To(Succeed())
 			delete(cm.Data, "policy")
 			Expect(k8sClient.Update(ctx, cm)).To(Succeed())

--- a/internal/controller/managed_keys.go
+++ b/internal/controller/managed_keys.go
@@ -1,0 +1,41 @@
+package controller
+
+import (
+	"maps"
+	"slices"
+	"strings"
+)
+
+// applyManagedKeys removes keys that were previously managed (recorded in the tracking
+// annotation) but are no longer present in the desired user-defined map, then applies the new
+// desired keys and records the current managed set in the tracking annotation.
+//
+// Parameters:
+//   - existing: the map to mutate in-place (either the labels or annotations map of the object).
+//   - desired: the user-defined map from spec (may be nil).
+//   - trackingAnnotations: always the object's annotations map. The tracking key is stored here
+//     so that it never pollutes the labels map. When existing is itself the annotations map
+//     (i.e. when managing annotations) both parameters point to the same map.
+//   - trackingKey: the annotation key used to store the comma-separated list of managed keys.
+func applyManagedKeys(existing map[string]string, desired map[string]string, trackingAnnotations map[string]string, trackingKey string) {
+	// Remove keys that were managed last time but are no longer desired.
+	if prev, found := trackingAnnotations[trackingKey]; found && prev != "" {
+		for _, key := range strings.Split(prev, ",") {
+			if _, stillDesired := desired[key]; !stillDesired {
+				delete(existing, key)
+			}
+		}
+	}
+
+	// Apply desired keys (user-defined values first; system values will overwrite after this call).
+	for key, value := range desired {
+		existing[key] = value
+	}
+
+	// Record the current set of managed keys, or remove the tracking annotation when none remain.
+	if len(desired) == 0 {
+		delete(trackingAnnotations, trackingKey)
+	} else {
+		trackingAnnotations[trackingKey] = strings.Join(slices.Collect(maps.Keys(desired)), ",")
+	}
+}

--- a/internal/controller/managed_keys_test.go
+++ b/internal/controller/managed_keys_test.go
@@ -1,0 +1,159 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const trackingKey = "kubewarden.io/managed-keys"
+
+func TestApplyManagedKeys(t *testing.T) {
+	tests := []struct {
+		name         string
+		existing     map[string]string
+		desired      map[string]string
+		tracking     map[string]string
+		wantExisting map[string]string
+		wantTracking map[string]string // full expected state of the tracking map after the call
+	}{
+		{
+			name:         "first apply, single key",
+			existing:     map[string]string{"system-key": "system-value"},
+			desired:      map[string]string{"user-key": "user-value"},
+			tracking:     map[string]string{},
+			wantExisting: map[string]string{"system-key": "system-value", "user-key": "user-value"},
+			wantTracking: map[string]string{trackingKey: "user-key"},
+		},
+		{
+			name:         "first apply, multiple keys",
+			existing:     map[string]string{"system-key": "system-value"},
+			desired:      map[string]string{"user-key-a": "value-a", "user-key-b": "value-b"},
+			tracking:     map[string]string{},
+			wantExisting: map[string]string{"system-key": "system-value", "user-key-a": "value-a", "user-key-b": "value-b"},
+			wantTracking: map[string]string{trackingKey: "user-key-a,user-key-b"},
+		},
+		{
+			name:         "idempotent re-apply",
+			existing:     map[string]string{"user-key": "user-value", "system-key": "system-value"},
+			desired:      map[string]string{"user-key": "user-value"},
+			tracking:     map[string]string{trackingKey: "user-key"},
+			wantExisting: map[string]string{"user-key": "user-value", "system-key": "system-value"},
+			wantTracking: map[string]string{trackingKey: "user-key"},
+		},
+		{
+			name:         "stale key removed",
+			existing:     map[string]string{"old-key": "old-value", "system-key": "system-value"},
+			desired:      map[string]string{"new-key": "new-value"},
+			tracking:     map[string]string{trackingKey: "old-key"},
+			wantExisting: map[string]string{"new-key": "new-value", "system-key": "system-value"},
+			wantTracking: map[string]string{trackingKey: "new-key"},
+		},
+		{
+			name:         "2 managed keys reduced to 1",
+			existing:     map[string]string{"key-a": "value-a", "key-b": "value-b", "system-key": "system-value"},
+			desired:      map[string]string{"key-b": "value-b"},
+			tracking:     map[string]string{trackingKey: "key-a,key-b"},
+			wantExisting: map[string]string{"key-b": "value-b", "system-key": "system-value"},
+			wantTracking: map[string]string{trackingKey: "key-b"},
+		},
+		{
+			name:         "all keys go stale, nil desired",
+			existing:     map[string]string{"managed-key": "managed-value", "system-key": "system-value"},
+			desired:      nil,
+			tracking:     map[string]string{trackingKey: "managed-key"},
+			wantExisting: map[string]string{"system-key": "system-value"},
+			wantTracking: map[string]string{},
+		},
+		{
+			name:         "all keys go stale, multiple tracked, nil desired",
+			existing:     map[string]string{"managed-key-a": "value-a", "managed-key-b": "value-b", "system-key": "system-value"},
+			desired:      nil,
+			tracking:     map[string]string{trackingKey: "managed-key-a,managed-key-b"},
+			wantExisting: map[string]string{"system-key": "system-value"},
+			wantTracking: map[string]string{},
+		},
+		{
+			name:         "unmanaged keys preserved when desired is empty",
+			existing:     map[string]string{"system-key": "system-value", "another-key": "another-value"},
+			desired:      map[string]string{},
+			tracking:     map[string]string{trackingKey: ""},
+			wantExisting: map[string]string{"system-key": "system-value", "another-key": "another-value"},
+			wantTracking: map[string]string{},
+		},
+		{
+			name:         "desired value updated",
+			existing:     map[string]string{"user-key": "old-value"},
+			desired:      map[string]string{"user-key": "new-value"},
+			tracking:     map[string]string{trackingKey: "user-key"},
+			wantExisting: map[string]string{"user-key": "new-value"},
+			wantTracking: map[string]string{trackingKey: "user-key"},
+		},
+		{
+			name:     "other annotations in tracking map are preserved",
+			existing: map[string]string{"user-key": "user-value", "system-key": "system-value"},
+			desired:  map[string]string{"user-key": "user-value"},
+			tracking: map[string]string{
+				trackingKey:             "user-key",
+				"some-other-annotation": "some-value",
+				"another-annotation":    "another-value",
+			},
+			wantExisting: map[string]string{"user-key": "user-value", "system-key": "system-value"},
+			wantTracking: map[string]string{
+				trackingKey:             "user-key",
+				"some-other-annotation": "some-value",
+				"another-annotation":    "another-value",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applyManagedKeys(tt.existing, tt.desired, tt.tracking, trackingKey)
+
+			assert.Equal(t, tt.wantExisting, tt.existing, "existing map mismatch")
+
+			// Verify the tracking map matches expectations exactly.
+			// The trackingKey value is compared order-agnostically since maps.Keys is non-deterministic.
+			// All other entries are compared with exact equality via assert.Equal at the end.
+			if _, ok := tt.wantTracking[trackingKey]; ok {
+				assert.ElementsMatch(t,
+					strings.Split(tt.wantTracking[trackingKey], ","),
+					strings.Split(tt.tracking[trackingKey], ","),
+					"managed keys in tracking annotation mismatch",
+				)
+			}
+			for key, wantVal := range tt.wantTracking {
+				if key != trackingKey {
+					assert.Equal(t, wantVal, tt.tracking[key], "tracking[%q] mismatch", key)
+				}
+			}
+			for key := range tt.tracking {
+				if _, expected := tt.wantTracking[key]; !expected {
+					t.Errorf("tracking contains unexpected key %q", key)
+				}
+			}
+		})
+	}
+}
+
+// TestApplyManagedKeys_LabelTrackingStoredInAnnotations covers the only valid pattern for
+// managing labels: desired keys are written into the labels map, but the tracking key is
+// always stored in the annotations map. Labels must never carry tracking keys.
+func TestApplyManagedKeys_LabelTrackingStoredInAnnotations(t *testing.T) {
+	labels := map[string]string{
+		"old-label":    "old-value",
+		"system-label": "system-value",
+	}
+	annotations := map[string]string{trackingKey: "old-label"}
+	desired := map[string]string{"new-label": "new-value"}
+
+	applyManagedKeys(labels, desired, annotations, trackingKey)
+
+	assert.NotContains(t, labels, "old-label", "stale old-label should be removed from labels")
+	assert.Equal(t, "new-value", labels["new-label"], "new-label should be applied to labels")
+	assert.Equal(t, "system-value", labels["system-label"], "unmanaged system-label should be preserved")
+	assert.Equal(t, "new-label", annotations[trackingKey], "tracking annotation should record new-label")
+	assert.NotContains(t, annotations, "new-label", "label key must not leak into the annotations map")
+}

--- a/internal/controller/policyserver_controller_deployment.go
+++ b/internal/controller/policyserver_controller_deployment.go
@@ -7,9 +7,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
-	"slices"
 	"strconv"
-	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -332,35 +330,6 @@ func configuresInsecureSources(policyServer *policiesv1.PolicyServer, admissionC
 	}
 }
 
-// applyManagedKeys removes keys that were previously managed (recorded in the tracking
-// annotation/label) but are no longer present in the desired user-defined map, then applies
-// the new desired keys and records the current managed set in the tracking annotation.
-//
-// Parameters:
-//   - existing: the current annotation/label map on the object (mutated in-place).
-//   - desired: the user-defined map from spec (may be nil).
-//   - trackingAnnotations: the annotation map where the tracking key is stored (may differ from
-//     existing when we track label keys inside the annotation map).
-//   - trackingKey: the annotation key used to store the comma-separated list of managed keys.
-func applyManagedKeys(existing map[string]string, desired map[string]string, trackingAnnotations map[string]string, trackingKey string) {
-	// Remove keys that were managed last time but are no longer desired.
-	if prev, found := trackingAnnotations[trackingKey]; found && prev != "" {
-		for _, key := range strings.Split(prev, ",") {
-			if _, stillDesired := desired[key]; !stillDesired {
-				delete(existing, key)
-			}
-		}
-	}
-
-	// Apply desired keys (user-defined values first; system values will overwrite after this call).
-	for key, value := range desired {
-		existing[key] = value
-	}
-
-	// Record the current set of managed keys.
-	trackingAnnotations[trackingKey] = strings.Join(slices.Collect(maps.Keys(desired)), ",")
-}
-
 func configureLabelsAndAnnotations(policyServerDeployment *appsv1.Deployment, policyServer *policiesv1.PolicyServer, configMapVersion string) {
 	// --- Annotations ---
 	if policyServerDeployment.ObjectMeta.Annotations == nil {
@@ -371,7 +340,7 @@ func configureLabelsAndAnnotations(policyServerDeployment *appsv1.Deployment, po
 		policyServerDeployment.ObjectMeta.Annotations,
 		policyServer.Spec.Annotations,
 		policyServerDeployment.ObjectMeta.Annotations,
-		constants.PolicyServerDeploymentManagedAnnotationKeysAnnotation,
+		constants.ManagedAnnotationKeysAnnotation,
 	)
 	// System annotation always wins.
 	policyServerDeployment.ObjectMeta.Annotations[constants.PolicyServerDeploymentConfigVersionAnnotation] = configMapVersion
@@ -386,7 +355,7 @@ func configureLabelsAndAnnotations(policyServerDeployment *appsv1.Deployment, po
 		policyServerDeployment.Labels,
 		policyServer.Spec.Labels,
 		policyServerDeployment.ObjectMeta.Annotations,
-		constants.PolicyServerDeploymentManagedLabelKeysAnnotation,
+		constants.ManagedLabelKeysAnnotation,
 	)
 	// System labels always win.
 	policyServerDeployment.Labels[constants.PolicyServerLabelKey] = policyServer.Name

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -138,6 +138,15 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	err = (&DefaultsApplierReconciler{
+		Client:               k8sManager.GetClient(),
+		Scheme:               k8sManager.GetScheme(),
+		Log:                  ctrl.Log.WithName("defaults-applier-test"),
+		DeploymentsNamespace: deploymentsNamespace,
+		ConfigMapName:        constants.DefaultDefaultsConfigMapName,
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
 	// Create the integration tests deployments namespace
 	err = k8sClient.Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -40,7 +40,6 @@ import (
 )
 
 const (
-	integrationTestsFinalizer = "kubewarden.io/integration-tests-safety-net-finalizer"
 	clientCAConfigMapName     = "client-ca"
 	fakeSigstoreTrustConfig   = `{"trusted_root": {"version": "test"}}`
 	reconcilerImagePullSecret = "reconciler-pull-secret"


### PR DESCRIPTION
### Description

Add a new reconciler that watches a ConfigMap containing default Kubewarden resources (PolicyServer, policies) and applies them to the cluster. It manages resource lifecycle via ownership labels and cleans up stale resources when entries are removed from the ConfigMap.

This enables moving default resource management from Helm chart templates into the controller itself.

This is a first change of a series of the changes necessary to implement the [RFC 0026](https://github.com/kubewarden/rfc/blob/main/rfc/0026-unified-admission-controller-chart.md). This is done to make the review smoothly and easy to follow.
