### PR TITLE
fix(ci): remove old chart references from updatecli scripts

### DIFF
--- a/updatecli/updatecli.d/update-hauler-manifest.yaml
+++ b/updatecli/updatecli.d/update-hauler-manifest.yaml
@@ -151,8 +151,8 @@ actions:
         > REMEMBER USING SQUASH MERGE FOR THIS PR
 
         ## Update Checklist
-        - [ ] I have checked that the kubewarden-defaults values `recommendedPolicies.*.settings` are up to date
-        - [ ] I have updated charts/kubewarden-defaults/questions.yaml from those of the policies
+        - [ ] I have checked that the admission-controller values `recommendedPolicies.*.settings` are up to date
+        - [ ] I have updated charts/admission-controller/questions.yaml from those of the policies
       #     {{ if .pr.reviewrs }}
       reviewers:
         #           {{ range .pr.reviewers }}

--- a/updatecli/updatecli.release.d/open-release-pr.yaml
+++ b/updatecli/updatecli.release.d/open-release-pr.yaml
@@ -1,4 +1,4 @@
-name: Update admission-controller chart versions
+name: Update admission-controller chart version
 pipelineid: "{{ .pipelineid }}"
 
 # This updatecli pipeline receives as input a RELEASE_VERSION env var with the
@@ -29,28 +29,12 @@ sources:
         kind: latest
 
   controllerChartVersion:
-    name: "Get latest kubewarden-controller helm version"
+    name: "Get latest admission-controller helm version"
     kind: yaml
     transformers:
       - semverinc: minor
     spec:
       file: charts/admission-controller/Chart.yaml
-      key: $.version
-  crdsChartVersion:
-    name: "Get latest kubewarden-crds helm version"
-    kind: yaml
-    transformers:
-      - semverinc: minor
-    spec:
-      file: charts/kubewarden-crds/Chart.yaml
-      key: $.version
-  defaultsChartVersion:
-    name: "Get latest kubewarden-defaults helm version"
-    kind: yaml
-    transformers:
-      - semverinc: minor
-    spec:
-      file: charts/kubewarden-defaults/Chart.yaml
       key: $.version
   readmeFile:
     kind: file
@@ -58,33 +42,19 @@ sources:
       file: "./README.md"
 
 conditions:
-  kubewardenCrdsChartPosition:
+  admissionControllerChartPosition:
     kind: yaml
     disablesourceinput: true
     spec:
       file: "./charts/hauler_manifest.yaml"
       key: "$.spec.charts[0].name"
-      value: "kubewarden-crds"
-  kubewardenControllerChartPosition:
-    kind: yaml
-    disablesourceinput: true
-    spec:
-      file: "./charts/hauler_manifest.yaml"
-      key: "$.spec.charts[1].name"
       value: "admission-controller"
-  kubewardenDefaultsChartPosition:
-    kind: yaml
-    disablesourceinput: true
-    spec:
-      file: "./charts/hauler_manifest.yaml"
-      key: "$.spec.charts[2].name"
-      value: "kubewarden-defaults"
 
 targets:
-  hauler_manifest_update_kubewarden_crds_chart:
-    name: "Update kubewarden-crds Helm chart version in Hauler manifest"
+  hauler_manifest_update_admission_controller_chart:
+    name: "Update admission-controller Helm chart version in Hauler manifest"
     kind: yaml
-    sourceid: crdsChartVersion
+    sourceid: controllerChartVersion
     scmid: "default"
     spec:
       file: "charts/hauler_manifest.yaml"
@@ -92,97 +62,25 @@ targets:
       # have the condition to ensure the script is not updating the wrong helm
       # chart
       key: "$.spec.charts[0].version"
