### PR TITLE
Release/v1.37 migration changes

### DIFF
--- a/api/policies/v1/admissionpolicy_types.go
+++ b/api/policies/v1/admissionpolicy_types.go
@@ -32,6 +32,7 @@ type AdmissionPolicySpec struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Namespaced,shortName=ap
 // +kubebuilder:storageversion
+// +kubebuilder:metadata:annotations="helm.sh/resource-policy=keep"
 // +kubebuilder:printcolumn:name="Policy Server",type=string,JSONPath=`.spec.policyServer`,description="Bound to Policy Server"
 // +kubebuilder:printcolumn:name="Mutating",type=boolean,JSONPath=`.spec.mutating`,description="Whether the policy is mutating"
 // +kubebuilder:printcolumn:name="BackgroundAudit",type=boolean,JSONPath=`.spec.backgroundAudit`,description="Whether the policy is used in audit checks"

--- a/api/policies/v1/admissionpolicygroup_types.go
+++ b/api/policies/v1/admissionpolicygroup_types.go
@@ -32,6 +32,7 @@ type AdmissionPolicyGroupSpec struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Namespaced,shortName=apg
 // +kubebuilder:storageversion
+// +kubebuilder:metadata:annotations="helm.sh/resource-policy=keep"
 // +kubebuilder:printcolumn:name="Policy Server",type=string,JSONPath=`.spec.policyServer`,description="Bound to Policy Server"
 // +kubebuilder:printcolumn:name="Mutating",type=boolean,JSONPath=`.spec.mutating`,description="Whether the policy is mutating"
 // +kubebuilder:printcolumn:name="BackgroundAudit",type=boolean,JSONPath=`.spec.backgroundAudit`,description="Whether the policy is used in audit checks"

--- a/api/policies/v1/clusteradmissionpolicy_types.go
+++ b/api/policies/v1/clusteradmissionpolicy_types.go
@@ -106,6 +106,7 @@ type ClusterAdmissionPolicySpec struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,shortName=cap
 // +kubebuilder:storageversion
+// +kubebuilder:metadata:annotations="helm.sh/resource-policy=keep"
 // +kubebuilder:printcolumn:name="Policy Server",type=string,JSONPath=`.spec.policyServer`,description="Bound to Policy Server"
 // +kubebuilder:printcolumn:name="Mutating",type=boolean,JSONPath=`.spec.mutating`,description="Whether the policy is mutating"
 // +kubebuilder:printcolumn:name="BackgroundAudit",type=boolean,JSONPath=`.spec.backgroundAudit`,description="Whether the policy is used in audit checks"

--- a/api/policies/v1/clusteradmissionpolicygroup_types.go
+++ b/api/policies/v1/clusteradmissionpolicygroup_types.go
@@ -101,6 +101,7 @@ type ClusterAdmissionPolicyGroupSpec struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,shortName=capg
 // +kubebuilder:storageversion
+// +kubebuilder:metadata:annotations="helm.sh/resource-policy=keep"
 // +kubebuilder:printcolumn:name="Policy Server",type=string,JSONPath=`.spec.policyServer`,description="Bound to Policy Server"
 // +kubebuilder:printcolumn:name="Mutating",type=boolean,JSONPath=`.spec.mutating`,description="Whether the policy is mutating"
 // +kubebuilder:printcolumn:name="BackgroundAudit",type=boolean,JSONPath=`.spec.backgroundAudit`,description="Whether the policy is used in audit checks"

