### PR TITLE
fix(kwctl): improve reporting about host capabilities

### DIFF
--- a/crates/kwctl/src/annotate.rs
+++ b/crates/kwctl/src/annotate.rs
@@ -6,7 +6,8 @@ use std::{
 
 use anyhow::{Result, anyhow};
 use policy_evaluator::{
-    ProtocolVersion, constants::*, policy_metadata::Metadata, validator::Validate,
+    ProtocolVersion, constants::*, host_capabilities::HostCapabilities, policy_metadata::Metadata,
+    validator::Validate,
 };
 use tracing::warn;
 
@@ -82,6 +83,60 @@ fn prepare_metadata(
         .and(Ok(metadata))
 }
 
+/// Holds the result of comparing detected host capabilities against declared ones.
+#[derive(Debug, Default, PartialEq)]
+struct CapabilitiesMismatch {
+    /// Capability paths detected in the policy binary that are not covered by
+    /// any declared pattern.
+    used_but_undeclared: BTreeSet<String>,
+    /// Declared patterns that do not cover any capability path detected in the
+    /// binary.  For [`HostCapabilities::AllowAll`] this always contains `"*"`
+    /// to signal that the wildcard is too permissive.
+    declared_but_unused: BTreeSet<String>,
+}
+
+/// Pure helper: given the set of detected capability paths and the parsed
+/// `HostCapabilities`, returns a [`CapabilitiesMismatch`] describing patterns
+/// that are used-but-undeclared and declared-but-unused.
+fn compute_capabilities_mismatch(
+    detected_set: &BTreeSet<String>,
+    host_capabilities: &HostCapabilities,
+) -> CapabilitiesMismatch {
+    // Capabilities the policy uses but that are not covered by the declarations.
+    let used_but_undeclared: BTreeSet<String> = detected_set
+        .iter()
+        .filter(|cap| !host_capabilities.is_allowed(cap.as_str()))
+        .cloned()
+        .collect();
+
+    // Declared patterns that don't match anything in the detected set.
+    let declared_but_unused: BTreeSet<String> = match host_capabilities {
+        HostCapabilities::DenyAll => BTreeSet::new(),
+        // The `*` wildcard is always considered too permissive — the caller
+        // will emit a dedicated warning regardless of what was detected.
+        HostCapabilities::AllowAll => BTreeSet::from(["*".to_string()]),
+        HostCapabilities::Patterns { prefixes, exact } => {
+            let mut unused: BTreeSet<String> = exact.difference(detected_set).cloned().collect();
+            for prefix in prefixes {
+                if !detected_set
+                    .iter()
+                    .any(|cap| cap.starts_with(prefix.as_str()))
+                {
+                    // Re-attach the `*` that was stripped during parsing so
+                    // the warning is human-readable (e.g. `oci/*`).
+                    unused.insert(format!("{prefix}*"));
+                }
+            }
+            unused
+        }
+    };
+
+    CapabilitiesMismatch {
+        used_but_undeclared,
+        declared_but_unused,
+    }
+}
+
 fn warn_on_capabilities_mismatch(
     detected: &[wasm_scanner::DetectedHostCapability],
     metadata: &Metadata,
@@ -91,27 +146,36 @@ fn warn_on_capabilities_mismatch(
         .map(|c| format!("{}/{}", c.namespace, c.operation))
         .collect();
 
-    let declared_set: BTreeSet<String> = metadata
-        .host_capabilities
-        .as_ref()
-        .cloned()
-        .unwrap_or_default();
+    let host_capabilities =
+        match HostCapabilities::new(metadata.host_capabilities.iter().flat_map(|s| s.iter())) {
+            Ok(hc) => hc,
+            Err(e) => {
+                warn!("invalid host_capabilities pattern in metadata: {}", e);
+                return;
+            }
+        };
 
-    let used_but_undeclared: BTreeSet<&String> = detected_set.difference(&declared_set).collect();
-    let declared_but_unused: BTreeSet<&String> = declared_set.difference(&detected_set).collect();
+    let mismatch = compute_capabilities_mismatch(&detected_set, &host_capabilities);
 
-    if !used_but_undeclared.is_empty() {
+    if !mismatch.used_but_undeclared.is_empty() {
         warn!(
-            capabilities = ?used_but_undeclared,
+            capabilities = ?mismatch.used_but_undeclared,
             "host capabilities used by the policy but not declared in metadata"
         );
     }
 
-    if !declared_but_unused.is_empty() {
-        warn!(
-            capabilities = ?declared_but_unused,
-            "host capabilities declared in metadata but not detected in the policy"
-        );
+    if !mismatch.declared_but_unused.is_empty() {
+        if matches!(host_capabilities, HostCapabilities::AllowAll) {
+            warn!(
+                "metadata declares all host capabilities (*); consider restricting \
+                 to only the capabilities actually used by the policy"
+            );
+        } else {
+            warn!(
+                capabilities = ?mismatch.declared_but_unused,
+                "host capabilities declared in metadata but not detected in the policy"
+            );
+        }
     }
 }
 
@@ -154,6 +218,111 @@ mod tests {
     use super::*;
     use std::io::Write;
     use tempfile::tempdir;
+
+    use rstest::rstest;
+
+    fn detected(caps: &[(&str, &str)]) -> BTreeSet<String> {
+        caps.iter().map(|(ns, op)| format!("{ns}/{op}")).collect()
+    }
+
+    #[rstest]
+    #[case::deny_all_nothing_detected(
+        vec![],                  // detected
+        vec![],                  // declared
+        vec![],                  // used_but_undeclared
+        vec![],                  // declared_but_unused
+    )]
+    #[case::deny_all_with_detected(
+        vec![("oci", "v1/verify")], // detected
+        vec![],                     // declared
+        vec!["oci/v1/verify"],      // used_but_undeclared
+        vec![],                     // declared_but_unused
+    )]
+    #[case::allow_all_with_detected(
+        vec![("oci", "v1/verify")], // detected
+        vec!["*"],                  // declared
+        vec![],                     // used_but_undeclared
+        vec!["*"],                  // declared_but_unused
+    )]
+    #[case::allow_all_nothing_detected(
+        vec![],    // detected
+        vec!["*"], // declared
+        vec![],    // used_but_undeclared
+        vec!["*"], // declared_but_unused
+    )]
+    #[case::prefix_covers_single(
+        vec![("oci", "v1/verify")], // detected
+        vec!["oci/*"],              // declared
+        vec![],                     // used_but_undeclared
+        vec![],                     // declared_but_unused
+    )]
+    #[case::prefix_covers_multiple(
+        vec![("oci", "v1/verify"), ("oci", "v1/manifest_digest")], // detected
+        vec!["oci/*"],                                              // declared
+        vec![],                                                     // used_but_undeclared
+        vec![],                                                     // declared_but_unused
+    )]
+    #[case::prefix_declared_nothing_detected(
+        vec![],        // detected
+        vec!["oci/*"], // declared
+        vec![],        // used_but_undeclared
+        vec!["oci/*"], // declared_but_unused
+    )]
+    #[case::prefix_other_namespace(
+        vec![("net", "v1/dns_lookup_host")], // detected
+        vec!["oci/*"],                       // declared
+        vec!["net/v1/dns_lookup_host"],      // used_but_undeclared
+        vec!["oci/*"],                       // declared_but_unused
+    )]
+    #[case::exact_match(
+        vec![("oci", "v1/verify")], // detected
+        vec!["oci/v1/verify"],      // declared
+        vec![],                     // used_but_undeclared
+        vec![],                     // declared_but_unused
+    )]
+    #[case::exact_used_but_undeclared(
+        vec![("oci", "v1/verify"), ("net", "v1/dns_lookup_host")], // detected
+        vec!["oci/v1/verify"],                                      // declared
+        vec!["net/v1/dns_lookup_host"],                             // used_but_undeclared
+        vec![],                                                     // declared_but_unused
+    )]
+    #[case::exact_declared_but_unused(
+        vec![("oci", "v1/verify")],                        // detected
+        vec!["oci/v1/verify", "net/v1/dns_lookup_host"],   // declared
+        vec![],                                            // used_but_undeclared
+        vec!["net/v1/dns_lookup_host"],                    // declared_but_unused
+    )]
+    #[case::versioned_prefix_covers(
+        vec![("oci", "v2/verify")], // detected
+        vec!["oci/v2/*"],           // declared
+        vec![],                     // used_but_undeclared
+        vec![],                     // declared_but_unused
+    )]
+    #[case::versioned_prefix_other_version(
+        vec![("oci", "v1/verify")], // detected
+        vec!["oci/v2/*"],           // declared
+        vec!["oci/v1/verify"],      // used_but_undeclared
+        vec!["oci/v2/*"],           // declared_but_unused
+    )]
+    fn compute_mismatch(
+        #[case] detected_caps: Vec<(&str, &str)>,
+        #[case] declared_patterns: Vec<&str>,
+        #[case] expected_used_but_undeclared: Vec<&str>,
+        #[case] expected_declared_but_unused: Vec<&str>,
+    ) {
+        let hc = HostCapabilities::new(declared_patterns).unwrap();
+        let mismatch = compute_capabilities_mismatch(&detected(&detected_caps), &hc);
+        let expected_used: BTreeSet<String> = expected_used_but_undeclared
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        let expected_unused: BTreeSet<String> = expected_declared_but_unused
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        assert_eq!(mismatch.used_but_undeclared, expected_used);
+        assert_eq!(mismatch.declared_but_unused, expected_unused);
+    }
 
     fn mock_protocol_version_detector_v1(_wasm_path: PathBuf) -> Result<ProtocolVersion> {
         Ok(ProtocolVersion::V1)

--- a/crates/kwctl/src/config/policy_definition.rs
+++ b/crates/kwctl/src/config/policy_definition.rs
@@ -520,6 +520,7 @@ mod tests {
                 assert_eq!(custom_rejection_message, Some("foo".to_string()));
                 assert_eq!(settings, expected_settings);
                 assert!(matches!(ctx_aware_cfg, ContextAwareConfiguration::NoAccess));
+                assert!(allowed_host_capabilities.is_empty());
             }
             _ => panic!("Expected Individual PolicyDefinition"),
         }
