### PR TITLE
ci: ignore proc-macro-error2 crate not being maintained

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -71,6 +71,7 @@ ignore = [
   { id = "RUSTSEC-2023-0071", reason = "rsa side channel attack, no fix exists yet" },
   { id = "RUSTSEC-2024-0436", reason = "paste, no longer maintained. transitive dependency" },
   { id = "RUSTSEC-2025-0069", reason = "daemonize crate is no longer maintained" },
+  { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is no longer maintained" },
 ]
 
 # If this is true, then cargo deny will use the git executable to fetch advisory database.


### PR DESCRIPTION
Update cargo deny configuration to ignore `proc-macro-error2` (a dependency of `validator`) being no longer maintained.

Waiting for https://github.com/Keats/validator/issues/396 to be addressed.
