### PR TITLE
feat(migration): install unified chart from merged legacy values

### DIFF
--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -224,13 +224,16 @@ detects the legacy release name automatically.
 `<release>-admission-controller`). The legacy resources being adopted were
 created by the old `kubewarden-controller` chart and carry
 `app.kubernetes.io/name: kubewarden-controller` in the same immutable
-selector. The script therefore installs with
-`--set nameOverride=<legacy name>` (read from the legacy release's Helm
-values, defaulting to `kubewarden-controller`) so the chart reproduces
-the old names/labels and Server-Side Apply adopts the objects in place.
-This value is stored in the release, so **future upgrades must keep
-it** — run `helm upgrade ... --reuse-values`, or add
-`nameOverride: kubewarden-controller` to your values file. Omitting it
+selector. The migration script builds a values file by concatenating
+`helm get values` from the three legacy releases (`kubewarden-crds`,
+`kubewarden-controller`, `kubewarden-defaults`) and writes a reconciled
+`nameOverride` into it (filled with `kubewarden-controller` only when
+you had not set it) so the chart reproduces the old names/labels and
+Server-Side Apply adopts the objects in place. Any `--set`/`--values`
+you pass to the script override the merged values. These values are
+stored in the release, so **future upgrades must keep them** — run
+`helm upgrade ... --reuse-values`, or pass the generated
+`kw-merged-values.yaml` with `--values`. Dropping `nameOverride`
 re-renders `admission-controller`-named selectors and fails on the immutable
 field. (A cluster migrated this way keeps `kubewarden-controller`
 resource names; a brand-new install uses `admission-controller`.)
@@ -241,6 +244,18 @@ configurations are still served by the surviving policy-server pods,
 so admission for active policies keeps working. New policy CRs
 created during this window are not reconciled into webhooks until
 the new controller starts.
+
+**Legacy defaults not carried over.** The migration script uses
+`helm get values` (user-supplied overrides only, not `--all`) to build
+the merged values file. Settings that were only legacy chart
+*defaults* (never explicitly set by you) are not carried over. If you
+relied on them, pass them with `--set` or `--values`. Notably, the
+unified chart defaults are `recommendedPolicies.enabled: false` and
+`recommendedPolicies.defaultPolicyMode: "monitor"` (the script no
+longer forces `enabled=true` / `protect`). If the legacy defaults chart
+enabled recommended policies by default and you never overrode that,
+pass `--set recommendedPolicies.enabled=true` and
+`--set recommendedPolicies.defaultPolicyMode=protect` to keep them.
 
 **Settings drift.** The DefaultsApplier rewrites each recommended
 policy's spec to match the values you pass to the unified chart. If