@@ -610,6 +611,7 @@ mod tests {
                     ctx_aware_cfg,
                     ContextAwareConfiguration::AllowList(expected_context_aware_resources)
                 );
+                assert!(allowed_host_capabilities.is_empty());
             }
             _ => panic!("Expected Individual PolicyDefinition"),
         }

--- a/crates/policy-evaluator/src/host_capabilities.rs
+++ b/crates/policy-evaluator/src/host_capabilities.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet},
     fmt,
     sync::LazyLock,
 };
@@ -11,26 +11,26 @@ use crate::errors::HostCapabilitiesPatternError;
 /// A node in the host-capability path tree.
 /// Leaf nodes (complete, addressable operations) have a `None` value.
 /// Intermediate nodes carry a `Some` map of named children.
-struct CapabilityNode(HashMap<&'static str, Option<Box<CapabilityNode>>>);
+struct CapabilityNode(BTreeMap<&'static str, Option<Box<CapabilityNode>>>);
 
 impl CapabilityNode {
     fn leaf() -> Option<Box<Self>> {
         None
     }
 
-    fn node(children: HashMap<&'static str, Option<Box<Self>>>) -> Option<Box<Self>> {
+    fn node(children: BTreeMap<&'static str, Option<Box<Self>>>) -> Option<Box<Self>> {
         Some(Box::new(Self(children)))
     }
 }
 
 static CAPABILITY_TREE: LazyLock<CapabilityNode> = LazyLock::new(|| {
-    CapabilityNode(HashMap::from([
+    CapabilityNode(BTreeMap::from([
         (
             "oci",
-            CapabilityNode::node(HashMap::from([
+            CapabilityNode::node(BTreeMap::from([
                 (
                     "v1",
-                    CapabilityNode::node(HashMap::from([
+                    CapabilityNode::node(BTreeMap::from([
                         ("verify", CapabilityNode::leaf()),
                         ("manifest_digest", CapabilityNode::leaf()),
                         ("oci_manifest", CapabilityNode::leaf()),
@@ -39,22 +39,25 @@ static CAPABILITY_TREE: LazyLock<CapabilityNode> = LazyLock::new(|| {
                 ),
                 (
                     "v2",
-                    CapabilityNode::node(HashMap::from([("verify", CapabilityNode::leaf())])),
+                    CapabilityNode::node(BTreeMap::from([("verify", CapabilityNode::leaf())])),
                 ),
             ])),
         ),
         (
             "net",
-            CapabilityNode::node(HashMap::from([(
+            CapabilityNode::node(BTreeMap::from([(
                 "v1",
-                CapabilityNode::node(HashMap::from([("dns_lookup_host", CapabilityNode::leaf())])),
+                CapabilityNode::node(BTreeMap::from([(
+                    "dns_lookup_host",
+                    CapabilityNode::leaf(),
+                )])),
             )])),
         ),
         (
             "crypto",
-            CapabilityNode::node(HashMap::from([(
+            CapabilityNode::node(BTreeMap::from([(
                 "v1",
-                CapabilityNode::node(HashMap::from([(
+                CapabilityNode::node(BTreeMap::from([(
                     "is_certificate_trusted",
                     CapabilityNode::leaf(),
                 )])),
@@ -62,7 +65,7 @@ static CAPABILITY_TREE: LazyLock<CapabilityNode> = LazyLock::new(|| {
         ),
         (
             "kubernetes",
-            CapabilityNode::node(HashMap::from([
+            CapabilityNode::node(BTreeMap::from([
                 ("list_resources_by_namespace", CapabilityNode::leaf()),
                 ("list_resources_all", CapabilityNode::leaf()),
                 ("get_resource", CapabilityNode::leaf()),
@@ -97,8 +100,7 @@ fn validate_against_tree(pattern: &str) -> Result<(), HostCapabilitiesPatternErr
 
         match node.0.get(part) {
             None => {
-                let mut valid: Vec<&str> = node.0.keys().copied().collect();
-                valid.sort_unstable();
+                let valid: Vec<&str> = node.0.keys().copied().collect();
                 return Err(HostCapabilitiesPatternError::UnknownSegment {
                     pattern: pattern.to_string(),
                     segment: part.to_string(),
@@ -160,9 +162,9 @@ pub enum HostCapabilities {
     /// Allow specific capabilities matched by prefix or exact patterns.
     Patterns {
         /// Prefix patterns (e.g., `oci/` from `oci/*`, `oci/v2/` from `oci/v2/*`)
-        prefixes: HashSet<String>,
+        prefixes: BTreeSet<String>,
         /// Exact capability paths (e.g., `oci/v1/verify`)
-        exact: HashSet<String>,
+        exact: BTreeSet<String>,
     },
 }
 
@@ -206,8 +208,8 @@ impl HostCapabilities {
     pub fn new(
         patterns: impl IntoIterator<Item = impl AsRef<str>>,
     ) -> Result<Self, HostCapabilitiesPatternError> {
-        let mut prefixes = HashSet::new();
-        let mut exact = HashSet::new();
+        let mut prefixes = BTreeSet::new();
+        let mut exact = BTreeSet::new();
 
         for pattern in patterns {
             let pattern = pattern.as_ref();
@@ -276,10 +278,7 @@ impl From<HostCapabilities> for Vec<String> {
             HostCapabilities::Patterns { prefixes, exact } => {
                 let mut result: Vec<String> =
                     prefixes.into_iter().map(|p| format!("{p}*")).collect();
-                result.sort();
-                let mut exact_sorted: Vec<String> = exact.into_iter().collect();
-                exact_sorted.sort();
-                result.extend(exact_sorted);
+                result.extend(exact);
                 result
             }
         }
@@ -293,10 +292,7 @@ impl fmt::Display for HostCapabilities {
             Self::DenyAll => write!(f, "[]"),
             Self::Patterns { prefixes, exact } => {
                 let mut items: Vec<String> = prefixes.iter().map(|p| format!("{p}*")).collect();
-                items.sort();
-                let mut exact_sorted: Vec<&String> = exact.iter().collect();
-                exact_sorted.sort();
-                items.extend(exact_sorted.into_iter().cloned());
+                items.extend(exact.iter().cloned());
                 write!(f, "[{}]", items.join(", "))
             }
         }


### PR DESCRIPTION
Prior to this change, the `kwctl annotate` did a too naive comparison between what the policy metadata declared and what was actually used. The comparison didn't support `*` inside of metadata, hence a lot of wrong complains were returned to the user.
