### PR TITLE
feat(policy-evaluator,policy-server): add cache host capability

### DIFF
--- a/crates/policy-evaluator/src/callback_handler.rs
+++ b/crates/policy-evaluator/src/callback_handler.rs
@@ -9,12 +9,14 @@ use crate::callback_handler::kubernetes::field_mask;
 use crate::callback_requests::{CallbackRequest, CallbackRequestType, CallbackResponse};
 
 mod builder;
+pub mod cache;
 mod crypto;
 mod kubernetes;
 mod oci;
 mod sigstore_verification;
 
 pub use builder::CallbackHandlerBuilder;
+pub use cache::{Cache, InMemoryCache};
 
 use sigstore_verification::{
     get_sigstore_certificate_verification_cached, get_sigstore_github_actions_verification_cached,
@@ -29,6 +31,9 @@ pub struct CallbackHandler {
     oci_client: Arc<oci::Client>,
     sigstore_client: sigstore_verification::Client,
     kubernetes_client: Option<kubernetes::Client>,
+    /// Backend shared by the `cache` host capability. Injected by policy-server
+    /// so the backend can be selected at runtime.
+    cache: Arc<dyn cache::Cache>,
     rx: mpsc::Receiver<CallbackRequest>,
     tx: mpsc::Sender<CallbackRequest>,
     shutdown_channel: oneshot::Receiver<()>,
@@ -94,6 +99,7 @@ impl CallbackHandler {
         let oci_client = self.oci_client.clone();
         let mut sigstore_client = self.sigstore_client.clone();
         let mut kubernetes_client = self.kubernetes_client.clone();
+        let cache = self.cache.clone();
 
         tokio::spawn(async move {
             match req.request {
@@ -200,6 +206,21 @@ impl CallbackHandler {
                         })
                         .map_err(anyhow::Error::new);
 
+                    if let Err(e) = req.response_channel.send(response) {
+                        warn!("callback handler: cannot send response back: {:?}", e);
+                    }
+                }
+                CallbackRequestType::CacheSet { key, value, ttl } => {
+                    debug!(key, ttl, "Cache set");
+                    let response =
+                        cache::handle_set(cache.as_ref(), cache::CacheSetRequest { key, value, ttl });
+                    if let Err(e) = req.response_channel.send(response) {
+                        warn!("callback handler: cannot send response back: {:?}", e);
+                    }
+                }
+                CallbackRequestType::CacheGet { key } => {
+                    debug!(key, "Cache get");
+                    let response = cache::handle_get(cache.as_ref(), cache::CacheGetRequest { key });
                     if let Err(e) = req.response_channel.send(response) {
                         warn!("callback handler: cannot send response back: {:?}", e);
                     }

--- a/crates/policy-evaluator/src/callback_handler.rs
+++ b/crates/policy-evaluator/src/callback_handler.rs
@@ -105,17 +105,17 @@ impl CallbackHandler {
             match req.request {
                 CallbackRequestType::OciManifestDigest { image } => {
                     handle_callback!(req, image, "Image digest computed", {
-                        oci::get_oci_digest_cached(&oci_client, &image)
+                        oci::get_oci_digest_cached(cache.as_ref(), &oci_client, &image)
                     });
                 }
                 CallbackRequestType::OciManifest { image } => {
                     handle_callback!(req, image, "Image manifest computed", {
-                        oci::get_oci_manifest_cached(&oci_client, &image)
+                        oci::get_oci_manifest_cached(cache.as_ref(), &oci_client, &image)
                     });
                 }
                 CallbackRequestType::OciManifestAndConfig { image } => {
                     handle_callback!(req, image, "Image manifest computed", {
-                        oci::get_oci_manifest_and_config_cached(&oci_client, &image)
+                        oci::get_oci_manifest_and_config_cached(cache.as_ref(), &oci_client, &image)
                     });
                 }
                 CallbackRequestType::SigstorePubKeyVerify {
@@ -125,6 +125,7 @@ impl CallbackHandler {
                 } => {
                     handle_callback!(req, image, "Sigstore pub key verification done", {
                         get_sigstore_pub_key_verification_cached(
+                            cache.as_ref(),
                             &mut sigstore_client,
                             image.clone(),
                             pub_keys,
@@ -139,6 +140,7 @@ impl CallbackHandler {
                 } => {
                     handle_callback!(req, image, "Sigstore keyless verification done", {
                         get_sigstore_keyless_verification_cached(
+                            cache.as_ref(),
                             &mut sigstore_client,
                             image.clone(),
                             keyless,
@@ -153,6 +155,7 @@ impl CallbackHandler {
                 } => {
                     handle_callback!(req, image, "Sigstore keyless prefix verification done", {
                         get_sigstore_keyless_prefix_verification_cached(
+                            cache.as_ref(),
                             &mut sigstore_client,
                             image.clone(),
                             keyless_prefix,
@@ -168,6 +171,7 @@ impl CallbackHandler {
                 } => {
                     handle_callback!(req, image, "Sigstore GitHub Action verification done", {
                         get_sigstore_github_actions_verification_cached(
+                            cache.as_ref(),
                             &mut sigstore_client,
                             image.clone(),
                             owner,
@@ -185,6 +189,7 @@ impl CallbackHandler {
                 } => {
                     handle_callback!(req, image, "Sigstore GitHub Action verification done", {
                         get_sigstore_certificate_verification_cached(
+                            cache.as_ref(),
                             &mut sigstore_client,
                             &image,
                             &certificate,
@@ -313,6 +318,7 @@ impl CallbackHandler {
                             "Get Kubernetes resource",
                             {
                                 let res = kubernetes::get_resource_cached(
+                                    cache.as_ref(),
                                     kubernetes_client.as_mut(),
                                     &api_version,
                                     &kind,
@@ -389,7 +395,7 @@ impl CallbackHandler {
                             req,
                             "can_i".to_owned(),
                             "Check if user or service account has permission to perform operation",
-                            { kubernetes::can_i_cached(kubernetes_client.as_mut(), request) }
+                            { kubernetes::can_i_cached(cache.as_ref(), kubernetes_client.as_mut(), request) }
                         )
                     }
                 }

--- a/crates/policy-evaluator/src/callback_handler/builder.rs
+++ b/crates/policy-evaluator/src/callback_handler/builder.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 
 use super::CallbackHandler;
+use super::cache::{Cache, InMemoryCache};
 use super::{oci, sigstore_verification};
 use crate::callback_requests::CallbackRequest;
 
@@ -17,6 +18,7 @@ pub struct CallbackHandlerBuilder {
     shutdown_channel: oneshot::Receiver<()>,
     trust_root: Option<Arc<SigstoreTrustRoot>>,
     kube_client: Option<kube::Client>,
+    cache: Option<Arc<dyn Cache>>,
 }
 
 impl CallbackHandlerBuilder {
@@ -27,6 +29,7 @@ impl CallbackHandlerBuilder {
             channel_buffer_size: DEFAULT_CHANNEL_BUFF_SIZE,
             trust_root: None,
             kube_client: None,
+            cache: None,
         }
     }
 
@@ -56,6 +59,14 @@ impl CallbackHandlerBuilder {
         self
     }
 
+    /// Set the backend used by the `cache` host capability. Optional: when not
+    /// provided, an in-memory backend is used. policy-server injects the backend
+    /// it owns (so it can also drive the eviction task).
+    pub fn cache(mut self, cache: Arc<dyn Cache>) -> Self {
+        self.cache = Some(cache);
+        self
+    }
+
     /// Create a CallbackHandler object
     pub async fn build(self) -> Result<CallbackHandler> {
         let (tx, rx) = mpsc::channel::<CallbackRequest>(self.channel_buffer_size);
@@ -67,10 +78,15 @@ impl CallbackHandlerBuilder {
 
         let kubernetes_client = self.kube_client.map(super::kubernetes::Client::new);
 
+        let cache = self
+            .cache
+            .unwrap_or_else(|| Arc::new(InMemoryCache::new()));
+
         Ok(CallbackHandler {
             oci_client,
             sigstore_client,
             kubernetes_client,
+            cache,
             tx,
             rx,
             shutdown_channel: self.shutdown_channel,

--- a/crates/policy-evaluator/src/callback_handler/cache.rs
+++ b/crates/policy-evaluator/src/callback_handler/cache.rs
@@ -1,0 +1,312 @@
+// The `cache` host capability, as described in RFC 0024.
+//
+// It exposes two operations to policy authors:
+//   * `kubewarden.cache.set` - store arbitrary bytes under a key, with a
+//     caller-provided TTL.
+//   * `kubewarden.cache.get` - retrieve the bytes stored under a key. A cache
+//     miss is not an error: it is reported with a success code and an empty
+//     value.
+//
+// The backend is modeled as a trait object (`Arc<dyn Cache>`) so that the
+// concrete implementation can be selected at runtime. Today the only backend is
+// an in-memory store backed by the `cached` crate's `ExpiringCache`; the trait
+// leaves the door open for shared/distributed backends (e.g. Redis) in the
+// future without touching the host capability or any policy.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use anyhow::{Result, anyhow};
+use cached::{Cached, Expires, ExpiringCache};
+use serde::{Deserialize, Serialize};
+
+use crate::callback_requests::CallbackResponse;
+
+/// Reserved key prefix for the caches owned by Kubewarden's internal host
+/// capabilities. Policies are not allowed to `set` keys using this prefix, so
+/// that policy-authored keys can never collide with the framework's own entries
+/// on the shared backend.
+pub const RESERVED_KEY_PREFIX: &str = "kubewarden_internal_";
+
+/// Default interval used by the background eviction task.
+pub const DEFAULT_EVICTION_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Response code returned to the guest when an operation succeeds.
+const CODE_SUCCESS: u32 = 0;
+/// Response code returned to the guest when an operation is rejected.
+const CODE_ERROR: u32 = 1;
+
+/// Payload of a `kubewarden.cache.set` request.
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
+pub struct CacheSetRequest {
+    /// The unique identifier for the data being stored.
+    pub key: String,
+    /// The arbitrary data to be stored in the cache.
+    pub value: Vec<u8>,
+    /// The lifespan of the data, in seconds.
+    pub ttl: u64,
+}
+
+/// Payload of a `kubewarden.cache.get` request.
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
+pub struct CacheGetRequest {
+    /// The key of the data to retrieve.
+    pub key: String,
+}
+
+/// Response of a `kubewarden.cache.set` operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheSetResponse {
+    /// `0` on success, non-zero otherwise.
+    pub code: u32,
+    /// Human readable description of the outcome.
+    pub message: String,
+}
+
+/// Response of a `kubewarden.cache.get` operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheGetResponse {
+    /// `0` on success, non-zero otherwise.
+    pub code: u32,
+    /// Human readable description of the outcome.
+    pub message: String,
+    /// The data stored under the requested key. `None` on a cache miss.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<Vec<u8>>,
+}
+
+/// Backend contract for the cache host capability.
+///
+/// Implemented as a trait object so the backend can be swapped at runtime. The
+/// `cached` crate's stores can serve as a foundation for additional
+/// implementations of this contract.
+pub trait Cache: Send + Sync {
+    /// Store `value` under `key`, keeping it for `ttl`.
+    fn set(&self, key: String, value: Vec<u8>, ttl: Duration);
+    /// Retrieve the value stored under `key`, if present and not expired.
+    fn get(&self, key: &str) -> Option<Vec<u8>>;
+    /// Remove every expired entry. Invoked periodically by the eviction task.
+    fn flush_expired(&self);
+}
+
+/// A cached value that carries its own expiration instant.
+///
+/// `ExpiringCache` determines expiry per value through the [`Expires`] trait,
+/// which is exactly what backs the per-key TTL required by the host capability:
+/// each entry expires on its own schedule, derived from the caller-provided TTL.
+struct ExpiringEntry {
+    value: Vec<u8>,
+    expires_at: Instant,
+}
+
+impl Expires for ExpiringEntry {
+    fn is_expired(&self) -> bool {
+        Instant::now() >= self.expires_at
+    }
+}
+
+/// Default, in-memory cache backend.
+///
+/// Wraps the `cached` crate's [`ExpiringCache`] (the RFC refers to this store by
+/// its older name, `ExpiringValueCache`; it was renamed to `ExpiringCache` in
+/// `cached` 2.0). `ExpiringCache` has no cache-wide TTL: each value decides when
+/// it has expired via [`Expires`], giving the per-key TTL the capability needs.
+/// It is kept behind the [`Cache`] trait so it can be swapped later. The
+/// `ExpiringCache` methods take `&mut self`, so the store is guarded by a
+/// `Mutex` to satisfy the shared-reference [`Cache`] contract.
+pub struct InMemoryCache {
+    store: Mutex<ExpiringCache<String, ExpiringEntry>>,
+}
+
+impl Default for InMemoryCache {
+    fn default() -> Self {
+        Self {
+            store: Mutex::new(ExpiringCache::default()),
+        }
+    }
+}
+
+impl InMemoryCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Cache for InMemoryCache {
+    fn set(&self, key: String, value: Vec<u8>, ttl: Duration) {
+        let entry = ExpiringEntry {
+            value,
+            expires_at: Instant::now() + ttl,
+        };
+        let mut store = self.store.lock().expect("cache mutex poisoned");
+        store.cache_set(key, entry);
+    }
+
+    fn get(&self, key: &str) -> Option<Vec<u8>> {
+        let mut store = self.store.lock().expect("cache mutex poisoned");
+        // `cache_get` evaluates `Expires::is_expired`, returning `None` (and
+        // evicting the entry) when it has expired, so per-key TTL is enforced.
+        store.cache_get(key).map(|entry| entry.value.clone())
+    }
+
+    fn flush_expired(&self) {
+        let mut store = self.store.lock().expect("cache mutex poisoned");
+        // `evict` sweeps and removes every expired entry in one pass.
+        store.evict();
+    }
+}
+
+/// Handle a `cache.set` request.
+///
+/// Enforces the reserved-prefix rule: keys starting with [`RESERVED_KEY_PREFIX`]
+/// are rejected with a non-zero code, leaving that namespace for the framework's
+/// own internal caches.
+pub fn handle_set(cache: &dyn Cache, req: CacheSetRequest) -> Result<CallbackResponse> {
+    let response = if req.key.starts_with(RESERVED_KEY_PREFIX) {
+        CacheSetResponse {
+            code: CODE_ERROR,
+            message: format!(
+                "the key prefix '{RESERVED_KEY_PREFIX}' is reserved for internal use and cannot be set by policies"
+            ),
+        }
+    } else {
+        cache.set(req.key, req.value, Duration::from_secs(req.ttl));
+        CacheSetResponse {
+            code: CODE_SUCCESS,
+            message: "ok".to_string(),
+        }
+    };
+
+    let payload = serde_json::to_vec(&response)
+        .map_err(|e| anyhow!("error serializing cache.set response: {e:?}"))?;
+    Ok(CallbackResponse { payload })
+}
+
+/// Handle a `cache.get` request. A miss is reported with a success code and an
+/// empty value, not as an error.
+pub fn handle_get(cache: &dyn Cache, req: CacheGetRequest) -> Result<CallbackResponse> {
+    let value = cache.get(&req.key);
+    let response = CacheGetResponse {
+        code: CODE_SUCCESS,
+        message: if value.is_some() {
+            "hit".to_string()
+        } else {
+            "miss".to_string()
+        },
+        value,
+    };
+
+    let payload = serde_json::to_vec(&response)
+        .map_err(|e| anyhow!("error serializing cache.get response: {e:?}"))?;
+    Ok(CallbackResponse { payload })
+}
+
+/// Spawn a background task that periodically evicts expired entries.
+///
+/// Expired entries are also reclaimed lazily on access, but without this task a
+/// key that is written once and never read again would occupy memory until the
+/// process restarts.
+pub fn spawn_eviction_task(cache: Arc<dyn Cache>, interval: Duration) {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        // Skip missed ticks instead of bursting on a loaded system.
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            cache.flush_expired();
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_then_get_returns_value() {
+        let cache = InMemoryCache::new();
+        cache.set("k".to_string(), b"v".to_vec(), Duration::from_secs(60));
+        assert_eq!(cache.get("k"), Some(b"v".to_vec()));
+    }
+
+    #[test]
+    fn missing_key_returns_none() {
+        let cache = InMemoryCache::new();
+        assert_eq!(cache.get("missing"), None);
+    }
+
+    #[test]
+    fn expired_entry_is_not_returned() {
+        let cache = InMemoryCache::new();
+        cache.set("k".to_string(), b"v".to_vec(), Duration::from_secs(0));
+        // TTL of zero means the entry is already expired.
+        assert_eq!(cache.get("k"), None);
+    }
+
+    #[test]
+    fn flush_expired_removes_only_expired_entries() {
+        let cache = InMemoryCache::new();
+        cache.set("fresh".to_string(), b"v".to_vec(), Duration::from_secs(60));
+        cache.set("stale".to_string(), b"v".to_vec(), Duration::from_secs(0));
+        cache.flush_expired();
+        assert_eq!(cache.get("fresh"), Some(b"v".to_vec()));
+        assert_eq!(cache.get("stale"), None);
+    }
+
+    #[test]
+    fn set_rejects_reserved_prefix() {
+        let cache = InMemoryCache::new();
+        let req = CacheSetRequest {
+            key: format!("{RESERVED_KEY_PREFIX}oci_digest"),
+            value: b"v".to_vec(),
+            ttl: 60,
+        };
+        let resp = handle_set(&cache, req).expect("handle_set should not fail");
+        let parsed: CacheSetResponse = serde_json::from_slice(&resp.payload).unwrap();
+        assert_eq!(parsed.code, CODE_ERROR);
+        // Nothing was stored.
+        assert_eq!(cache.get(&format!("{RESERVED_KEY_PREFIX}oci_digest")), None);
+    }
+
+    #[test]
+    fn set_accepts_regular_key() {
+        let cache = InMemoryCache::new();
+        let req = CacheSetRequest {
+            key: "my-key".to_string(),
+            value: b"v".to_vec(),
+            ttl: 60,
+        };
+        let resp = handle_set(&cache, req).expect("handle_set should not fail");
+        let parsed: CacheSetResponse = serde_json::from_slice(&resp.payload).unwrap();
+        assert_eq!(parsed.code, CODE_SUCCESS);
+        assert_eq!(cache.get("my-key"), Some(b"v".to_vec()));
+    }
+
+    #[test]
+    fn handle_get_reports_hit_and_miss() {
+        let cache = InMemoryCache::new();
+        cache.set("k".to_string(), b"v".to_vec(), Duration::from_secs(60));
+
+        let hit = handle_get(
+            &cache,
+            CacheGetRequest {
+                key: "k".to_string(),
+            },
+        )
+        .unwrap();
+        let parsed: CacheGetResponse = serde_json::from_slice(&hit.payload).unwrap();
+        assert_eq!(parsed.code, CODE_SUCCESS);
+        assert_eq!(parsed.value, Some(b"v".to_vec()));
+
+        let miss = handle_get(
+            &cache,
+            CacheGetRequest {
+                key: "absent".to_string(),
+            },
+        )
+        .unwrap();
+        let parsed: CacheGetResponse = serde_json::from_slice(&miss.payload).unwrap();
+        assert_eq!(parsed.code, CODE_SUCCESS);
+        assert_eq!(parsed.value, None);
+    }
+}

--- a/crates/policy-evaluator/src/callback_handler/cache.rs
+++ b/crates/policy-evaluator/src/callback_handler/cache.rs
@@ -13,11 +13,13 @@
 // leaves the door open for shared/distributed backends (e.g. Redis) in the
 // future without touching the host capability or any policy.
 
+use std::future::Future;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use anyhow::{Result, anyhow};
 use cached::{Cached, Expires, ExpiringCache};
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 use crate::callback_requests::CallbackResponse;
@@ -199,6 +201,50 @@ pub fn handle_get(cache: &dyn Cache, req: CacheGetRequest) -> Result<CallbackRes
     let payload = serde_json::to_vec(&response)
         .map_err(|e| anyhow!("error serializing cache.get response: {e:?}"))?;
     Ok(CallbackResponse { payload })
+}
+
+/// Look up a framework-internal entry in the shared cache, computing and
+/// storing it on a miss.
+///
+/// This backs the built-in host capabilities (OCI, sigstore, Kubernetes) so they
+/// share the single cache backend instead of each owning a private store (which
+/// is what the `#[cached]` macro used to do). `sub_key` is namespaced with
+/// [`RESERVED_KEY_PREFIX`], so these entries can never collide with
+/// policy-authored keys. The returned `cached::Return` carries the `was_cached`
+/// flag the `#[cached]` macro used to provide for logging.
+///
+/// Only successful results are cached. A (de)serialization failure is treated as
+/// a cache miss rather than an error, so it never changes the call's outcome.
+pub(crate) async fn internal_cached<T, Fut>(
+    cache: &dyn Cache,
+    sub_key: &str,
+    ttl: Duration,
+    compute: impl FnOnce() -> Fut,
+) -> Result<cached::Return<T>>
+where
+    T: Serialize + DeserializeOwned,
+    Fut: Future<Output = Result<T>>,
+{
+    let key = format!("{RESERVED_KEY_PREFIX}{sub_key}");
+
+    if let Some(bytes) = cache.get(&key) {
+        if let Ok(value) = serde_json::from_slice::<T>(&bytes) {
+            return Ok(cached::Return {
+                was_cached: true,
+                value,
+            });
+        }
+    }
+
+    let value = compute().await?;
+    if let Ok(bytes) = serde_json::to_vec(&value) {
+        cache.set(key, bytes, ttl);
+    }
+
+    Ok(cached::Return {
+        was_cached: false,
+        value,
+    })
 }
 
 /// Spawn a background task that periodically evicts expired entries.

--- a/crates/policy-evaluator/src/callback_handler/kubernetes.rs
+++ b/crates/policy-evaluator/src/callback_handler/kubernetes.rs
@@ -1,17 +1,23 @@
 use std::collections::BTreeSet;
+use std::time::Duration;
 
 mod client;
 pub(crate) mod field_mask;
 mod reflector;
 
 use anyhow::{Result, anyhow};
-use cached::macros::cached;
 use k8s_openapi::api::authorization::v1::SubjectAccessReviewStatus;
 use kube::core::ObjectList;
 use kubewarden_policy_sdk::host_capabilities::kubernetes::SubjectAccessReview as KWSubjectAccessReview;
 use serde::Serialize;
 
+use super::cache;
+
 pub(crate) use client::Client;
+
+/// Queries against the Kubernetes API are kept in the shared cache for this
+/// long. It is deliberately short, since cluster state can change at any moment.
+const KUBERNETES_CACHE_TTL: Duration = Duration::from_secs(5);
 
 #[derive(Eq, Hash, PartialEq)]
 struct ApiVersionKind {
@@ -98,21 +104,21 @@ pub(crate) async fn get_resource(
         })
 }
 
-#[cached(
-    ttl = 5,
-    sync_writes = "default",
-    key = "String",
-    convert = r#"{ format!("get_resource_cached({},{}),{},{:?}", api_version, kind, name, namespace) }"#,
-    with_cached_flag = true
-)]
 pub(crate) async fn get_resource_cached(
+    cache: &dyn cache::Cache,
     client: Option<&mut Client>,
     api_version: &str,
     kind: &str,
     name: &str,
     namespace: Option<&str>,
 ) -> Result<cached::Return<kube::core::DynamicObject>> {
-    get_resource(client, api_version, kind, name, namespace).await
+    let sub_key = format!("get_resource:{api_version}/{kind}:{name}:{namespace:?}");
+    cache::internal_cached(cache, &sub_key, KUBERNETES_CACHE_TTL, || async move {
+        get_resource(client, api_version, kind, name, namespace)
+            .await
+            .map(|ret| ret.value)
+    })
+    .await
 }
 
 pub(crate) async fn get_resource_plural_name(
@@ -183,20 +189,20 @@ pub(crate) async fn can_i(
         })
 }
 
-#[cached(
-    ttl = 5,
-    // We can use the request type as key because cached requires the key to implement Hash + Eq
-    // traits. As we already implement these traits, there is no need to have a custom logic for key
-    // generation. If we do that, we will only convert it into a type (e.g. string)  that
-    // implements the traits as well. 
-    key = "KWSubjectAccessReview",
-    convert = r#"{request.clone()}"#,
-    sync_writes = "default",
-    with_cached_flag = true
-)]
 pub(crate) async fn can_i_cached(
+    cache: &dyn cache::Cache,
     client: Option<&mut Client>,
     request: KWSubjectAccessReview,
 ) -> Result<cached::Return<SubjectAccessReviewStatus>> {
-    can_i(client, request).await
+    // The previous `#[cached]` macro used the request itself as the key (it
+    // implements Hash + Eq). The shared backend is keyed by String, so we
+    // serialize the request to derive an equivalent, stable key.
+    let sub_key = format!(
+        "can_i:{}",
+        serde_json::to_string(&request).unwrap_or_default()
+    );
+    cache::internal_cached(cache, &sub_key, KUBERNETES_CACHE_TTL, || async move {
+        can_i(client, request).await.map(|ret| ret.value)
+    })
+    .await
 }

--- a/crates/policy-evaluator/src/callback_handler/oci.rs
+++ b/crates/policy-evaluator/src/callback_handler/oci.rs
@@ -1,5 +1,6 @@
+use std::time::Duration;
+
 use anyhow::Result;
-use cached::macros::cached;
 use kubewarden_policy_sdk::host_capabilities::oci::ManifestDigestResponse;
 use policy_fetcher::{
     oci_client::{
@@ -10,6 +11,12 @@ use policy_fetcher::{
     sources::Sources,
 };
 use serde::{Deserialize, Serialize};
+
+use super::cache;
+
+/// Interacting with a remote OCI registry is expensive, so the results are kept
+/// in the shared cache for this long.
+const OCI_CACHE_TTL: Duration = Duration::from_secs(60);
 
 /// Helper struct to interact with an OCI registry
 pub(crate) struct Client {
@@ -77,67 +84,51 @@ impl Client {
 
 // Interacting with a remote OCI registry is time expensive, this can cause a massive slow down
 // of policy evaluations, especially inside of PolicyServer.
-// Because of that we will keep a cache of the digests results.
+// Because of that we keep the results in the shared cache backend.
 //
 // Details about this cache:
 //   * only the image "url" is used as key. oci::Client is not hashable, plus
 //     the client is always the same
 //   * the cache is time bound: cached values are purged after 60 seconds
 //   * only successful results are cached
-#[cached(
-    ttl = 60,
-    sync_writes = "default",
-    key = "String",
-    convert = r#"{ format!("{}", img) }"#,
-    with_cached_flag = true
-)]
 pub(crate) async fn get_oci_digest_cached(
+    cache: &dyn cache::Cache,
     oci_client: &Client,
     img: &str,
 ) -> Result<cached::Return<ManifestDigestResponse>> {
-    oci_client
-        .digest(img)
-        .await
-        .map(|digest| ManifestDigestResponse { digest })
-        .map(cached::Return::new)
+    cache::internal_cached(cache, &format!("oci_digest:{img}"), OCI_CACHE_TTL, || async {
+        oci_client
+            .digest(img)
+            .await
+            .map(|digest| ManifestDigestResponse { digest })
+    })
+    .await
 }
 
-// Interacting with a remote OCI registry is time expensive, this can cause a massive slow down
-// of policy evaluations, especially inside of PolicyServer.
-// Because of that we will keep a cache of the manifest results.
-//
-// Details about this cache:
-//   * only the image "url" is used as key. oci::Client is not hashable, plus
-//     the client is always the same
-//   * the cache is time bound: cached values are purged after 60 seconds
-//   * only successful results are cached
-#[cached(
-    ttl = 60,
-    sync_writes = "default",
-    key = "String",
-    convert = r#"{ format!("{}", img) }"#,
-    with_cached_flag = true
-)]
 pub(crate) async fn get_oci_manifest_cached(
+    cache: &dyn cache::Cache,
     oci_client: &Client,
     img: &str,
 ) -> Result<cached::Return<OciManifest>> {
-    oci_client.manifest(img).await.map(cached::Return::new)
+    cache::internal_cached(
+        cache,
+        &format!("oci_manifest:{img}"),
+        OCI_CACHE_TTL,
+        || async { oci_client.manifest(img).await },
+    )
+    .await
 }
 
-#[cached(
-    ttl = 60,
-    sync_writes = "default",
-    key = "String",
-    convert = r#"{ format!("{}", img) }"#,
-    with_cached_flag = true
-)]
 pub(crate) async fn get_oci_manifest_and_config_cached(
+    cache: &dyn cache::Cache,
     oci_client: &Client,
     img: &str,
 ) -> Result<cached::Return<ManifestAndConfigResponse>> {
-    oci_client
-        .manifest_and_config(img)
-        .await
-        .map(cached::Return::new)
+    cache::internal_cached(
+        cache,
+        &format!("oci_manifest_and_config:{img}"),
+        OCI_CACHE_TTL,
+        || async { oci_client.manifest_and_config(img).await },
+    )
+    .await
 }

--- a/crates/policy-evaluator/src/callback_handler/sigstore_verification.rs
+++ b/crates/policy-evaluator/src/callback_handler/sigstore_verification.rs
@@ -1,7 +1,6 @@
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use anyhow::{Result, anyhow};
-use cached::macros::cached;
 use itertools::Itertools;
 use kubewarden_policy_sdk::host_capabilities::verification::{
     KeylessInfo, KeylessPrefixInfo, VerificationResponse,
@@ -24,6 +23,12 @@ use sigstore::{
 };
 use tokio::sync::Mutex;
 use tracing::warn;
+
+use super::cache;
+
+/// Sigstore verifications are expensive, so the results are kept in the shared
+/// cache for this long.
+const SIGSTORE_CACHE_TTL: Duration = Duration::from_secs(60);
 
 #[derive(Clone)]
 pub(crate) struct Client {
@@ -265,23 +270,18 @@ impl Client {
 // Details about this cache:
 //   * the cache is time bound: cached values are purged after 60 seconds
 //   * only successful results are cached
-#[cached(
-    ttl = 60,
-    sync_writes = "default",
-    key = "String",
-    convert = r#"{ format!("{}{:?}{:?}", image, pub_keys, annotations)}"#,
-    with_cached_flag = true
-)]
 pub(crate) async fn get_sigstore_pub_key_verification_cached(
+    cache: &dyn cache::Cache,
     client: &mut Client,
     image: String,
     pub_keys: Vec<String>,
     annotations: Option<BTreeMap<String, String>>,
 ) -> Result<cached::Return<VerificationResponse>> {
-    client
-        .verify_public_key(image, pub_keys, annotations)
-        .await
-        .map(cached::Return::new)
+    let sub_key = format!("sigstore_pubkey:{image}{pub_keys:?}{annotations:?}");
+    cache::internal_cached(cache, &sub_key, SIGSTORE_CACHE_TTL, || async move {
+        client.verify_public_key(image, pub_keys, annotations).await
+    })
+    .await
 }
 
 // Sigstore verifications are time expensive, this can cause a massive slow down
@@ -291,23 +291,18 @@ pub(crate) async fn get_sigstore_pub_key_verification_cached(
 // Details about this cache:
 //   * the cache is time bound: cached values are purged after 60 seconds
 //   * only successful results are cached
-#[cached(
-    ttl = 60,
-    sync_writes = "default",
-    key = "String",
-    convert = r#"{ format!("{}{:?}{:?}", image, keyless, annotations)}"#,
-    with_cached_flag = true
-)]
 pub(crate) async fn get_sigstore_keyless_verification_cached(
+    cache: &dyn cache::Cache,
     client: &mut Client,
     image: String,
     keyless: Vec<KeylessInfo>,
     annotations: Option<BTreeMap<String, String>>,
 ) -> Result<cached::Return<VerificationResponse>> {
-    client
-        .verify_keyless(image, keyless, annotations)
-        .await
-        .map(cached::Return::new)
+    let sub_key = format!("sigstore_keyless:{image}{keyless:?}{annotations:?}");
+    cache::internal_cached(cache, &sub_key, SIGSTORE_CACHE_TTL, || async move {
+        client.verify_keyless(image, keyless, annotations).await
+    })
+    .await
 }
 
 // Sigstore verifications are time expensive, this can cause a massive slow down
@@ -317,23 +312,20 @@ pub(crate) async fn get_sigstore_keyless_verification_cached(
 // Details about this cache:
 //   * the cache is time bound: cached values are purged after 60 seconds
 //   * only successful results are cached
-#[cached(
-    ttl = 60,
-    sync_writes = "default",
-    key = "String",
-    convert = r#"{ format!("{}{:?}{:?}", image, keyless_prefix, annotations)}"#,
-    with_cached_flag = true
-)]
 pub(crate) async fn get_sigstore_keyless_prefix_verification_cached(
+    cache: &dyn cache::Cache,
     client: &mut Client,
     image: String,
     keyless_prefix: Vec<KeylessPrefixInfo>,
     annotations: Option<BTreeMap<String, String>>,
 ) -> Result<cached::Return<VerificationResponse>> {
-    client
-        .verify_keyless_prefix(image, keyless_prefix, annotations)
-        .await
-        .map(cached::Return::new)
+    let sub_key = format!("sigstore_keyless_prefix:{image}{keyless_prefix:?}{annotations:?}");
+    cache::internal_cached(cache, &sub_key, SIGSTORE_CACHE_TTL, || async move {
+        client
+            .verify_keyless_prefix(image, keyless_prefix, annotations)
+            .await
+    })
+    .await
 }
 
 // Sigstore verifications are time expensive, this can cause a massive slow down
@@ -343,24 +335,21 @@ pub(crate) async fn get_sigstore_keyless_prefix_verification_cached(
 // Details about this cache:
 //   * the cache is time bound: cached values are purged after 60 seconds
 //   * only successful results are cached
-#[cached(
-    ttl = 60,
-    sync_writes = "default",
-    key = "String",
-    convert = r#"{ format!("{}{:?}{:?}{:?}", image, owner, repo, annotations)}"#,
-    with_cached_flag = true
-)]
 pub(crate) async fn get_sigstore_github_actions_verification_cached(
+    cache: &dyn cache::Cache,
     client: &mut Client,
     image: String,
     owner: String,
     repo: Option<String>,
     annotations: Option<BTreeMap<String, String>>,
 ) -> Result<cached::Return<VerificationResponse>> {
-    client
-        .verify_github_actions(image, owner, repo, annotations)
-        .await
-        .map(cached::Return::new)
+    let sub_key = format!("sigstore_github_actions:{image}{owner}{repo:?}{annotations:?}");
+    cache::internal_cached(cache, &sub_key, SIGSTORE_CACHE_TTL, || async move {
+        client
+            .verify_github_actions(image, owner, repo, annotations)
+            .await
+    })
+    .await
 }
 
 fn get_sigstore_certificate_verification_cache_key(
@@ -398,14 +387,8 @@ fn get_sigstore_certificate_verification_cache_key(
     hex::encode(hasher.finalize())
 }
 
-#[cached(
-    ttl = 60,
-    sync_writes = "default",
-    key = "String",
-    convert = r#"{ format!("{}", get_sigstore_certificate_verification_cache_key(image, certificate, certificate_chain, require_rekor_bundle, annotations.as_ref()))}"#,
-    with_cached_flag = true
-)]
 pub(crate) async fn get_sigstore_certificate_verification_cached(
+    cache: &dyn cache::Cache,
     client: &mut Client,
     image: &str,
     certificate: &[u8],
@@ -413,14 +396,26 @@ pub(crate) async fn get_sigstore_certificate_verification_cached(
     require_rekor_bundle: bool,
     annotations: Option<BTreeMap<String, String>>,
 ) -> Result<cached::Return<VerificationResponse>> {
-    client
-        .verify_certificate(
+    let sub_key = format!(
+        "sigstore_certificate:{}",
+        get_sigstore_certificate_verification_cache_key(
             image,
             certificate,
             certificate_chain,
             require_rekor_bundle,
-            annotations,
+            annotations.as_ref(),
         )
-        .await
-        .map(cached::Return::new)
+    );
+    cache::internal_cached(cache, &sub_key, SIGSTORE_CACHE_TTL, || async move {
+        client
+            .verify_certificate(
+                image,
+                certificate,
+                certificate_chain,
+                require_rekor_bundle,
+                annotations,
+            )
+            .await
+    })
+    .await
 }

--- a/crates/policy-evaluator/src/callback_requests.rs
+++ b/crates/policy-evaluator/src/callback_requests.rs
@@ -125,6 +125,24 @@ pub enum CallbackRequestType {
     /// Lookup the addresses for a given hostname via DNS
     DNSLookupHost { host: String },
 
+    /// Store arbitrary data inside of the policy-author-controlled cache.
+    /// See RFC 0024 (cache host capability).
+    CacheSet {
+        /// The unique identifier for the data being stored
+        key: String,
+        /// The arbitrary data to be stored in the cache
+        value: Vec<u8>,
+        /// The lifespan of the data, in seconds
+        ttl: u64,
+    },
+
+    /// Retrieve data from the policy-author-controlled cache.
+    /// A cache miss is not an error: an empty value is returned instead.
+    CacheGet {
+        /// The key of the data to retrieve
+        key: String,
+    },
+
     /// Get all the Kubernetes resources defined inside of the given
     /// namespace
     /// Note: cannot be used with cluster-wide resources

--- a/crates/policy-evaluator/src/host_capabilities.rs
+++ b/crates/policy-evaluator/src/host_capabilities.rs
@@ -69,6 +69,13 @@ static CAPABILITY_TREE: LazyLock<CapabilityNode> = LazyLock::new(|| {
                 ("can_i", CapabilityNode::leaf()),
             ])),
         ),
+        (
+            "cache",
+            CapabilityNode::node(HashMap::from([
+                ("set", CapabilityNode::leaf()),
+                ("get", CapabilityNode::leaf()),
+            ])),
+        ),
     ]))
 });
 
@@ -443,6 +450,9 @@ mod tests {
             "kubernetes/list_resources_all",
             "kubernetes/list_resources_by_namespace",
             "kubernetes/*",
+            "cache/set",
+            "cache/get",
+            "cache/*",
         ];
         let result = HostCapabilities::new(patterns);
         assert!(
@@ -483,6 +493,8 @@ mod tests {
 
         // The expected complete set of leaf paths, kept in sync with CAPABILITY_TREE.
         let mut expected: Vec<(String, String)> = vec![
+            ("cache", "get"),
+            ("cache", "set"),
             ("crypto", "v1/is_certificate_trusted"),
             ("kubernetes", "can_i"),
             ("kubernetes", "get_resource"),

--- a/crates/policy-evaluator/src/runtimes/callback.rs
+++ b/crates/policy-evaluator/src/runtimes/callback.rs
@@ -365,6 +365,64 @@ pub(crate) fn host_callback(
             }
             _ => unknown_operation(namespace, operation),
         },
+        "cache" => match operation {
+            "set" => {
+                let req: crate::callback_handler::cache::CacheSetRequest =
+                    serde_json::from_slice(payload)?;
+                debug!(
+                    eval_ctx.policy_id,
+                    binding,
+                    namespace,
+                    operation,
+                    key = req.key,
+                    ttl = req.ttl,
+                    "Sending request via callback channel"
+                );
+                let (tx, rx) = oneshot::channel::<Result<CallbackResponse>>();
+                let req = CallbackRequest {
+                    request: CallbackRequestType::CacheSet {
+                        key: req.key,
+                        value: req.value,
+                        ttl: req.ttl,
+                    },
+                    response_channel: tx,
+                };
+                send_request_and_wait_for_response(
+                    &eval_ctx.policy_id,
+                    binding,
+                    operation,
+                    req,
+                    rx,
+                    eval_ctx,
+                )
+            }
+            "get" => {
+                let req: crate::callback_handler::cache::CacheGetRequest =
+                    serde_json::from_slice(payload)?;
+                debug!(
+                    eval_ctx.policy_id,
+                    binding,
+                    namespace,
+                    operation,
+                    key = req.key,
+                    "Sending request via callback channel"
+                );
+                let (tx, rx) = oneshot::channel::<Result<CallbackResponse>>();
+                let req = CallbackRequest {
+                    request: CallbackRequestType::CacheGet { key: req.key },
+                    response_channel: tx,
+                };
+                send_request_and_wait_for_response(
+                    &eval_ctx.policy_id,
+                    binding,
+                    operation,
+                    req,
+                    rx,
+                    eval_ctx,
+                )
+            }
+            _ => unknown_operation(namespace, operation),
+        },
         _ => unknown_namespace(namespace),
     }
 }

--- a/crates/policy-server/src/lib.rs
+++ b/crates/policy-server/src/lib.rs
@@ -24,7 +24,7 @@ use axum_server::tls_rustls::RustlsConfig;
 use certs::create_tls_config_and_watch_certificate_changes;
 use evaluation::EvaluationEnvironmentBuilder;
 use policy_evaluator::{
-    callback_handler::{CallbackHandler, CallbackHandlerBuilder},
+    callback_handler::{CallbackHandler, CallbackHandlerBuilder, cache},
     kube,
     policy_fetcher::sigstore::trust::sigstore::SigstoreTrustRoot,
     wasmtime,
@@ -91,10 +91,17 @@ impl PolicyServer {
             }
         };
 
+        // Backend for the `cache` host capability (RFC 0024). policy-server owns
+        // the backend so it can also drive the background eviction task; it is
+        // injected into the callback handler below.
+        let cache_backend: Arc<dyn cache::Cache> = Arc::new(cache::InMemoryCache::new());
+        cache::spawn_eviction_task(cache_backend.clone(), cache::DEFAULT_EVICTION_INTERVAL);
+
         let mut callback_handler_builder =
             CallbackHandlerBuilder::new(callback_handler_shutdown_channel_rx)
                 .registry_config(config.sources.clone())
-                .trust_root(sigstore_trust_root.clone());
+                .trust_root(sigstore_trust_root.clone())
+                .cache(cache_backend);
 
         let kube_client: Option<kube::Client> = match kube::Client::try_default().await {
             Ok(client) => Some(client),


### PR DESCRIPTION
Implements the policy-author-controlled cache host capability from [[RFC 0024](https://github.com/kubewarden/rfc/blob/main/rfc/0024-cache-host-capability.md)](https://github.com/kubewarden/rfc/blob/main/rfc/0024-cache-host-capability.md). Part of #1273.

## Testing

- `policy-evaluator` lib unit tests pass (cache backend, set/get/eviction, reserved-prefix, capability gating).
- ⚠️ policy-server not compiled/tested locally — my host is Windows, where `tikv-jemalloc-sys` fails to build (`x86_64-pc-windows-msvc`). The policy-server changes are small and type-aligned with the evaluator API, but need CI/Linux to verify.

## Pending 

- SDK wrappers (rust/go/js) — live in their own repos; needed before policies can use this ergonomically.


## Pending

**SDK wrappers** — language-native `cache.set` / `cache.get`, in their own repos:
- [x] policy-sdk-rust
- [x] policy-sdk-js
- [x] policy-sdk-go
- [ ] policy-sdk-dotnet
- [ ] policy-sdk-swift

**Follow-up in this repo:**
- [x] Refactor existing `#[cached]` capabilities (oci/sigstore/kubernetes) onto the shared cache backend, using the reserved `kubewarden_internal_` prefix 
- [x] policy-server: verify build on CI/Linux (jemalloc blocks local Windows build)