--- a/api/policies/v1/policyserver_types.go
+++ b/api/policies/v1/policyserver_types.go
@@ -255,6 +255,7 @@ type PolicyServerStatus struct {
 //+kubebuilder:printcolumn:name="Replicas",type=string,JSONPath=`.spec.replicas`,description="Policy Server replicas"
 //+kubebuilder:printcolumn:name="Image",type=string,JSONPath=`.spec.image`,description="Policy Server image"
 //+kubebuilder:storageversion
+//+kubebuilder:metadata:annotations="helm.sh/resource-policy=keep"
 
 // PolicyServer is the Schema for the policyservers API.
 type PolicyServer struct {

--- a/charts/hauler_manifest.yaml
+++ b/charts/hauler_manifest.yaml
@@ -58,13 +58,13 @@ spec:
   charts:
     - name: kubewarden-crds
       repoURL: https://charts.kubewarden.io
-      version: 1.28.0
+      version: 1.28.1
     - name: kubewarden-controller
       repoURL: https://charts.kubewarden.io
-      version: 5.14.0
+      version: 5.14.1
     - name: kubewarden-defaults
       repoURL: https://charts.kubewarden.io
-      version: 3.14.0
+      version: 3.14.1
     - name: policy-reporter
       version: 3.7.4
       repoURL: https://kyverno.github.io/policy-reporter

--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -23,7 +23,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.14.0
+version: 5.14.1
 # This is the version of Kubewarden stack
 appVersion: v1.36.0
 annotations:

--- a/charts/kubewarden-controller/templates/pre-delete-hook.yaml
+++ b/charts/kubewarden-controller/templates/pre-delete-hook.yaml
@@ -36,7 +36,7 @@ spec:
       containers:
         - name: pre-delete-job
           image: '{{ template "system_default_registry" . }}{{ .Values.preDeleteJob.image.repository }}:{{ .Values.preDeleteJob.image.tag }}'
-          command: ["kubectl", "delete", "--all", "--wait", "policyservers.policies.kubewarden.io"]
+          command: ["kubectl", "delete", "--wait", "--selector=app.kubernetes.io/instance={{ .Release.Name }}", "policyservers.policies.kubewarden.io"]
           env:
             - name: KUBERLR_ALLOWDOWNLOAD
               value: "1"

--- a/charts/kubewarden-controller/templates/webhooks.yaml
+++ b/charts/kubewarden-controller/templates/webhooks.yaml
@@ -56,6 +56,8 @@ kind: Secret
 metadata:
   name: kubewarden-ca
   namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
 data:

--- a/charts/kubewarden-controller/tests/migration_test.yaml
+++ b/charts/kubewarden-controller/tests/migration_test.yaml
@@ -1,0 +1,43 @@
+suite: zero-downtime migration patches
+release:
+  name: kubewarden-controller
+  namespace: kubewarden
+
+tests:
+  - it: "kubewarden-ca Secret should carry the helm.sh/resource-policy keep annotation"
+    template: webhooks.yaml
+    documentSelector:
+      path: metadata.name
+      value: kubewarden-ca
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: "kubewarden-webhook-server-cert Secret should NOT carry the keep annotation"
+    template: webhooks.yaml
+    documentSelector:
+      path: metadata.name
+      value: kubewarden-webhook-server-cert
+    asserts:
+      - notExists:
+          path: metadata.annotations["helm.sh/resource-policy"]
+
+  - it: "kubewarden-audit-scanner-client-cert Secret should NOT carry the keep annotation"
+    template: webhooks.yaml
+    documentSelector:
+      path: metadata.name
+      value: kubewarden-audit-scanner-client-cert
+    asserts:
+      - notExists:
+          path: metadata.annotations["helm.sh/resource-policy"]
+
+  - it: "pre-delete hook should use --selector instead of --all"
+    template: pre-delete-hook.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].command
+          content: "--selector=app.kubernetes.io/instance=kubewarden-controller"
+      - notContains:
+          path: spec.template.spec.containers[0].command
+          content: "--all"

--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -22,7 +22,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.28.0
+version: 1.28.1
 # This is the version of Kubewarden stack
 appVersion: v1.36.0
 annotations:

--- a/charts/kubewarden-crds/templates/crds/policies.kubewarden.io_admissionpolicies.yaml
+++ b/charts/kubewarden-crds/templates/crds/policies.kubewarden.io_admissionpolicies.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    helm.sh/resource-policy: keep
   name: admissionpolicies.policies.kubewarden.io
 spec:
   group: policies.kubewarden.io

--- a/charts/kubewarden-crds/templates/crds/policies.kubewarden.io_admissionpolicygroups.yaml
+++ b/charts/kubewarden-crds/templates/crds/policies.kubewarden.io_admissionpolicygroups.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    helm.sh/resource-policy: keep
   name: admissionpolicygroups.policies.kubewarden.io
 spec:
   group: policies.kubewarden.io

--- a/charts/kubewarden-crds/templates/crds/policies.kubewarden.io_clusteradmissionpolicies.yaml
+++ b/charts/kubewarden-crds/templates/crds/policies.kubewarden.io_clusteradmissionpolicies.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    helm.sh/resource-policy: keep
   name: clusteradmissionpolicies.policies.kubewarden.io
 spec:
   group: policies.kubewarden.io

--- a/charts/kubewarden-crds/templates/crds/policies.kubewarden.io_clusteradmissionpolicygroups.yaml
+++ b/charts/kubewarden-crds/templates/crds/policies.kubewarden.io_clusteradmissionpolicygroups.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    helm.sh/resource-policy: keep
   name: clusteradmissionpolicygroups.policies.kubewarden.io
 spec:
   group: policies.kubewarden.io

--- a/charts/kubewarden-crds/templates/crds/policies.kubewarden.io_policyservers.yaml
+++ b/charts/kubewarden-crds/templates/crds/policies.kubewarden.io_policyservers.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    helm.sh/resource-policy: keep
   name: policyservers.policies.kubewarden.io
 spec:
   group: policies.kubewarden.io

--- a/charts/kubewarden-crds/tests/crds_test.yaml
+++ b/charts/kubewarden-crds/tests/crds_test.yaml
@@ -12,6 +12,9 @@ tests:
       - equal:
           path: spec.group
           value: policies.kubewarden.io
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
 
   - it: "admissionpolicygroups CRD should be a CustomResourceDefinition"
     template: templates/crds/policies.kubewarden.io_admissionpolicygroups.yaml
@@ -25,6 +28,9 @@ tests:
       - equal:
           path: spec.group
           value: policies.kubewarden.io
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
 
   - it: "clusteradmissionpolicies CRD should be a CustomResourceDefinition"
     template: templates/crds/policies.kubewarden.io_clusteradmissionpolicies.yaml
@@ -38,6 +44,9 @@ tests:
       - equal:
           path: spec.group
           value: policies.kubewarden.io
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
 
   - it: "clusteradmissionpolicygroups CRD should be a CustomResourceDefinition"
     template: templates/crds/policies.kubewarden.io_clusteradmissionpolicygroups.yaml
@@ -51,6 +60,9 @@ tests:
       - equal:
           path: spec.group
           value: policies.kubewarden.io
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
 
   - it: "policyservers CRD should be a CustomResourceDefinition"
     template: templates/crds/policies.kubewarden.io_policyservers.yaml
@@ -64,3 +76,6 @@ tests:
       - equal:
           path: spec.group
           value: policies.kubewarden.io
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -22,7 +22,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.14.0
+version: 3.14.1
 # This is the version of Kubewarden stack
 appVersion: v1.36.0
 annotations:

--- a/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
+++ b/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     io.kubewarden.policy.severity: medium
     io.kubewarden.policy.category: PSP
+    helm.sh/resource-policy: keep
     {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ $.Values.recommendedPolicies.allowPrivilegeEscalationPolicy.name }}
 spec:

--- a/charts/kubewarden-defaults/templates/capabilities-policy.yaml
+++ b/charts/kubewarden-defaults/templates/capabilities-policy.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     io.kubewarden.policy.category: PSP
     io.kubewarden.policy.severity: medium
+    helm.sh/resource-policy: keep
     {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ $.Values.recommendedPolicies.capabilitiesPolicy.name }}
 spec:

--- a/charts/kubewarden-defaults/templates/host-namespace-policy.yaml
+++ b/charts/kubewarden-defaults/templates/host-namespace-policy.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     io.kubewarden.policy.category: PSP
     io.kubewarden.policy.severity: medium
+    helm.sh/resource-policy: keep
     {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ $.Values.recommendedPolicies.hostNamespacePolicy.name }}
 spec:

--- a/charts/kubewarden-defaults/templates/host-path-policy.yaml
+++ b/charts/kubewarden-defaults/templates/host-path-policy.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     io.kubewarden.policy.category: PSP
     io.kubewarden.policy.severity: medium
+    helm.sh/resource-policy: keep
     {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ $.Values.recommendedPolicies.hostPathsPolicy.name }}
 spec:

--- a/charts/kubewarden-defaults/templates/pod-privileged-policy.yaml
+++ b/charts/kubewarden-defaults/templates/pod-privileged-policy.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     io.kubewarden.policy.category: PSP
     io.kubewarden.policy.severity: medium
