### PR TITLE
fix(controller): reduce API server load and policy status update churn

### DIFF
--- a/internal/controller/policy_subreconciler.go
+++ b/internal/controller/policy_subreconciler.go
@@ -24,6 +24,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,14 +52,29 @@ func (r *policySubReconciler) reconcile(ctx context.Context, policy policiesv1.P
 		return ctrl.Result{}, r.removePolicyWebhooksAndFinalizers(ctx, policy)
 	}
 
+	// Snapshot the policy before reconciliation so we can (a) skip the API write
+	// when the status did not change and (b) compute a merge patch against this
+	// base. A policy waiting for its PolicyServer to become ready requeues every
+	// couple of seconds; without the guard every requeue would send an identical
+	// status update, which is the bulk of the status-update churn reported in
+	// issue #743.
+	original := policy.DeepCopyObject().(policiesv1.Policy)
+
 	reconcileResult, reconcileErr := r.reconcilePolicy(ctx, policy)
 
 	if err := r.setPolicyModeStatus(ctx, policy); err != nil {
 		return ctrl.Result{}, fmt.Errorf("error setting policy status: %w", err)
 	}
 
-	if err := r.Status().Update(ctx, policy); err != nil {
-		return ctrl.Result{}, fmt.Errorf("update admission policy status error: %w", err)
+	// Use a merge patch rather than an update. The cached client can hand back a
+	// momentarily stale policy right after our own previous write; a full update
+	// then fails the optimistic-lock check with "the object has been modified",
+	// the status update error reported in issue #743. A merge patch carries no
+	// resourceVersion precondition, so it applies cleanly from a stale base.
+	if !equality.Semantic.DeepEqual(original.GetStatus(), policy.GetStatus()) {
+		if err := r.Status().Patch(ctx, policy, client.MergeFrom(original)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("update admission policy status error: %w", err)
+		}
 	}
 
 	// record policy count metric

--- a/internal/controller/policyserver_controller.go
+++ b/internal/controller/policyserver_controller.go
@@ -26,6 +26,7 @@ import (
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -106,8 +107,15 @@ func (r *PolicyServerReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
+	// Snapshot the object so we only write the status back when it actually
+	// changed, and so we can patch against this base. Both the steady-state and
+	// the deletion paths can requeue every couple of seconds; without this guard
+	// each requeue would send an identical status update to the API server
+	// (issue #743).
+	original := policyServer.DeepCopy()
+
 	if policyServer.ObjectMeta.DeletionTimestamp != nil {
-		return r.reconcileDeletion(ctx, &policyServer)
+		return r.reconcileDeletion(ctx, &policyServer, original)
 	}
 
 	err := r.reconcilePolicyServerCertSecret(ctx, &policyServer)
@@ -120,7 +128,8 @@ func (r *PolicyServerReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, errors.Join(errors.New("could not get policies"), err)
 	}
 
-	if err = r.reconcilePolicyServerConfigMap(ctx, &policyServer, policies); err != nil {
+	configMapVersion, err := r.reconcilePolicyServerConfigMap(ctx, &policyServer, policies)
+	if err != nil {
 		setFalseConditionType(
 			&policyServer.Status.Conditions,
 			string(policiesv1.PolicyServerConfigMapReconciled),
@@ -148,7 +157,7 @@ func (r *PolicyServerReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		string(policiesv1.PolicyServerPodDisruptionBudgetReconciled),
 	)
 
-	if err = r.reconcilePolicyServerDeployment(ctx, &policyServer); err != nil {
+	if err = r.reconcilePolicyServerDeployment(ctx, &policyServer, configMapVersion); err != nil {
 		setFalseConditionType(
 			&policyServer.Status.Conditions,
 			string(policiesv1.PolicyServerDeploymentReconciled),
@@ -176,11 +185,27 @@ func (r *PolicyServerReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		string(policiesv1.PolicyServerServiceReconciled),
 	)
 
-	if err = r.Client.Status().Update(ctx, &policyServer); err != nil {
-		return ctrl.Result{}, fmt.Errorf("update policy server status error: %w", err)
+	if err = r.updateStatusIfChanged(ctx, &policyServer, original); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// updateStatusIfChanged writes the PolicyServer status back to the API server
+// only when it differs from the snapshot taken at the start of the reconcile
+// loop. This avoids the redundant status update requests that a requeue-based
+// wait would otherwise generate on every cycle. It uses a merge patch so that a
+// momentarily stale cached object does not cause "object has been modified"
+// conflicts (issue #743).
+func (r *PolicyServerReconciler) updateStatusIfChanged(ctx context.Context, policyServer, original *policiesv1.PolicyServer) error {
+	if equality.Semantic.DeepEqual(original.Status, policyServer.Status) {
+		return nil
+	}
+	if err := r.Client.Status().Patch(ctx, policyServer, client.MergeFrom(original)); err != nil {
+		return fmt.Errorf("update policy server status error: %w", err)
+	}
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -368,7 +393,7 @@ func (r *PolicyServerReconciler) getPolicies(ctx context.Context, policyServer *
 //   - False: webhooks still exist; requeue with a short delay.
 //   - True: all webhooks gone; remove finalizers on the next reconcile loop so
 //     the fresh resourceVersion from the status update is used.
-func (r *PolicyServerReconciler) reconcileDeletion(ctx context.Context, policyServer *policiesv1.PolicyServer) (ctrl.Result, error) {
+func (r *PolicyServerReconciler) reconcileDeletion(ctx context.Context, policyServer, original *policiesv1.PolicyServer) (ctrl.Result, error) {
 	// If the condition is already True the previous reconcile already confirmed
 	// all webhooks are gone. Remove the finalizers using the freshly-fetched
 	// object (guaranteed by Reconcile calling r.Get before reaching here).
@@ -411,8 +436,8 @@ func (r *PolicyServerReconciler) reconcileDeletion(ctx context.Context, policySe
 			string(policiesv1.PolicyServerPolicyWebhooksCleanedUp),
 			fmt.Sprintf("Waiting for webhook cleanup of policies: %s", strings.Join(remaining, ", ")),
 		)
-		if err = r.Client.Status().Update(ctx, policyServer); err != nil {
-			return ctrl.Result{}, fmt.Errorf("cannot update policy server status: %w", err)
+		if err = r.updateStatusIfChanged(ctx, policyServer, original); err != nil {
+			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: constants.TimeToRequeuePolicyReconciliation}, nil
 	}
@@ -421,8 +446,8 @@ func (r *PolicyServerReconciler) reconcileDeletion(ctx context.Context, policySe
 		&policyServer.Status.Conditions,
 		string(policiesv1.PolicyServerPolicyWebhooksCleanedUp),
 	)
-	if err = r.Client.Status().Update(ctx, policyServer); err != nil {
-		return ctrl.Result{}, fmt.Errorf("cannot update policy server status: %w", err)
+	if err = r.updateStatusIfChanged(ctx, policyServer, original); err != nil {
+		return ctrl.Result{}, err
 	}
 	// Requeue so the next reconcile fetches the object with the updated
 	// resourceVersion before calling r.Update to remove the finalizers.

--- a/internal/controller/policyserver_controller_configmap.go
+++ b/internal/controller/policyserver_controller_configmap.go
@@ -8,11 +8,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -124,11 +121,14 @@ type policyServerSourcesEntry struct {
 }
 
 // Reconciles the ConfigMap that holds the configuration of the Policy Server.
+// It returns the ConfigMap resourceVersion as observed after the create/patch,
+// so callers can stamp it onto the Deployment without issuing a separate,
+// uncached GET against the API server.
 func (r *PolicyServerReconciler) reconcilePolicyServerConfigMap(
 	ctx context.Context,
 	policyServer *policiesv1.PolicyServer,
 	policies []policiesv1.Policy,
-) error {
+) (string, error) {
 	cfg := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      policyServer.NameWithPrefix(),
@@ -140,9 +140,11 @@ func (r *PolicyServerReconciler) reconcilePolicyServerConfigMap(
 		return r.updateConfigMapData(cfg, policyServer, policies)
 	})
 	if err != nil {
-		return fmt.Errorf("cannot create or update PolicyServer ConfigMap: %w", err)
+		return "", fmt.Errorf("cannot create or update PolicyServer ConfigMap: %w", err)
 	}
-	return nil
+	// CreateOrPatch updates cfg in place with the object returned by the API
+	// server, so cfg.ResourceVersion is the authoritative current version.
+	return cfg.ResourceVersion, nil
 }
 
 // Function used to update the ConfigMap data when creating or updating it.
@@ -172,25 +174,6 @@ func (r *PolicyServerReconciler) updateConfigMapData(cfg *corev1.ConfigMap, poli
 		return errors.Join(errors.New("failed to set policy server configmap owner reference"), err)
 	}
 	return nil
-}
-
-func (r *PolicyServerReconciler) policyServerConfigMapVersion(ctx context.Context, policyServer *policiesv1.PolicyServer) (string, error) {
-	// By using Unstructured data we force the client to fetch fresh, uncached
-	// data from the API server
-	unstructuredObj := &unstructured.Unstructured{}
-	unstructuredObj.SetGroupVersionKind(schema.GroupVersionKind{
-		Kind:    "ConfigMap", //nolint:goconst
-		Version: "v1",
-	})
-	err := r.Client.Get(ctx, client.ObjectKey{
-		Namespace: r.DeploymentsNamespace,
-		Name:      policyServer.NameWithPrefix(),
-	}, unstructuredObj)
-	if err != nil {
-		return "", fmt.Errorf("cannot retrieve existing policies ConfigMap: %w", err)
-	}
-
-	return unstructuredObj.GetResourceVersion(), nil
 }
 
 func buildPolicyGroupMembersWithContext(policies policiesv1.PolicyGroupMembersWithContext, hostCaps []string) map[string]policyGroupMemberWithContext {

--- a/internal/controller/policyserver_controller_deployment.go
+++ b/internal/controller/policyserver_controller_deployment.go
@@ -44,20 +44,18 @@ const (
 	defaultOtelCertificateMountMode  = 420
 )
 
-// reconcilePolicyServerDeployment reconciles the Deployment that runs the PolicyServer.
-func (r *PolicyServerReconciler) reconcilePolicyServerDeployment(ctx context.Context, policyServer *policiesv1.PolicyServer) error {
-	configMapVersion, err := r.policyServerConfigMapVersion(ctx, policyServer)
-	if err != nil {
-		return fmt.Errorf("cannot get policy-server ConfigMap version: %w", err)
-	}
-
+// reconcilePolicyServerDeployment reconciles the Deployment that runs the
+// PolicyServer. configMapVersion is the resourceVersion of the PolicyServer
+// ConfigMap as observed during the same reconcile loop; it is stamped onto the
+// Deployment so that a configuration change triggers a rollout.
+func (r *PolicyServerReconciler) reconcilePolicyServerDeployment(ctx context.Context, policyServer *policiesv1.PolicyServer, configMapVersion string) error {
 	policyServerDeployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      policyServer.NameWithPrefix(),
 			Namespace: r.DeploymentsNamespace,
 		},
 	}
-	_, err = controllerutil.CreateOrPatch(ctx, r.Client, policyServerDeployment, func() error {
+	_, err := controllerutil.CreateOrPatch(ctx, r.Client, policyServerDeployment, func() error {
 		return r.updatePolicyServerDeployment(ctx, policyServer, policyServerDeployment, configMapVersion)
 	})
 	if err != nil {


### PR DESCRIPTION
## Description

Fix #743

Reduces the API server load and the policy status update errors described in
the issue. The reconcilers were re-writing status and re-fetching resources on
every requeue, even when nothing changed.

Note: the loop simplification is left for a follow-up PR, since it touches the
pod-readiness path and needs the e2e cluster to validate.

## Test

```shell
cd internal/controller
go test ./...
Checklist
 I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)

```