-  hauler_manifest_update_kubewarden_controller_chart:
-    name: "Update kubewarden-controller Helm chart version in Hauler manifest"
-    kind: yaml
-    sourceid: controllerChartVersion
-    scmid: "default"
-    spec:
-      file: "charts/hauler_manifest.yaml"
-      # Yamlpath to filter the helm chart by name did not work. That's why we
-      # have the condition to ensure the script is not updating the wrong helm
-      # chart
-      key: "$.spec.charts[1].version"
-  hauler_manifest_update_kubewarden_defaults_chart:
-    name: "Update kubewarden-defaults Helm chart version in Hauler manifest"
-    kind: yaml
-    sourceid: "defaultsChartVersion"
-    scmid: "default"
-    spec:
-      file: "charts/hauler_manifest.yaml"
-      # Yamlpath to filter the helm chart by name did not work. That's why we
-      # have the condition to ensure the script is not updating the wrong helm
-      # chart
-      key: "$.spec.charts[2].version"
-  update_kubewarden_crds_helm_version:
+  update_admission_controller_helm_version:
     scmid: default
-    name: Update Helm chart kubewarden-crds version
-    kind: yaml
-    sourceid: crdsChartVersion
-    spec:
-      file: charts/kubewarden-crds/Chart.yaml
-      key: $.version
-  update_kubewarden_crds_helm_appversion:
-    scmid: default
-    name: Update Helm chart kubewarden-crds appVersion
-    kind: yaml
-    sourceid: desiredReleaseVersion
-    spec:
-      file: charts/kubewarden-crds/Chart.yaml
-      key: $.appVersion
-  update_kubewarden_controller_helm_version:
-    scmid: default
-    name: Update Helm chart kubewarden-controller version
+    name: Update Helm chart admission-controller version
     kind: yaml
     sourceid: controllerChartVersion
     spec:
       file: charts/admission-controller/Chart.yaml
       key: $.version
-  update_kubewarden_controller_helm_appversion:
+  update_admission_controller_helm_appversion:
     scmid: default
-    name: Update Helm chart kubewarden-controller appVersion
+    name: Update Helm chart admission-controller appVersion
     kind: yaml
     sourceid: desiredReleaseVersion
     spec:
       file: charts/admission-controller/Chart.yaml
       key: $.appVersion
-  update_kubewarden_controller_auto_install_annotation:
-    name: "Update kubewarden-controller auto-install annotation"
-    kind: yaml
-    sourceid: crdsChartVersion
-    scmid: "default"
-    spec:
-      file: "file://charts/admission-controller/Chart.yaml"
-      key: 'annotations.catalog\.cattle\.io/auto-install'
-      value: 'kubewarden-crds={{ source "crdsChartVersion" }}'
-  update_kubewarden_defaults_helm_version:
-    scmid: default
-    name: Update Helm chart kubewarden-defaults version
-    kind: yaml
-    sourceid: defaultsChartVersion
-    spec:
-      file: charts/kubewarden-defaults/Chart.yaml
-      key: $.version
-  update_kubewarden_defaults_helm_appversion:
-    scmid: default
-    name: Update Helm chart kubewarden-defaults appVersion
-    kind: yaml
-    sourceid: desiredReleaseVersion
-    spec:
-      file: charts/kubewarden-defaults/Chart.yaml
-      key: $.appVersion
-  update_kubewarden_defaults_auto_install_annotation:
-    name: "Update kubewarden-defaults auto-install annotation"
-    kind: yaml
-    sourceid: crdsChartVersion
-    scmid: "default"
-    spec:
-      file: "file://charts/kubewarden-defaults/Chart.yaml"
-      key: 'annotations.catalog\.cattle\.io/auto-install'
-      value: 'kubewarden-crds={{ source "crdsChartVersion" }}'
   update_controller_image_tag:
     scmid: default
-    name: Update Helm chart kubewarden-controller image tag
+    name: Update Helm chart admission-controller image tag
     kind: yaml
     sourceid: desiredReleaseVersion
     spec:
@@ -202,11 +100,11 @@ targets:
     kind: yaml
     sourceid: desiredReleaseVersion
     spec:
-      file: charts/kubewarden-defaults/values.yaml
+      file: charts/admission-controller/values.yaml
       key: $.policyServer.image.tag
   update_readme:
     scmid: default
-    name: Update Helm chart kubewarden-controller README
+    name: Update Helm chart admission-controller README
     kind: file
     sourceid: readmeFile
     spec:

--- a/updatecli/values/artifacts.yaml
+++ b/updatecli/values/artifacts.yaml
@@ -21,29 +21,29 @@ ociArtifacts:
     image: "ghcr.io/kubewarden/adm-controller/audit-scanner"
     workflowUrl: "https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags"
     skipVersionFromRegistry: true
-  - file: "charts/kubewarden-defaults/values.yaml"
+  - file: "charts/admission-controller/values.yaml"
     key: "$.policyServer.image.tag"
     image: "ghcr.io/kubewarden/adm-controller/policy-server"
     workflowUrl: "https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags"
     skipVersionFromRegistry: true
   # Policies
   - image: ghcr.io/kubewarden/policies/allow-privilege-escalation-psp
-    file: "charts/kubewarden-defaults/values.yaml"
+    file: "charts/admission-controller/values.yaml"
     key: "$.recommendedPolicies.allowPrivilegeEscalationPolicy.module.tag"
   - image: ghcr.io/kubewarden/policies/host-namespaces-psp
-    file: "charts/kubewarden-defaults/values.yaml"
+    file: "charts/admission-controller/values.yaml"
     key: "$.recommendedPolicies.hostNamespacePolicy.module.tag"
   - image: ghcr.io/kubewarden/policies/pod-privileged
-    file: "charts/kubewarden-defaults/values.yaml"
+    file: "charts/admission-controller/values.yaml"
     key: "$.recommendedPolicies.podPrivilegedPolicy.module.tag"
   - image: ghcr.io/kubewarden/policies/user-group-psp
-    file: "charts/kubewarden-defaults/values.yaml"
+    file: "charts/admission-controller/values.yaml"
     key: "$.recommendedPolicies.userGroupPolicy.module.tag"
   - image: ghcr.io/kubewarden/policies/hostpaths-psp
-    file: "charts/kubewarden-defaults/values.yaml"
+    file: "charts/admission-controller/values.yaml"
     key: "$.recommendedPolicies.hostPathsPolicy.module.tag"
   - image: ghcr.io/kubewarden/policies/capabilities-psp
-    file: "charts/kubewarden-defaults/values.yaml"
+    file: "charts/admission-controller/values.yaml"
     key: "$.recommendedPolicies.capabilitiesPolicy.module.tag"
   # Third party dependencies
   - image: ghcr.io/rancher/kuberlr-kubectl
@@ -53,18 +53,12 @@ ociArtifacts:
 # updated regularly. This list should be in the same order as defined in the
 # charts/hauler_manifest.yaml file.
 helmCharts:
-  - name: kubewarden-crds
-    file: "charts/kubewarden-crds/Chart.yaml"
-    versionKey: "$.version"
   - name: admission-controller
     file: "charts/admission-controller/Chart.yaml"
     versionKey: "$.version"
-  - name: kubewarden-defaults
-    file: "charts/kubewarden-defaults/Chart.yaml"
-    versionKey: "$.version"
   - name: policy-reporter
     file: "charts/admission-controller/Chart.yaml"
-    versionKey: "$.dependencies[0].version"
+    versionKey: "$.dependencies[1].version"
     repository: https://kyverno.github.io/policy-reporter
   - name: openreports
     file: "charts/kubewarden-crds/Chart.yaml"
@@ -83,7 +77,7 @@ kubewardenContainerImage:
     image: "ghcr.io/kubewarden/adm-controller/audit-scanner"
     workflowUrl: "https://github.com/kubewarden/audit-scanner/.github/workflows/release.yml@refs/tags"
   - name: "policyServer"
-    file: "charts/kubewarden-defaults/values.yaml"
+    file: "charts/admission-controller/values.yaml"
     key: "$.policyServer.image.tag"
     image: "ghcr.io/kubewarden/adm-controller/policy-server"
     workflowUrl: "https://github.com/kubewarden/policy-server/.github/workflows/release.yml@refs/tags"


### PR DESCRIPTION
## Description

Updates the updatecli pipelines used to trigger the PR to start the release process. Removes all the references to the old Helm charts and updates the configuration pointing to the new single Helm chart

Related to https://github.com/kubewarden/adm-controller/issues/1830