+    helm.sh/resource-policy: keep
     {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ $.Values.recommendedPolicies.podPrivilegedPolicy.name }}
 spec:

--- a/charts/kubewarden-defaults/templates/policy-server-rbac.yaml
+++ b/charts/kubewarden-defaults/templates/policy-server-rbac.yaml
@@ -5,6 +5,7 @@ metadata:
     {{- include "kubewarden-defaults.labels" . | nindent 4 }}
     app.kubernetes.io/component: policy-server
   annotations:
+    helm.sh/resource-policy: keep
     {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ .Values.policyServer.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
@@ -16,6 +17,7 @@ metadata:
     {{- include "kubewarden-defaults.labels" . | nindent 4 }}
     app.kubernetes.io/component: policy-server
   annotations:
+    helm.sh/resource-policy: keep
     {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: kubewarden-context-watcher
 rules:
@@ -40,6 +42,7 @@ metadata:
     {{- include "kubewarden-defaults.labels" . | nindent 4 }}
     app.kubernetes.io/component: policy-server
   annotations:
+    helm.sh/resource-policy: keep
     {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: kubewarden-context-watcher
 subjects:

--- a/charts/kubewarden-defaults/templates/policyserver-default.yaml
+++ b/charts/kubewarden-defaults/templates/policyserver-default.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "kubewarden-defaults.labels" . | nindent 4 }}
     app.kubernetes.io/component: policy-server
   annotations:
+    helm.sh/resource-policy: keep
     {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: default
   finalizers:

--- a/charts/kubewarden-defaults/templates/user-group-policy.yaml
+++ b/charts/kubewarden-defaults/templates/user-group-policy.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     io.kubewarden.policy.category: PSP
     io.kubewarden.policy.severity: medium
+    helm.sh/resource-policy: keep
     {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ $.Values.recommendedPolicies.userGroupPolicy.name }}
 spec:

--- a/charts/kubewarden-defaults/tests/migration_test.yaml
+++ b/charts/kubewarden-defaults/tests/migration_test.yaml
@@ -1,0 +1,73 @@
+suite: zero-downtime migration patches
+release:
+  name: kubewarden-defaults
+  namespace: kubewarden
+
+tests:
+  - it: "default PolicyServer should carry the helm.sh/resource-policy keep annotation"
+    template: policyserver-default.yaml
+    set:
+      policyServer.enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: "policy-server ServiceAccount should carry the helm.sh/resource-policy keep annotation"
+    template: policy-server-rbac.yaml
+    documentSelector:
+      path: kind
+      value: ServiceAccount
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: "kubewarden-context-watcher ClusterRole should carry the helm.sh/resource-policy keep annotation"
+    template: policy-server-rbac.yaml
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: "kubewarden-context-watcher ClusterRoleBinding should carry the helm.sh/resource-policy keep annotation"
+    template: policy-server-rbac.yaml
+    documentSelector:
+      path: kind
+      value: ClusterRoleBinding
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: "recommended policies should carry keep annotation when enabled"
+    templates:
+      - allow-privileged-escalation-policy.yaml
+      - capabilities-policy.yaml
+      - host-namespace-policy.yaml
+      - host-path-policy.yaml
+      - pod-privileged-policy.yaml
+      - user-group-policy.yaml
+    set:
+      recommendedPolicies.enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: "recommended policies should not render when disabled"
+    templates:
+      - allow-privileged-escalation-policy.yaml
+      - capabilities-policy.yaml
+      - host-namespace-policy.yaml
+      - host-path-policy.yaml
+      - pod-privileged-policy.yaml
+      - user-group-policy.yaml
+    set:
+      recommendedPolicies.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
## Description

This changes all required to allow a migration to the single helm chart defined at #1802. This changes will allow users to do a migration with no downtime for user resources and resources installed by the `kubewarden-defaults`. 

In summary, the changes necessary to allow the migration are adding the `helm.sh/resource-policy: keep` annotations to tell Helm to not remove important resource that must be exist to keep the policies and policy server continue to work after the Helm charts uninstall. And,  the pre-delete hook must avoid removing user defined resources. 