--- a/charts/admission-controller/kubewarden-unified-adm-controller-chart-migration.sh
+++ b/charts/admission-controller/kubewarden-unified-adm-controller-chart-migration.sh
@@ -116,10 +116,6 @@ LEGACY_RELEASES=(
 # Detected at runtime.
 LEGACY_CONTROLLER_RELEASE_NAME=""
 RECOMMENDED_POLICIES=()
-# Raw user-supplied nameOverride of the legacy controller release ("" if the
-# user never set it). Used to decide whether the merged values need a filled-in
-# nameOverride.
-LEGACY_CONTROLLER_NAMEOVERRIDE=""
 # Values file built by concatenating the three legacy releases' user values.
 MERGED_VALUES_FILE="${MERGED_VALUES_FILE:-./kw-merged-values.yaml}"
 # nameOverride to pass to the unified chart so it renders the SAME resource
@@ -356,7 +352,6 @@ phase_preflight() {
   local legacy_name_override
   legacy_name_override="$(hctl get values "$LEGACY_CONTROLLER_RELEASE_NAME" -n "$KW_NAMESPACE" -o json 2>/dev/null \
                           | jq -r '.nameOverride // empty' 2>/dev/null || true)"
-  LEGACY_CONTROLLER_NAMEOVERRIDE="$legacy_name_override"
   if [[ -n "$legacy_name_override" ]]; then
     LEGACY_NAME_OVERRIDE="$legacy_name_override"
     info "legacy release set a custom nameOverride: '$LEGACY_NAME_OVERRIDE'"
@@ -595,6 +590,10 @@ phase_build_merged_values() {
       info "$release: no user-supplied values"
       continue
     fi
+    # Strip any top-level nameOverride; it is reconciled to a single
+    # authoritative value below (avoids duplicate keys when a legacy release
+    # stored nameOverride: "").
+    vals="$(printf '%s\n' "$vals" | grep -v '^nameOverride:' || true)"
     info "$release: appending user-supplied values"
     {
       printf '# values from legacy release: %s\n' "$release"
@@ -602,17 +601,15 @@ phase_build_merged_values() {
     } >> "$MERGED_VALUES_FILE"
   done
 
-  # Reconcile nameOverride. The unified chart was renamed to "adm-controller",
-  # so an empty/absent nameOverride renders app.kubernetes.io/name=adm-controller
-  # and breaks in-place adoption of the live kubewarden-controller resources. If
-  # the legacy controller release set a non-empty nameOverride it is already in
-  # the appended block above; otherwise fill it with the legacy effective name.
-  if [[ -z "$LEGACY_CONTROLLER_NAMEOVERRIDE" ]]; then
-    {
-      printf '# nameOverride filled in by migration (legacy chart default name)\n'
-      printf 'nameOverride: %s\n' "$LEGACY_NAME_OVERRIDE"
-    } >> "$MERGED_VALUES_FILE"
-  fi
+  # Reconcile nameOverride. The unified chart is named "admission-controller",
+  # so an empty/absent nameOverride renders app.kubernetes.io/name=admission-controller
+  # and breaks in-place adoption of the live kubewarden-controller resources.
+  # LEGACY_NAME_OVERRIDE already holds the legacy effective name (custom or the
+  # kubewarden-controller default), so we always write exactly one nameOverride.
+  {
+    printf '# nameOverride reconciled by migration (legacy effective name)\n'
+    printf 'nameOverride: %s\n' "$LEGACY_NAME_OVERRIDE"
+  } >> "$MERGED_VALUES_FILE"
 
   ok "merged values written to $MERGED_VALUES_FILE"
   info "merged values:"

--- a/charts/admission-controller/kubewarden-unified-adm-controller-chart-migration.sh
+++ b/charts/admission-controller/kubewarden-unified-adm-controller-chart-migration.sh
@@ -31,9 +31,11 @@
 #      chart. Two things make in-place adoption work despite the chart rename:
 #      the release name must match the legacy kubewarden-controller release
 #      name (preserves the app.kubernetes.io/instance selector label), and the
-#      install passes --set nameOverride=<legacy name> (preserves the
-#      app.kubernetes.io/name selector label). The legacy name is read from the
-#      legacy release's Helm values in preflight. Helm 4 uses Server-Side Apply
+#      install passes a merged values file (the concatenation of the three
+#      legacy releases' `helm get values`) that carries a reconciled
+#      nameOverride (preserves the app.kubernetes.io/name selector label). The
+#      legacy name is read from the legacy release's Helm values in preflight.
+#      Helm 4 uses Server-Side Apply
 #      to adopt existing resources and strip the legacy keep annotations from
 #      chart-rendered resources.
 #
@@ -114,6 +116,12 @@ LEGACY_RELEASES=(
 # Detected at runtime.
 LEGACY_CONTROLLER_RELEASE_NAME=""
 RECOMMENDED_POLICIES=()
+# Raw user-supplied nameOverride of the legacy controller release ("" if the
+# user never set it). Used to decide whether the merged values need a filled-in
+# nameOverride.
+LEGACY_CONTROLLER_NAMEOVERRIDE=""
+# Values file built by concatenating the three legacy releases' user values.
+MERGED_VALUES_FILE="${MERGED_VALUES_FILE:-./kw-merged-values.yaml}"
 # nameOverride to pass to the unified chart so it renders the SAME resource
 # names/labels as the legacy chart (required for in-place adoption — see
 # phase_install_unified). Defaults to the well-known legacy chart name and is
@@ -348,13 +356,14 @@ phase_preflight() {
   local legacy_name_override
   legacy_name_override="$(hctl get values "$LEGACY_CONTROLLER_RELEASE_NAME" -n "$KW_NAMESPACE" -o json 2>/dev/null \
                           | jq -r '.nameOverride // empty' 2>/dev/null || true)"
+  LEGACY_CONTROLLER_NAMEOVERRIDE="$legacy_name_override"
   if [[ -n "$legacy_name_override" ]]; then
     LEGACY_NAME_OVERRIDE="$legacy_name_override"
     info "legacy release set a custom nameOverride: '$LEGACY_NAME_OVERRIDE'"
   else
     info "legacy release used the default chart name: nameOverride='$LEGACY_NAME_OVERRIDE'"
   fi
-  info "unified chart will be installed with --set nameOverride=$LEGACY_NAME_OVERRIDE (preserves legacy resource identity)"
+  info "merged values file will carry nameOverride=$LEGACY_NAME_OVERRIDE (preserves legacy resource identity)"
 
   # Validate unified chart source.
   if [[ -f "$UNIFIED_CHART" ]]; then
@@ -564,6 +573,53 @@ phase_uninstall_legacy() {
 }
 
 #------------------------------------------------------------------------------
+# Build the merged values file from the three legacy releases.
+#
+# The unified chart's values are the concatenation of the three legacy charts'
+# values (their key namespaces are effectively disjoint), so we simply append
+# each release's user-supplied values into one file — no deep merge. Runs before
+# the legacy uninstall because `helm get values` needs the releases to exist.
+#------------------------------------------------------------------------------
+phase_build_merged_values() {
+  step "Phase: build merged values from legacy releases"
+
+  : > "$MERGED_VALUES_FILE"
+
+  local entry release vals
+  for entry in "${LEGACY_RELEASES[@]}"; do
+    release="${entry%%=*}"
+    vals="$(hctl get values "$release" -n "$KW_NAMESPACE" -o yaml 2>/dev/null || true)"
+    # `helm get values -o yaml` prints "null" (or nothing) when the release has
+    # no user-supplied values; skip those.
+    if [[ -z "$vals" || "$vals" == "null" ]]; then
+      info "$release: no user-supplied values"
+      continue
+    fi
+    info "$release: appending user-supplied values"
+    {
+      printf '# values from legacy release: %s\n' "$release"
+      printf '%s\n' "$vals"
+    } >> "$MERGED_VALUES_FILE"
+  done
+
+  # Reconcile nameOverride. The unified chart was renamed to "adm-controller",
+  # so an empty/absent nameOverride renders app.kubernetes.io/name=adm-controller
+  # and breaks in-place adoption of the live kubewarden-controller resources. If
+  # the legacy controller release set a non-empty nameOverride it is already in
+  # the appended block above; otherwise fill it with the legacy effective name.
+  if [[ -z "$LEGACY_CONTROLLER_NAMEOVERRIDE" ]]; then
+    {
+      printf '# nameOverride filled in by migration (legacy chart default name)\n'
+      printf 'nameOverride: %s\n' "$LEGACY_NAME_OVERRIDE"
+    } >> "$MERGED_VALUES_FILE"
+  fi
+
+  ok "merged values written to $MERGED_VALUES_FILE"
+  info "merged values:"
+  sed 's/^/      /' "$MERGED_VALUES_FILE"
+}
+
+#------------------------------------------------------------------------------
 # Phase 5: Install unified chart
 #------------------------------------------------------------------------------
 phase_install_unified() {
@@ -576,29 +632,33 @@ phase_install_unified() {
 
   confirm "About to run 'helm install $release_name --take-ownership' to adopt existing resources."
 
-  # nameOverride=$LEGACY_NAME_OVERRIDE is REQUIRED for the migration.
+  # Install from the merged legacy values (see phase_build_merged_values) instead
+  # of hardcoded --set flags, so the migrated release keeps the configuration the
+  # user actually had on the legacy stack. The merged file also carries the
+  # reconciled nameOverride, which preserves the legacy app.kubernetes.io/name so
+  # Helm 4 Server-Side Apply adopts the existing objects in place rather than
+  # failing on the immutable Deployment selector (reusing the legacy release name
+  # preserves app.kubernetes.io/instance).
   #
   # The unified chart is now named "admission-controller", so by default it renders
   # resources with the new identity (app.kubernetes.io/name=admission-controller,
   # Deployment <release>-admission-controller, etc.). The live legacy resources we are
   # adopting were created by the old "kubewarden-controller" chart and carry the
-  # legacy app.kubernetes.io/name in their immutable Deployment selectors.
-  # Pinning nameOverride to the detected legacy name (see phase_preflight) makes
-  # the unified chart render the OLD app.kubernetes.io/name; reusing the legacy
-  # release name (above) preserves the OLD app.kubernetes.io/instance. With both
-  # immutable selector labels matched, Helm 4 Server-Side Apply adopts the
+  # legacy app.kubernetes.io/name in their immutable Deployment selectors. The merged
+  # values file carries the reconciled nameOverride (see phase_build_merged_values),
+  # which makes the unified chart render the OLD app.kubernetes.io/name; reusing the
+  # legacy release name (above) preserves the OLD app.kubernetes.io/instance. With
+  # both immutable selector labels matched, Helm 4 Server-Side Apply adopts the
   # existing objects in place instead of failing on the immutable selector.
   #
-  # This value is stored in the release: future `helm upgrade --reuse-values`
-  # (or a values file carrying nameOverride: $LEGACY_NAME_OVERRIDE) keeps it.
-  if dry_run_guard "helm install $release_name $UNIFIED_CHART --namespace $KW_NAMESPACE --take-ownership --set nameOverride=$LEGACY_NAME_OVERRIDE --set policyServer.enabled=true --set recommendedPolicies.enabled=true ${HELM_INSTALL_EXTRA_ARGS[*]:-}"; then
+  # User-passed --set/--values (HELM_INSTALL_EXTRA_ARGS) come last so they
+  # override the merged values. These values are stored in the release, so future
+  # `helm upgrade --reuse-values` keeps them.
+  if dry_run_guard "helm install $release_name $UNIFIED_CHART --namespace $KW_NAMESPACE --take-ownership --values $MERGED_VALUES_FILE ${HELM_INSTALL_EXTRA_ARGS[*]:-}"; then
     hctl install "$release_name" "$UNIFIED_CHART" \
       --namespace "$KW_NAMESPACE" \
       --take-ownership \
-      --set "nameOverride=$LEGACY_NAME_OVERRIDE" \
-      --set "policyServer.enabled=true" \
-      --set "recommendedPolicies.enabled=true" \
-      --set "recommendedPolicies.defaultPolicyMode=protect" \
+      --values "$MERGED_VALUES_FILE" \
       "${HELM_INSTALL_EXTRA_ARGS[@]}" \
       --wait --timeout "$WAIT_TIMEOUT"
     ok "unified chart installed"
@@ -706,6 +766,7 @@ phase_install_unified() {
 #------------------------------------------------------------------------------
 phase_preflight
 phase_snapshot
+phase_build_merged_values
 phase_inject_keep_annotations
 phase_uninstall_legacy
 phase_install_unified
@@ -717,9 +778,11 @@ info "Log saved to: $LOG_FILE"
 info ""
 info "Next steps:"
 info "  - Verify your PolicyServers and policies are working as expected"
-info "  - IMPORTANT: this release was installed with nameOverride=$LEGACY_NAME_OVERRIDE"
-info "    to preserve the legacy resource names/labels (immutable Deployment"
-info "    selector). Future upgrades MUST keep this value, e.g. run"
-info "    'helm upgrade ... --reuse-values' or add 'nameOverride: $LEGACY_NAME_OVERRIDE'"
-info "    to your values file. Omitting it would re-render admission-controller-named"
-info "    selectors and fail on the immutable field."
+info "  - The unified chart was installed from the merged legacy values at:"
+info "      $MERGED_VALUES_FILE"
+info "    Keep this file. It carries nameOverride=$LEGACY_NAME_OVERRIDE, which"
+info "    preserves the legacy resource names/labels (immutable Deployment"
+info "    selector). Future upgrades MUST keep these values, e.g. run"
+info "    'helm upgrade ... --reuse-values' or pass '--values $MERGED_VALUES_FILE'."
+info "    Dropping nameOverride would re-render admission-controller-named selectors"
+info "    and fail on the immutable field."

--- a/charts/admission-controller/kubewarden-unified-adm-controller-chart-migration.sh
+++ b/charts/admission-controller/kubewarden-unified-adm-controller-chart-migration.sh
@@ -578,6 +578,17 @@ phase_uninstall_legacy() {
 phase_build_merged_values() {
   step "Phase: build merged values from legacy releases"
 
+  # Refuse to clobber an existing file (it may be a previous run's output or a
+  # user-managed file holding real config). Prompt in interactive mode, fail
+  # fast otherwise.
+  if [[ -e "$MERGED_VALUES_FILE" ]]; then
+    if (( INTERACTIVE == 1 )); then
+      confirm "merged values file $MERGED_VALUES_FILE already exists and will be overwritten."
+    else
+      fail "merged values file $MERGED_VALUES_FILE already exists; remove it or set MERGED_VALUES_FILE to a new path"
+    fi
+  fi
+
   : > "$MERGED_VALUES_FILE"
 
   local entry release vals

--- a/charts/admission-controller/kubewarden-unified-adm-controller-chart-migration.sh
+++ b/charts/admission-controller/kubewarden-unified-adm-controller-chart-migration.sh
@@ -63,6 +63,7 @@
 #       [--values FILE]
 #       [--interactive]
 #       [--dry-run]
+#       [--verbose]
 #       [--help]
 #
 # Examples:
@@ -91,6 +92,7 @@ HELM_REPO_URL="${HELM_REPO_URL:-https://charts.kubewarden.io}"
 WAIT_TIMEOUT="${WAIT_TIMEOUT:-5m}"
 INTERACTIVE=0
 DRY_RUN=0
+VERBOSE=0
 
 # Extra arguments forwarded to `helm install` for the unified chart.
 HELM_INSTALL_EXTRA_ARGS=()
@@ -166,6 +168,8 @@ while (( $# > 0 )); do
       INTERACTIVE=1; shift ;;
     --dry-run)
       DRY_RUN=1; shift ;;
+    --verbose)
+      VERBOSE=1; shift ;;
     --set)
       require_flag_value "$1" "${2:-}"; HELM_INSTALL_EXTRA_ARGS+=(--set "$2"); shift 2 ;;
     --set=*)
@@ -623,8 +627,15 @@ phase_build_merged_values() {
   } >> "$MERGED_VALUES_FILE"
 
   ok "merged values written to $MERGED_VALUES_FILE"
-  info "merged values:"
-  sed 's/^/      /' "$MERGED_VALUES_FILE"
+  # The merged values come from `helm get values` and may carry sensitive
+  # user-supplied config, so only dump the full contents under --verbose;
+  # otherwise just point at the file.
+  if (( VERBOSE == 1 )); then
+    info "merged values:"
+    sed 's/^/      /' "$MERGED_VALUES_FILE"
+  else
+    info "re-run with --verbose to print the merged values"
+  fi
 }
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

The migration script builds a values file from helm get values output of the three legacy releases (kubewarden-crds, kubewarden-controller, kubewarden-defaults) and uses that to install the unified chart instead of hardcoded --set flags.
    
nameOverride gets filled in when absent to preserve resource identity for in-place adoption. If the legacy controller release set it, the script uses that. Otherwise it defaults to kubewarden-controller to match the old resource names. User-passed --set and --values override the merged values.

This keeps whatever configuration you had on the legacy stack. Note that helm get values returns only user overrides, not chart defaults. If you relied on a default without setting it explicitly, pass it with --set or --values.

