### PR TITLE
feat(policy-evaluator) : Provide an option to disable caching when listing resources

### DIFF
--- a/crates/policy-evaluator/src/callback_handler.rs
+++ b/crates/policy-evaluator/src/callback_handler.rs
@@ -210,47 +210,86 @@ impl CallbackHandler {
                     namespace,
                     label_selector,
                     field_selector,
+                    disable_cache,
                     field_masks,
                 } => {
-                    handle_callback!(
-                        req,
-                        format!("[{namespace}] {api_version}/{kind}"),
-                        "List namespaced Kubernetes resource",
-                        {
-                            kubernetes::list_resources_by_namespace(
-                                kubernetes_client.as_mut(),
-                                &api_version,
-                                &kind,
-                                &namespace,
-                                label_selector,
-                                field_selector,
-                                field_masks,
-                            )
-                        }
-                    )
+                    if disable_cache {
+                        handle_callback!(
+                            req,
+                            format!("[{namespace}] {api_version}/{kind}"),
+                            "List namespaced Kubernetes resource - no cache",
+                            {
+                                kubernetes::list_resources_by_namespace_direct(
+                                    kubernetes_client.as_mut(),
+                                    &api_version,
+                                    &kind,
+                                    &namespace,
+                                    label_selector,
+                                    field_selector,
+                                    field_masks,
+                                )
+                            }
+                        )
+                    } else {
+                        handle_callback!(
+                            req,
+                            format!("[{namespace}] {api_version}/{kind}"),
+                            "List namespaced Kubernetes resource",
+                            {
+                                kubernetes::list_resources_by_namespace(
+                                    kubernetes_client.as_mut(),
+                                    &api_version,
+                                    &kind,
+                                    &namespace,
+                                    label_selector,
+                                    field_selector,
+                                    field_masks,
+                                )
+                            }
+                        )
+                    }
                 }
                 CallbackRequestType::KubernetesListResourceAll {
                     api_version,
                     kind,
                     label_selector,
                     field_selector,
+                    disable_cache,
                     field_masks,
                 } => {
-                    handle_callback!(
-                        req,
-                        format!("{api_version}/{kind}"),
-                        "List Kubernetes resource",
-                        {
-                            kubernetes::list_resources_all(
-                                kubernetes_client.as_mut(),
-                                &api_version,
-                                &kind,
-                                label_selector,
-                                field_selector,
-                                field_masks,
-                            )
-                        }
-                    )
+                    if disable_cache {
+                        handle_callback!(
+                            req,
+                            format!("{api_version}/{kind}"),
+                            "List Kubernetes resource - no cache",
+                            {
+                                kubernetes::list_resources_all_direct(
+                                    kubernetes_client.as_mut(),
+                                    &api_version,
+                                    &kind,
+                                    label_selector,
+                                    field_selector,
+                                    field_masks,
+                                )
+                            }
+                        )
+                    } else {
+                        handle_callback!(
+                            req,
+                            format!("{api_version}/{kind}"),
+                            "List Kubernetes resource",
+                            {
+                                kubernetes::list_resources_all(
+                                    kubernetes_client.as_mut(),
+                                    &api_version,
+                                    &kind,
+                                    label_selector,
+                                    field_selector,
+                                    field_masks,
+                                )
+                            }
+                        )
+                    }
                 }
                 CallbackRequestType::KubernetesGetResource {
                     api_version,

--- a/crates/policy-evaluator/src/callback_handler/kubernetes.rs
+++ b/crates/policy-evaluator/src/callback_handler/kubernetes.rs
@@ -77,6 +77,62 @@ pub(crate) async fn list_resources_all(
         .map(cached::Return::new)
 }
 
+/// Like [`list_resources_by_namespace`], but performs a direct, one-shot call to the
+/// Kubernetes API Server instead of relying on a reflector.
+pub(crate) async fn list_resources_by_namespace_direct(
+    client: Option<&mut Client>,
+    api_version: &str,
+    kind: &str,
+    namespace: &str,
+    label_selector: Option<String>,
+    field_selector: Option<String>,
+    field_masks: Option<BTreeSet<String>>,
+) -> Result<cached::Return<ObjectList<kube::core::DynamicObject>>> {
+    if client.is_none() {
+        return Err(anyhow!("kube::Client was not initialized properly")).map(cached::Return::new);
+    }
+
+    client
+        .unwrap()
+        .list_resources_by_namespace_direct(
+            api_version,
+            kind,
+            namespace,
+            label_selector,
+            field_selector,
+            field_masks,
+        )
+        .await
+        .map(cached::Return::new)
+}
+
+/// Like [`list_resources_all`], but performs a direct, one-shot call to the
+/// Kubernetes API Server instead of relying on a reflector.
+pub(crate) async fn list_resources_all_direct(
+    client: Option<&mut Client>,
+    api_version: &str,
+    kind: &str,
+    label_selector: Option<String>,
+    field_selector: Option<String>,
+    field_masks: Option<BTreeSet<String>>,
+) -> Result<cached::Return<ObjectList<kube::core::DynamicObject>>> {
+    if client.is_none() {
+        return Err(anyhow!("kube::Client was not initialized properly")).map(cached::Return::new);
+    }
+
+    client
+        .unwrap()
+        .list_resources_all_direct(
+            api_version,
+            kind,
+            label_selector,
+            field_selector,
+            field_masks,
+        )
+        .await
+        .map(cached::Return::new)
+}
+
 pub(crate) async fn get_resource(
     client: Option<&mut Client>,
     api_version: &str,

--- a/crates/policy-evaluator/src/callback_handler/kubernetes/client.rs
+++ b/crates/policy-evaluator/src/callback_handler/kubernetes/client.rs
@@ -13,10 +13,7 @@ use kube::{
 use kubewarden_policy_sdk::host_capabilities::kubernetes::SubjectAccessReview as KWSubjectAccessReview;
 use tokio::{sync::RwLock, time::Instant};
 
-use crate::callback_handler::kubernetes::{
-    ApiVersionKind, KubeResource, field_mask,
-    reflector::{Reflector, modify_object},
-};
+use crate::callback_handler::kubernetes::{ApiVersionKind, KubeResource, field_mask, reflector::Reflector};
 
 #[derive(Clone)]
 pub(crate) struct Client {
@@ -411,7 +408,7 @@ async fn list_resources_direct(
     let field_masker: Option<field_mask::FieldMaskNode> =
         field_masks.map(field_mask::FieldMaskNode::new);
     for item in &mut list.items {
-        modify_object(item, field_masker.as_ref());
+        field_mask::modify_object(item, field_masker.as_ref());
     }
 
     Ok(list)

--- a/crates/policy-evaluator/src/callback_handler/kubernetes/client.rs
+++ b/crates/policy-evaluator/src/callback_handler/kubernetes/client.rs
@@ -13,7 +13,10 @@ use kube::{
 use kubewarden_policy_sdk::host_capabilities::kubernetes::SubjectAccessReview as KWSubjectAccessReview;
 use tokio::{sync::RwLock, time::Instant};
 
-use crate::callback_handler::kubernetes::{ApiVersionKind, KubeResource, reflector::Reflector};
+use crate::callback_handler::kubernetes::{
+    ApiVersionKind, KubeResource, field_mask,
+    reflector::{Reflector, modify_object},
+};
 
 #[derive(Clone)]
 pub(crate) struct Client {
@@ -180,6 +183,53 @@ impl Client {
         .await
     }
 
+    /// List resources matching the given criteria with a direct, one-shot call to the
+    /// Kubernetes API Server, bypassing the reflector cache.
+    pub async fn list_resources_by_namespace_direct(
+        &mut self,
+        api_version: &str,
+        kind: &str,
+        namespace: &str,
+        label_selector: Option<String>,
+        field_selector: Option<String>,
+        field_masks: Option<BTreeSet<String>>,
+    ) -> Result<ObjectList<kube::core::DynamicObject>> {
+        let resource = self.build_kube_resource(api_version, kind).await?;
+        if !resource.namespaced {
+            return Err(anyhow!(
+                "resource {api_version}/{kind} is cluster wide. Cannot search for it inside of a namespace"
+            ));
+        }
+
+        let api = kube::api::Api::<kube::core::DynamicObject>::namespaced_with(
+            self.kube_client.clone(),
+            namespace,
+            &resource.resource,
+        );
+
+        list_resources_direct(api, label_selector, field_selector, field_masks).await
+    }
+
+    /// List resources matching the given criteria with a direct, one-shot call to the
+    /// Kubernetes API Server, bypassing the reflector cache.
+    pub async fn list_resources_all_direct(
+        &mut self,
+        api_version: &str,
+        kind: &str,
+        label_selector: Option<String>,
+        field_selector: Option<String>,
+        field_masks: Option<BTreeSet<String>>,
+    ) -> Result<ObjectList<kube::core::DynamicObject>> {
+        let resource = self.build_kube_resource(api_version, kind).await?;
+
+        let api = kube::api::Api::<kube::core::DynamicObject>::all_with(
+            self.kube_client.clone(),
+            &resource.resource,
+        );
+
+        list_resources_direct(api, label_selector, field_selector, field_masks).await
+    }
+
     pub async fn has_list_resources_all_result_changed_since_instant(
         &mut self,
         api_version: &str,
@@ -337,4 +387,32 @@ impl Client {
                 .ok_or(anyhow!("SubjectAccessReview did not return a response"))
         })
     }
+}
+
+/// Perform a one-shot list call against the Kubernetes API Server, applying the same
+/// object pruning (managed fields, last-applied-configuration annotation, field masks)
+/// that the reflector applies to the objects it caches.
+async fn list_resources_direct(
+    api: kube::api::Api<kube::core::DynamicObject>,
+    label_selector: Option<String>,
+    field_selector: Option<String>,
+    field_masks: Option<BTreeSet<String>>,
+) -> Result<ObjectList<kube::core::DynamicObject>> {
+    let mut list_params = kube::api::ListParams::default();
+    if let Some(label_selector) = label_selector {
+        list_params = list_params.labels(&label_selector);
+    }
+    if let Some(field_selector) = field_selector {
+        list_params = list_params.fields(&field_selector);
+    }
+
+    let mut list = api.list(&list_params).await.map_err(anyhow::Error::new)?;
+
+    let field_masker: Option<field_mask::FieldMaskNode> =
+        field_masks.map(field_mask::FieldMaskNode::new);
+    for item in &mut list.items {
+        modify_object(item, field_masker.as_ref());
+    }
+
+    Ok(list)
 }

--- a/crates/policy-evaluator/src/callback_handler/kubernetes/field_mask.rs
+++ b/crates/policy-evaluator/src/callback_handler/kubernetes/field_mask.rs
@@ -2,6 +2,25 @@ use std::collections::BTreeMap;
 
 use serde_json::Value;
 
+/// Prepares a Kubernetes object for caching/returning to a policy: clears
+/// fields that are not useful outside of the API server (managed fields,
+/// the last-applied-configuration annotation) and, if a field mask is
+/// provided, prunes the object down to only the masked fields.
+pub(crate) fn modify_object(
+    obj: &mut kube::core::DynamicObject,
+    field_masker: Option<&FieldMaskNode>,
+) {
+    // clear managed fields to reduce memory usage
+    obj.managed_fields_mut().clear();
+    // clear last-applied-configuration to reduce memory usage
+    obj.annotations_mut()
+        .remove("kubectl.kubernetes.io/last-applied-configuration");
+    // apply field masks, if any
+    if let Some(mask) = field_masker {
+        prune_in_place(&mut obj.data, mask);
+    }
+}
+
 /// Represents a node in a field mask tree.
 ///
 /// This structure is used to define and operate on masks that specify which parts of a JSON object should

--- a/crates/policy-evaluator/src/callback_handler/kubernetes/field_mask.rs
+++ b/crates/policy-evaluator/src/callback_handler/kubernetes/field_mask.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use kube::ResourceExt;
 use serde_json::Value;
 
 /// Prepares a Kubernetes object for caching/returning to a policy: clears

--- a/crates/policy-evaluator/src/callback_handler/kubernetes/reflector.rs
+++ b/crates/policy-evaluator/src/callback_handler/kubernetes/reflector.rs
@@ -127,7 +127,7 @@ impl Reflector {
 
         let stream = watcher(api, filter).map_ok(move |ev| {
             ev.modify(|obj| {
-                modify_object(obj, field_masker.as_ref());
+                field_mask::modify_object(obj, field_masker.as_ref());
             })
         });
 
@@ -179,24 +179,10 @@ impl Reflector {
     }
 }
 
-pub(crate) fn modify_object(
-    obj: &mut kube::core::DynamicObject,
-    field_masker: Option<&field_mask::FieldMaskNode>,
-) {
-    // clear managed fields to reduce memory usage
-    obj.managed_fields_mut().clear();
-    // clear last-applied-configuration to reduce memory usage
-    obj.annotations_mut()
-        .remove("kubectl.kubernetes.io/last-applied-configuration");
-    // apply field masks, if any
-    if let Some(mask) = field_masker {
-        field_mask::prune_in_place(&mut obj.data, mask);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use field_mask::modify_object;
     use k8s_openapi::apimachinery::pkg::apis::meta::v1::ManagedFieldsEntry;
     use kube::core::{DynamicObject, ObjectMeta};
     use serde_json::json;

--- a/crates/policy-evaluator/src/callback_handler/kubernetes/reflector.rs
+++ b/crates/policy-evaluator/src/callback_handler/kubernetes/reflector.rs
@@ -179,7 +179,7 @@ impl Reflector {
     }
 }
 
-fn modify_object(
+pub(crate) fn modify_object(
     obj: &mut kube::core::DynamicObject,
     field_masker: Option<&field_mask::FieldMaskNode>,
 ) {

--- a/crates/policy-evaluator/src/callback_handler/kubernetes/reflector.rs
+++ b/crates/policy-evaluator/src/callback_handler/kubernetes/reflector.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeSet, hash::Hash};
 use anyhow::Result;
 use futures::{Stream, StreamExt, TryStreamExt, future::ready};
 use kube::{
-    Resource, ResourceExt,
+    Resource,
     runtime::{
         WatchStreamExt,
         reflector::store::{self, Writer},

--- a/crates/policy-evaluator/src/callback_requests.rs
+++ b/crates/policy-evaluator/src/callback_requests.rs
@@ -460,8 +460,6 @@ impl From<kubewarden_policy_sdk::host_capabilities::kubernetes::ListResourcesByN
             namespace: req.namespace,
             label_selector: req.label_selector,
             field_selector: req.field_selector,
-            // kubewarden-policy-sdk does not expose a `disable_cache` field for this
-            // request yet, so list queries always go through the reflector for now.
             disable_cache: false,
             field_masks: req.field_masks,
         }
@@ -479,8 +477,6 @@ impl From<kubewarden_policy_sdk::host_capabilities::kubernetes::ListAllResources
             kind: req.kind,
             label_selector: req.label_selector,
             field_selector: req.field_selector,
-            // kubewarden-policy-sdk does not expose a `disable_cache` field for this
-            // request yet, so list queries always go through the reflector for now.
             disable_cache: false,
             field_masks: req.field_masks,
         }

--- a/crates/policy-evaluator/src/callback_requests.rs
+++ b/crates/policy-evaluator/src/callback_requests.rs
@@ -141,6 +141,16 @@ pub enum CallbackRequestType {
         /// A selector to restrict the list of returned objects by their fields.
         /// Defaults to everything if `None`
         field_selector: Option<String>,
+        /// Disable the use of a watch-based reflector to serve and cache this query.
+        /// By default, list queries are served by a reflector that keeps an in-memory,
+        /// continuously updated copy of the matching resources running for the lifetime
+        /// of the policy server process.
+        /// When set to `true`, the query is performed directly against the Kubernetes API
+        /// Server and no reflector is created. This avoids the memory and connection cost
+        /// of a long-lived watch for queries that are rarely repeated, at the cost of
+        /// hitting the Kubernetes API Server on every call.
+        #[serde(default)]
+        disable_cache: bool,
         /// A list of fields to include in the response.
         ///
         /// If strictly defined, the host will prune the Kubernetes resource to contain *only*
@@ -179,6 +189,16 @@ pub enum CallbackRequestType {
         /// A selector to restrict the list of returned objects by their fields.
         /// Defaults to everything if `None`
         field_selector: Option<String>,
+        /// Disable the use of a watch-based reflector to serve and cache this query.
+        /// By default, list queries are served by a reflector that keeps an in-memory,
+        /// continuously updated copy of the matching resources running for the lifetime
+        /// of the policy server process.
+        /// When set to `true`, the query is performed directly against the Kubernetes API
+        /// Server and no reflector is created. This avoids the memory and connection cost
+        /// of a long-lived watch for queries that are rarely repeated, at the cost of
+        /// hitting the Kubernetes API Server on every call.
+        #[serde(default)]
+        disable_cache: bool,
         /// A list of fields to include in the response.
         ///
         /// If strictly defined, the host will prune the Kubernetes resource to contain *only*
@@ -440,6 +460,9 @@ impl From<kubewarden_policy_sdk::host_capabilities::kubernetes::ListResourcesByN
             namespace: req.namespace,
             label_selector: req.label_selector,
             field_selector: req.field_selector,
+            // kubewarden-policy-sdk does not expose a `disable_cache` field for this
+            // request yet, so list queries always go through the reflector for now.
+            disable_cache: false,
             field_masks: req.field_masks,
         }
     }
@@ -456,6 +479,9 @@ impl From<kubewarden_policy_sdk::host_capabilities::kubernetes::ListAllResources
             kind: req.kind,
             label_selector: req.label_selector,
             field_selector: req.field_selector,
+            // kubewarden-policy-sdk does not expose a `disable_cache` field for this
+            // request yet, so list queries always go through the reflector for now.
+            disable_cache: false,
             field_masks: req.field_masks,
         }
     }

--- a/crates/policy-evaluator/src/runtimes/rego/context_aware.rs
+++ b/crates/policy-evaluator/src/runtimes/rego/context_aware.rs
@@ -49,6 +49,7 @@ fn get_all_resources_by_type(
         kind: resource_type.kind.to_owned(),
         label_selector: None,
         field_selector: None,
+        disable_cache: false,
         field_masks: None,
     };
 
@@ -199,6 +200,7 @@ pub(crate) mod tests {
                     kind,
                     label_selector,
                     field_selector,
+                    disable_cache: _,
                     field_masks: _,
                 } => {
                     assert_eq!(api_version, expected_resource.api_version);

--- a/crates/policy-evaluator/src/runtimes/rego/gatekeeper_inventory_cache.rs
+++ b/crates/policy-evaluator/src/runtimes/rego/gatekeeper_inventory_cache.rs
@@ -162,6 +162,7 @@ pub(crate) mod tests {
                         kind,
                         label_selector,
                         field_selector,
+                        disable_cache: _,
                         field_masks: _,
                     } => {
                         assert_eq!(api_version, expected_resource.api_version);
@@ -323,6 +324,7 @@ pub(crate) mod tests {
                         kind,
                         label_selector,
                         field_selector,
+                        disable_cache: _,
                         field_masks: _,
                     } => {
                         assert_eq!(api_version, expected_resource.api_version);


### PR DESCRIPTION
## Summary

Adds a `disable_cache` flag to `KubernetesListResourceNamespace` and
`KubernetesListResourceAll`, mirroring the existing behavior of
`KubernetesGetResource`.

By default, list queries are served by a watch-based reflector that keeps an
in-memory, continuously updated copy of the matching resources for the
lifetime of the policy-server process. This is wasteful for queries that are
rarely repeated (e.g. label/field selectors that match nothing, or one-off
lookups), leading to an excessive number of long-lived reflectors, extra
memory usage, and added latency on the first call.

When `disable_cache: true` is set, the query is performed directly against
the Kubernetes API Server (a one-shot `list()` call) and no reflector is
created. The same object pruning applied by the reflector (stripping
`managedFields`, removing the `kubectl.kubernetes.io/last-applied-configuration`
annotation, and applying field masks) is reused for the direct path, so the
response shape is identical regardless of which path served it.

## Changes

- `callback_requests.rs`: add `#[serde(default)] disable_cache: bool` to
  `KubernetesListResourceNamespace` and `KubernetesListResourceAll`.
- `callback_handler.rs`: route to the new direct (non-reflector) functions
  when `disable_cache` is set, otherwise keep the existing reflector-backed
  path.
- `callback_handler/kubernetes.rs` / `client.rs`: new
  `list_resources_by_namespace_direct` / `list_resources_all_direct` /
  `list_resources_direct` perform a one-shot API Server `list()` call.
- `callback_handler/kubernetes/reflector.rs`: make `modify_object` `pub(crate)`
  so it can be reused by the new direct-list path.
- `runtimes/rego/context_aware.rs`, `runtimes/rego/gatekeeper_inventory_cache.rs`:
  updated for the new struct field (no behavior change, still
  `disable_cache: false`).

Closes #1319
Refs #1322