### PR TITLE
fix(audit-scanner): delete stale reports by write-set, not label selector

### DIFF
--- a/charts/admission-controller/templates/controller/audit-scanner-role.yaml
+++ b/charts/admission-controller/templates/controller/audit-scanner-role.yaml
@@ -33,6 +33,7 @@ rules:
     - clusterpolicyreports
   verbs:
     - create
+    - delete
     - deletecollection
     - get
     - list
@@ -46,6 +47,7 @@ rules:
     - clusterreports
   verbs:
     - create
+    - delete
     - deletecollection
     - get
     - list

--- a/internal/audit-scanner/report/legacy_migration.go
+++ b/internal/audit-scanner/report/legacy_migration.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/google/uuid"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -18,21 +16,16 @@ import (
 //
 // This is called once per scan when scans save openreports.
 //
-// The deletion is performed with existing functions that do performant
-// deletecollection api calls.
+// The deletion is performed with a single deletecollection api call per kind,
+// which is cheap and free of read-after-write races: every kubewarden-managed
+// legacy report is deleted unconditionally, so there is no risk of removing a
+// report that was just written by the current scan (openreports are a different
+// kind and are never matched here).
 //
 // For reducing cost in subsequent runs, it checks for the existence of legacy
 // wgpolicyk8s.io reports before attempting deletion: in clusters with many
 // namespaces the cost after the first migration is just two cheap List calls.
 func DeleteAllLegacyPolicyReports(ctx context.Context, c client.Client, logger *slog.Logger) error {
-	// The store.DeleteOldReports() functions that we are reusing delete stale
-	// reports prior to saving a new scan. They do this by using a scanRunID.
-	// Here, a fresh UUID is used as the scanRunID: since no existing report will carry
-	// this UID, the "run-uid != <id>" selector matches all of them, effectively
-	// deleting every kubewarden-managed report.
-	ephemeralRunUID := uuid.New().String()
-	store := NewPolicyReportStore(c, logger)
-
 	labelSelector, err := labels.Parse(fmt.Sprintf("%s=%s", labelAppManagedBy, labelApp))
 	if err != nil {
 		return fmt.Errorf("failed to parse label selector: %w", err)
@@ -50,8 +43,10 @@ func DeleteAllLegacyPolicyReports(ctx context.Context, c client.Client, logger *
 		return fmt.Errorf("failed to list legacy ClusterPolicyReports: %w", err)
 	case len(clusterReportList.Items) > 0:
 		logger.InfoContext(ctx, "Deleting legacy wgpolicyk8s.io ClusterPolicyReports")
-		if err = store.DeleteOldClusterReports(ctx, ephemeralRunUID); err != nil {
-			return err
+		if err = c.DeleteAllOf(ctx, &wgpolicy.ClusterPolicyReport{}, &client.DeleteAllOfOptions{
+			ListOptions: client.ListOptions{LabelSelector: labelSelector},
+		}); err != nil {
+			return fmt.Errorf("failed to delete legacy ClusterPolicyReports: %w", err)
 		}
 	}
 
@@ -63,16 +58,11 @@ func DeleteAllLegacyPolicyReports(ctx context.Context, c client.Client, logger *
 	case err != nil:
 		return fmt.Errorf("failed to list legacy PolicyReports: %w", err)
 	case len(policyReportList.Items) > 0:
-		namespaceList := &corev1.NamespaceList{}
-		if err = c.List(ctx, namespaceList); err != nil {
-			return fmt.Errorf("failed to list namespaces: %w", err)
-		}
-		for _, ns := range namespaceList.Items {
-			logger.InfoContext(ctx, "Deleting legacy wgpolicyk8s.io PolicyReports",
-				slog.String("namespace", ns.Name))
-			if err = store.DeleteOldReports(ctx, ephemeralRunUID, ns.Name); err != nil {
-				return err
-			}
+		logger.InfoContext(ctx, "Deleting legacy wgpolicyk8s.io PolicyReports")
+		if err = c.DeleteAllOf(ctx, &wgpolicy.PolicyReport{}, &client.DeleteAllOfOptions{
+			ListOptions: client.ListOptions{LabelSelector: labelSelector},
+		}); err != nil {
+			return fmt.Errorf("failed to delete legacy PolicyReports: %w", err)
 		}
 	}
 

--- a/internal/audit-scanner/report/legacy_migration.go
+++ b/internal/audit-scanner/report/legacy_migration.go
@@ -6,8 +6,11 @@ import (
 	"log/slog"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	wgpolicy "sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
 )
 
@@ -16,26 +19,33 @@ import (
 //
 // This is called once per scan when scans save openreports.
 //
-// The deletion is performed with a single deletecollection api call per kind,
-// which is cheap and free of read-after-write races: every kubewarden-managed
-// legacy report is deleted unconditionally, so there is no risk of removing a
-// report that was just written by the current scan (openreports are a different
-// kind and are never matched here).
+// ClusterPolicyReport is cluster-scoped, so it is deleted with a single
+// deletecollection call, free of read-after-write races: every
+// kubewarden-managed legacy cluster report is deleted unconditionally, so
+// there is no risk of removing a report that was just written by the current
+// scan (openreports are a different kind and are never matched here).
+//
+// PolicyReport is namespaced, and the Kubernetes API only exposes
+// deletecollection on the namespaced route: there is no way to delete a
+// namespaced kind across every namespace with a single call. So namespaces
+// that actually hold legacy reports are discovered first with a metadata-only
+// List across all namespaces, and one deletecollection call is issued per
+// affected namespace.
 //
 // For reducing cost in subsequent runs, it checks for the existence of legacy
 // wgpolicyk8s.io reports before attempting deletion: in clusters with many
 // namespaces the cost after the first migration is just two cheap List calls.
 func DeleteAllLegacyPolicyReports(ctx context.Context, c client.Client, logger *slog.Logger) error {
-	labelSelector, err := labels.Parse(fmt.Sprintf("%s=%s", labelAppManagedBy, labelApp))
+	labelSelector, err := managedByKubewardenSelector()
 	if err != nil {
-		return fmt.Errorf("failed to parse label selector: %w", err)
+		return err
 	}
 	// After first migration, we will perform 2 list calls, one for
 	// ClusterPolicyReport, another for PolicyReport, both with limit=1.
-	listOpts := &client.ListOptions{LabelSelector: labelSelector, Limit: 1}
+	probeOpts := &client.ListOptions{LabelSelector: labelSelector, Limit: 1}
 
 	clusterReportList := &wgpolicy.ClusterPolicyReportList{}
-	err = c.List(ctx, clusterReportList, listOpts)
+	err = c.List(ctx, clusterReportList, probeOpts)
 	switch {
 	case meta.IsNoMatchError(err):
 		logger.DebugContext(ctx, "wgpolicyk8s.io CRDs not installed, skipping legacy clusterreport cleanup")
@@ -43,28 +53,63 @@ func DeleteAllLegacyPolicyReports(ctx context.Context, c client.Client, logger *
 		return fmt.Errorf("failed to list legacy ClusterPolicyReports: %w", err)
 	case len(clusterReportList.Items) > 0:
 		logger.InfoContext(ctx, "Deleting legacy wgpolicyk8s.io ClusterPolicyReports")
-		if err = c.DeleteAllOf(ctx, &wgpolicy.ClusterPolicyReport{}, &client.DeleteAllOfOptions{
+		if deleteErr := c.DeleteAllOf(ctx, &wgpolicy.ClusterPolicyReport{}, &client.DeleteAllOfOptions{
 			ListOptions: client.ListOptions{LabelSelector: labelSelector},
-		}); err != nil {
-			return fmt.Errorf("failed to delete legacy ClusterPolicyReports: %w", err)
+		}); deleteErr != nil {
+			return fmt.Errorf("failed to delete legacy ClusterPolicyReports: %w", deleteErr)
 		}
 	}
 
-	policyReportList := &wgpolicy.PolicyReportList{}
-	err = c.List(ctx, policyReportList, listOpts)
+	policyReportProbe := &wgpolicy.PolicyReportList{}
+	err = c.List(ctx, policyReportProbe, probeOpts)
 	switch {
 	case meta.IsNoMatchError(err):
 		logger.DebugContext(ctx, "wgpolicyk8s.io CRDs not installed, skipping legacy report cleanup")
+		return nil
 	case err != nil:
 		return fmt.Errorf("failed to list legacy PolicyReports: %w", err)
-	case len(policyReportList.Items) > 0:
-		logger.InfoContext(ctx, "Deleting legacy wgpolicyk8s.io PolicyReports")
-		if err = c.DeleteAllOf(ctx, &wgpolicy.PolicyReport{}, &client.DeleteAllOfOptions{
-			ListOptions: client.ListOptions{LabelSelector: labelSelector},
-		}); err != nil {
-			return fmt.Errorf("failed to delete legacy PolicyReports: %w", err)
+	case len(policyReportProbe.Items) == 0:
+		return nil
+	}
+
+	namespaces, err := legacyPolicyReportNamespaces(ctx, c, labelSelector)
+	if err != nil {
+		return fmt.Errorf("failed to list legacy PolicyReport namespaces: %w", err)
+	}
+
+	for ns := range namespaces {
+		logger.InfoContext(ctx, "Deleting legacy wgpolicyk8s.io PolicyReports", slog.String("namespace", ns))
+		if deleteErr := c.DeleteAllOf(ctx, &wgpolicy.PolicyReport{}, &client.DeleteAllOfOptions{
+			ListOptions: client.ListOptions{LabelSelector: labelSelector, Namespace: ns},
+		}); deleteErr != nil {
+			return fmt.Errorf("failed to delete legacy PolicyReports in namespace %s: %w", ns, deleteErr)
 		}
 	}
 
 	return nil
+}
+
+// legacyPolicyReportNamespaces returns the set of namespaces holding at least
+// one kubewarden-managed legacy PolicyReport. The list only fetches object
+// metadata (name/namespace), since that's all that's needed to determine which
+// namespaces to target with deletecollection.
+func legacyPolicyReportNamespaces(ctx context.Context, c client.Client, labelSelector labels.Selector) (sets.Set[string], error) {
+	gvk, err := apiutil.GVKForObject(&wgpolicy.PolicyReport{}, c.Scheme())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get GroupVersionKind for PolicyReport: %w", err)
+	}
+	listGVK := gvk
+	listGVK.Kind += "List"
+
+	list := &metav1.PartialObjectMetadataList{}
+	list.SetGroupVersionKind(listGVK)
+	if listErr := c.List(ctx, list, &client.ListOptions{LabelSelector: labelSelector}); listErr != nil {
+		return nil, fmt.Errorf("failed to list PolicyReports: %w", listErr)
+	}
+
+	namespaces := sets.New[string]()
+	for i := range list.Items {
+		namespaces.Insert(list.Items[i].GetNamespace())
+	}
+	return namespaces, nil
 }

--- a/internal/audit-scanner/report/legacy_migration_test.go
+++ b/internal/audit-scanner/report/legacy_migration_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	wgpolicy "sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
 )
@@ -16,7 +17,12 @@ func TestDeleteAllLegacyPolicyReports(t *testing.T) {
 	nsDefault := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
 	nsOther := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "other"}}
 
-	// kubewarden-managed reports in two namespaces should be deleted
+	// kubewarden-managed reports in two namespaces should be deleted. Note:
+	// the fake client does not enforce the real API server's rule that
+	// deletecollection for a namespaced kind must target a single namespace,
+	// so this test cannot by itself catch a regression back to a single
+	// cross-namespace DeleteAllOf call; see TestLegacyPolicyReportNamespaces
+	// for a direct test of the namespace-discovery step that avoids that.
 	managedDefault := testutils.NewPolicyReportFactory().
 		Name("managed-default").Namespace("default").RunUID("old-uid").WithAppLabel().Build()
 	managedOther := testutils.NewPolicyReportFactory().
@@ -55,4 +61,29 @@ func TestDeleteAllLegacyPolicyReports(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, clusterReportList.Items, 1)
 	require.Equal(t, "unmanaged-cluster", clusterReportList.Items[0].Name)
+}
+
+// TestLegacyPolicyReportNamespaces directly tests the namespace-discovery step
+// used by DeleteAllLegacyPolicyReports to work around the fact that
+// deletecollection for a namespaced kind (PolicyReport) cannot be issued
+// across every namespace with a single call: it must return exactly the
+// distinct namespaces holding at least one kubewarden-managed legacy report,
+// ignoring unmanaged reports.
+func TestLegacyPolicyReportNamespaces(t *testing.T) {
+	managedDefault := testutils.NewPolicyReportFactory().
+		Name("managed-default").Namespace("default").WithAppLabel().Build()
+	managedOther := testutils.NewPolicyReportFactory().
+		Name("managed-other").Namespace("other").WithAppLabel().Build()
+	unmanagedThird := testutils.NewPolicyReportFactory().
+		Name("unmanaged-third").Namespace("third").Build()
+
+	fakeClient, err := testutils.NewFakeClient(managedDefault, managedOther, unmanagedThird)
+	require.NoError(t, err)
+
+	labelSelector, err := managedByKubewardenSelector()
+	require.NoError(t, err)
+
+	namespaces, err := legacyPolicyReportNamespaces(t.Context(), fakeClient, labelSelector)
+	require.NoError(t, err)
+	require.Equal(t, sets.New("default", "other"), namespaces)
 }

--- a/internal/audit-scanner/report/openreports_store.go
+++ b/internal/audit-scanner/report/openreports_store.go
@@ -81,6 +81,14 @@ func (s *OpenReportStore) DeleteOldReports(ctx context.Context, keptReports sets
 	}, keptReports)
 }
 
+// DeleteAllReports deletes, in a single deletecollection call, all the
+// kubewarden-managed OpenReports Reports in the given namespace. Must only be
+// called when the current scan run wrote no reports in this namespace.
+func (s *OpenReportStore) DeleteAllReports(ctx context.Context, namespace string) error {
+	s.logger.DebugContext(ctx, "Deleting all managed Reports", slog.String("namespace", namespace))
+	return deleteAllManagedReports(ctx, s.client, &openreports.Report{}, namespace)
+}
+
 // CreateOrPatchClusterReport creates or patches a OpenReports ClusterReport.
 //
 //nolint:dupl // Temporary duplicated code with policyreports_store.go, it's planned to be the only implementation in the future.
@@ -131,4 +139,12 @@ func (s *OpenReportStore) DeleteOldClusterReports(ctx context.Context, keptRepor
 	return deleteReportsNotInSet(ctx, s.client, s.logger, &openreports.ClusterReport{}, &client.ListOptions{
 		LabelSelector: labelSelector,
 	}, keptReports)
+}
+
+// DeleteAllClusterReports deletes, in a single deletecollection call, all the
+// kubewarden-managed OpenReports ClusterReports. Must only be called when the
+// current scan run wrote no cluster reports.
+func (s *OpenReportStore) DeleteAllClusterReports(ctx context.Context) error {
+	s.logger.DebugContext(ctx, "Deleting all managed ClusterReports")
+	return deleteAllManagedReports(ctx, s.client, &openreports.ClusterReport{}, "")
 }

--- a/internal/audit-scanner/report/openreports_store.go
+++ b/internal/audit-scanner/report/openreports_store.go
@@ -75,7 +75,7 @@ func (s *OpenReportStore) DeleteOldReports(ctx context.Context, keptReports sets
 		slog.String("namespace", namespace),
 		slog.Int("kept-reports", keptReports.Len()))
 
-	return deleteReportsNotInSet(ctx, s.client, s.logger, &openreports.ReportList{}, &client.ListOptions{
+	return deleteReportsNotInSet(ctx, s.client, s.logger, &openreports.Report{}, &client.ListOptions{
 		LabelSelector: labelSelector,
 		Namespace:     namespace,
 	}, keptReports)
@@ -128,7 +128,7 @@ func (s *OpenReportStore) DeleteOldClusterReports(ctx context.Context, keptRepor
 	s.logger.DebugContext(ctx, "Deleting old ClusterReports",
 		slog.Int("kept-reports", keptReports.Len()))
 
-	return deleteReportsNotInSet(ctx, s.client, s.logger, &openreports.ClusterReportList{}, &client.ListOptions{
+	return deleteReportsNotInSet(ctx, s.client, s.logger, &openreports.ClusterReport{}, &client.ListOptions{
 		LabelSelector: labelSelector,
 	}, keptReports)
 }

--- a/internal/audit-scanner/report/openreports_store.go
+++ b/internal/audit-scanner/report/openreports_store.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"log/slog"
 
-	auditConstants "github.com/kubewarden/adm-controller/internal/audit-scanner/constants"
 	openreports "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -64,21 +63,22 @@ func (s *OpenReportStore) CreateOrPatchReport(ctx context.Context, obj any) erro
 	return nil
 }
 
-// DeleteOldReports deletes all the OpenReports Reports that do not belong to the current scan run.
-func (s *OpenReportStore) DeleteOldReports(ctx context.Context, scanRunID, namespace string) error {
-	labelSelector, err := labels.Parse(fmt.Sprintf("%s!=%s,%s=%s", auditConstants.AuditScannerRunUIDLabel, scanRunID, labelAppManagedBy, labelApp))
+// DeleteOldReports deletes all the kubewarden-managed OpenReports Reports in the
+// given namespace whose name is not present in keptReports (the reports created
+// or patched during the current scan run).
+func (s *OpenReportStore) DeleteOldReports(ctx context.Context, keptReports sets.Set[string], namespace string) error {
+	labelSelector, err := managedByKubewardenSelector()
 	if err != nil {
-		return fmt.Errorf("failed to parse label selector: %w", err)
+		return err
 	}
-	s.logger.DebugContext(ctx, "Deleting old PolicyReports", slog.String("labelSelector", labelSelector.String()))
+	s.logger.DebugContext(ctx, "Deleting old Reports",
+		slog.String("namespace", namespace),
+		slog.Int("kept-reports", keptReports.Len()))
 
-	if deleteErr := s.client.DeleteAllOf(ctx, &openreports.Report{}, &client.DeleteAllOfOptions{ListOptions: client.ListOptions{
+	return deleteReportsNotInSet(ctx, s.client, s.logger, &openreports.ReportList{}, &client.ListOptions{
 		LabelSelector: labelSelector,
 		Namespace:     namespace,
-	}}); deleteErr != nil {
-		return fmt.Errorf("failed to delete PolicyReports: %w", deleteErr)
-	}
-	return nil
+	}, keptReports)
 }
 
 // CreateOrPatchClusterReport creates or patches a OpenReports ClusterReport.
@@ -117,18 +117,18 @@ func (s *OpenReportStore) CreateOrPatchClusterReport(ctx context.Context, obj an
 	return nil
 }
 
-// DeleteOldClusterReports deletes all the OpenReports ClusterReports that do not belong to the current scan run.
-func (s *OpenReportStore) DeleteOldClusterReports(ctx context.Context, scanRunID string) error {
-	labelSelector, err := labels.Parse(fmt.Sprintf("%s!=%s,%s=%s", auditConstants.AuditScannerRunUIDLabel, scanRunID, labelAppManagedBy, labelApp))
+// DeleteOldClusterReports deletes all the kubewarden-managed OpenReports
+// ClusterReports whose name is not present in keptReports (the reports created
+// or patched during the current scan run).
+func (s *OpenReportStore) DeleteOldClusterReports(ctx context.Context, keptReports sets.Set[string]) error {
+	labelSelector, err := managedByKubewardenSelector()
 	if err != nil {
-		return fmt.Errorf("failed to parse label selector: %w", err)
+		return err
 	}
-	s.logger.DebugContext(ctx, "Deleting old ClusterPolicyReports", slog.String("labelSelector", labelSelector.String()))
+	s.logger.DebugContext(ctx, "Deleting old ClusterReports",
+		slog.Int("kept-reports", keptReports.Len()))
 
-	if deleteErr := s.client.DeleteAllOf(ctx, &openreports.ClusterReport{}, &client.DeleteAllOfOptions{ListOptions: client.ListOptions{
+	return deleteReportsNotInSet(ctx, s.client, s.logger, &openreports.ClusterReportList{}, &client.ListOptions{
 		LabelSelector: labelSelector,
-	}}); deleteErr != nil {
-		return fmt.Errorf("failed to delete ClusterPolicyReports: %w", deleteErr)
-	}
-	return nil
+	}, keptReports)
 }

--- a/internal/audit-scanner/report/openreports_store_test.go
+++ b/internal/audit-scanner/report/openreports_store_test.go
@@ -10,10 +10,12 @@ import (
 	openreports "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
 	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admission/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubewarden/adm-controller/internal/audit-scanner/testutils"
@@ -191,7 +193,7 @@ func TestDeleteReport(t *testing.T) {
 	logger := slog.Default()
 	store := NewOpenReportStore(fakeClient, logger)
 
-	err = store.DeleteOldReports(t.Context(), "new-uid", "default")
+	err = store.DeleteOldReports(t.Context(), sets.New("new-report"), "default")
 	require.NoError(t, err)
 
 	storedPolicyReportList := &openreports.ReportList{}
@@ -226,7 +228,7 @@ func TestDeleteClusterReport(t *testing.T) {
 	logger := slog.Default()
 	store := NewOpenReportStore(fakeClient, logger)
 
-	err = store.DeleteOldClusterReports(t.Context(), "new-uid")
+	err = store.DeleteOldClusterReports(t.Context(), sets.New("new-report"))
 	require.NoError(t, err)
 
 	storedPolicyReportList := &openreports.ClusterReportList{}
@@ -245,4 +247,57 @@ func TestDeleteClusterReport(t *testing.T) {
 	err = fakeClient.List(t.Context(), storedPolicyReportList, &client.ListOptions{LabelSelector: labelSelector})
 	require.NoError(t, err)
 	require.Len(t, storedPolicyReportList.Items, 1)
+}
+
+// TestDeleteOldReportsKeepsReportWrittenThisRunWithStaleLabel is a regression
+// test for the read-after-write race where a Report that was patched during the
+// current run could still be deleted because the garbage collection relied on
+// the run-uid label, whose new value may not yet be visible when the delete
+// runs. Deletion is now driven by the set of report names written this run, so a
+// kept report survives even if its run-uid label still shows a previous run.
+func TestDeleteOldReportsKeepsReportWrittenThisRunWithStaleLabel(t *testing.T) {
+	// "kept-report" is in the write-set but still carries a stale run-uid label,
+	// simulating a patch whose new label is not yet observable by the delete.
+	keptWithStaleLabel := testutils.NewPolicyReportFactory().
+		Name("kept-report").Namespace("default").RunUID("stale-uid").WithAppLabel().BuildOpenReports()
+	// "stale-report" is managed but was NOT written this run, so it must be deleted.
+	staleReport := testutils.NewPolicyReportFactory().
+		Name("stale-report").Namespace("default").RunUID("stale-uid").WithAppLabel().BuildOpenReports()
+
+	fakeClient, err := testutils.NewFakeClient(keptWithStaleLabel, staleReport)
+	require.NoError(t, err)
+	store := NewOpenReportStore(fakeClient, slog.Default())
+
+	err = store.DeleteOldReports(t.Context(), sets.New("kept-report"), "default")
+	require.NoError(t, err)
+
+	// kept-report must survive despite its stale run-uid label.
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "kept-report", Namespace: "default"}, &openreports.Report{})
+	require.NoError(t, err)
+
+	// stale-report must be deleted.
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "stale-report", Namespace: "default"}, &openreports.Report{})
+	require.True(t, apierrors.IsNotFound(err))
+}
+
+// TestDeleteOldClusterReportsKeepsReportWrittenThisRunWithStaleLabel is the
+// cluster-scoped counterpart of the regression test above.
+func TestDeleteOldClusterReportsKeepsReportWrittenThisRunWithStaleLabel(t *testing.T) {
+	keptWithStaleLabel := testutils.NewClusterPolicyReportFactory().
+		Name("kept-report").RunUID("stale-uid").WithAppLabel().BuildOpenReports()
+	staleReport := testutils.NewClusterPolicyReportFactory().
+		Name("stale-report").RunUID("stale-uid").WithAppLabel().BuildOpenReports()
+
+	fakeClient, err := testutils.NewFakeClient(keptWithStaleLabel, staleReport)
+	require.NoError(t, err)
+	store := NewOpenReportStore(fakeClient, slog.Default())
+
+	err = store.DeleteOldClusterReports(t.Context(), sets.New("kept-report"))
+	require.NoError(t, err)
+
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "kept-report"}, &openreports.ClusterReport{})
+	require.NoError(t, err)
+
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "stale-report"}, &openreports.ClusterReport{})
+	require.True(t, apierrors.IsNotFound(err))
 }

--- a/internal/audit-scanner/report/openreports_store_test.go
+++ b/internal/audit-scanner/report/openreports_store_test.go
@@ -301,3 +301,54 @@ func TestDeleteOldClusterReportsKeepsReportWrittenThisRunWithStaleLabel(t *testi
 	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "stale-report"}, &openreports.ClusterReport{})
 	require.True(t, apierrors.IsNotFound(err))
 }
+
+// TestDeleteAllReports covers the bulk-delete fast path, used when the scan
+// wrote no reports in a namespace (e.g. no auditable policies target it): all
+// kubewarden-managed reports in that namespace are deleted unconditionally,
+// while unmanaged reports and reports in other namespaces are preserved.
+func TestDeleteAllReports(t *testing.T) {
+	managedDefault := testutils.NewPolicyReportFactory().
+		Name("managed-default").Namespace("default").WithAppLabel().BuildOpenReports()
+	unmanagedDefault := testutils.NewPolicyReportFactory().
+		Name("unmanaged-default").Namespace("default").BuildOpenReports()
+	managedOther := testutils.NewPolicyReportFactory().
+		Name("managed-other").Namespace("other").WithAppLabel().BuildOpenReports()
+
+	fakeClient, err := testutils.NewFakeClient(managedDefault, unmanagedDefault, managedOther)
+	require.NoError(t, err)
+	store := NewOpenReportStore(fakeClient, slog.Default())
+
+	err = store.DeleteAllReports(t.Context(), "default")
+	require.NoError(t, err)
+
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "managed-default", Namespace: "default"}, &openreports.Report{})
+	require.True(t, apierrors.IsNotFound(err))
+
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "unmanaged-default", Namespace: "default"}, &openreports.Report{})
+	require.NoError(t, err)
+
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "managed-other", Namespace: "other"}, &openreports.Report{})
+	require.NoError(t, err)
+}
+
+// TestDeleteAllClusterReports is the cluster-scoped counterpart of
+// TestDeleteAllReports.
+func TestDeleteAllClusterReports(t *testing.T) {
+	managed := testutils.NewClusterPolicyReportFactory().
+		Name("managed").WithAppLabel().BuildOpenReports()
+	unmanaged := testutils.NewClusterPolicyReportFactory().
+		Name("unmanaged").BuildOpenReports()
+
+	fakeClient, err := testutils.NewFakeClient(managed, unmanaged)
+	require.NoError(t, err)
+	store := NewOpenReportStore(fakeClient, slog.Default())
+
+	err = store.DeleteAllClusterReports(t.Context())
+	require.NoError(t, err)
+
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "managed"}, &openreports.ClusterReport{})
+	require.True(t, apierrors.IsNotFound(err))
+
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "unmanaged"}, &openreports.ClusterReport{})
+	require.NoError(t, err)
+}

--- a/internal/audit-scanner/report/policyreports_store.go
+++ b/internal/audit-scanner/report/policyreports_store.go
@@ -83,6 +83,14 @@ func (s *PolicyReportStore) DeleteOldReports(ctx context.Context, keptReports se
 	}, keptReports)
 }
 
+// DeleteAllReports deletes, in a single deletecollection call, all the
+// kubewarden-managed PolicyReports in the given namespace. Must only be
+// called when the current scan run wrote no reports in this namespace.
+func (s *PolicyReportStore) DeleteAllReports(ctx context.Context, namespace string) error {
+	s.logger.DebugContext(ctx, "Deleting all managed PolicyReports", slog.String("namespace", namespace))
+	return deleteAllManagedReports(ctx, s.client, &wgpolicy.PolicyReport{}, namespace)
+}
+
 // CreateOrPatchClusterReport creates or patches a ClusterPolicyReport.
 //
 //nolint:dupl // Temporary duplicated code with openreports_store.go, it's planned to be removed in the near future.
@@ -133,4 +141,12 @@ func (s *PolicyReportStore) DeleteOldClusterReports(ctx context.Context, keptRep
 	return deleteReportsNotInSet(ctx, s.client, s.logger, &wgpolicy.ClusterPolicyReport{}, &client.ListOptions{
 		LabelSelector: labelSelector,
 	}, keptReports)
+}
+
+// DeleteAllClusterReports deletes, in a single deletecollection call, all the
+// kubewarden-managed ClusterPolicyReports. Must only be called when the
+// current scan run wrote no cluster reports.
+func (s *PolicyReportStore) DeleteAllClusterReports(ctx context.Context) error {
+	s.logger.DebugContext(ctx, "Deleting all managed ClusterPolicyReports")
+	return deleteAllManagedReports(ctx, s.client, &wgpolicy.ClusterPolicyReport{}, "")
 }

--- a/internal/audit-scanner/report/policyreports_store.go
+++ b/internal/audit-scanner/report/policyreports_store.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 
-	auditConstants "github.com/kubewarden/adm-controller/internal/audit-scanner/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	wgpolicy "sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
@@ -66,21 +65,22 @@ func (s *PolicyReportStore) CreateOrPatchReport(ctx context.Context, obj any) er
 	return nil
 }
 
-// DeleteOldReports deletes old PolicyReports that do not match the given scanRunID.
-func (s *PolicyReportStore) DeleteOldReports(ctx context.Context, scanRunID, namespace string) error {
-	labelSelector, err := labels.Parse(fmt.Sprintf("%s!=%s,%s=%s", auditConstants.AuditScannerRunUIDLabel, scanRunID, labelAppManagedBy, labelApp))
+// DeleteOldReports deletes all the kubewarden-managed PolicyReports in the given
+// namespace whose name is not present in keptReports (the reports created or
+// patched during the current scan run).
+func (s *PolicyReportStore) DeleteOldReports(ctx context.Context, keptReports sets.Set[string], namespace string) error {
+	labelSelector, err := managedByKubewardenSelector()
 	if err != nil {
-		return fmt.Errorf("failed to parse label selector: %w", err)
+		return err
 	}
-	s.logger.DebugContext(ctx, "Deleting old PolicyReports", slog.String("labelSelector", labelSelector.String()))
+	s.logger.DebugContext(ctx, "Deleting old PolicyReports",
+		slog.String("namespace", namespace),
+		slog.Int("kept-reports", keptReports.Len()))
 
-	if deleteErr := s.client.DeleteAllOf(ctx, &wgpolicy.PolicyReport{}, &client.DeleteAllOfOptions{ListOptions: client.ListOptions{
+	return deleteReportsNotInSet(ctx, s.client, s.logger, &wgpolicy.PolicyReportList{}, &client.ListOptions{
 		LabelSelector: labelSelector,
 		Namespace:     namespace,
-	}}); deleteErr != nil {
-		return fmt.Errorf("failed to delete PolicyReports: %w", deleteErr)
-	}
-	return nil
+	}, keptReports)
 }
 
 // CreateOrPatchClusterReport creates or patches a ClusterPolicyReport.
@@ -119,18 +119,18 @@ func (s *PolicyReportStore) CreateOrPatchClusterReport(ctx context.Context, obj 
 	return nil
 }
 
-// DeleteOldClusterReports deletes old ClusterPolicyReports that do not belong to the current scan run.
-func (s *PolicyReportStore) DeleteOldClusterReports(ctx context.Context, scanRunID string) error {
-	labelSelector, err := labels.Parse(fmt.Sprintf("%s!=%s,%s=%s", auditConstants.AuditScannerRunUIDLabel, scanRunID, labelAppManagedBy, labelApp))
+// DeleteOldClusterReports deletes all the kubewarden-managed ClusterPolicyReports
+// whose name is not present in keptReports (the reports created or patched during
+// the current scan run).
+func (s *PolicyReportStore) DeleteOldClusterReports(ctx context.Context, keptReports sets.Set[string]) error {
+	labelSelector, err := managedByKubewardenSelector()
 	if err != nil {
-		return fmt.Errorf("failed to parse label selector: %w", err)
+		return err
 	}
-	s.logger.DebugContext(ctx, "Deleting old ClusterPolicyReports", slog.String("labelSelector", labelSelector.String()))
+	s.logger.DebugContext(ctx, "Deleting old ClusterPolicyReports",
+		slog.Int("kept-reports", keptReports.Len()))
 
-	if deleteErr := s.client.DeleteAllOf(ctx, &wgpolicy.ClusterPolicyReport{}, &client.DeleteAllOfOptions{ListOptions: client.ListOptions{
+	return deleteReportsNotInSet(ctx, s.client, s.logger, &wgpolicy.ClusterPolicyReportList{}, &client.ListOptions{
 		LabelSelector: labelSelector,
-	}}); deleteErr != nil {
-		return fmt.Errorf("failed to delete ClusterPolicyReports: %w", deleteErr)
-	}
-	return nil
+	}, keptReports)
 }

--- a/internal/audit-scanner/report/policyreports_store.go
+++ b/internal/audit-scanner/report/policyreports_store.go
@@ -77,7 +77,7 @@ func (s *PolicyReportStore) DeleteOldReports(ctx context.Context, keptReports se
 		slog.String("namespace", namespace),
 		slog.Int("kept-reports", keptReports.Len()))
 
-	return deleteReportsNotInSet(ctx, s.client, s.logger, &wgpolicy.PolicyReportList{}, &client.ListOptions{
+	return deleteReportsNotInSet(ctx, s.client, s.logger, &wgpolicy.PolicyReport{}, &client.ListOptions{
 		LabelSelector: labelSelector,
 		Namespace:     namespace,
 	}, keptReports)
@@ -130,7 +130,7 @@ func (s *PolicyReportStore) DeleteOldClusterReports(ctx context.Context, keptRep
 	s.logger.DebugContext(ctx, "Deleting old ClusterPolicyReports",
 		slog.Int("kept-reports", keptReports.Len()))
 
-	return deleteReportsNotInSet(ctx, s.client, s.logger, &wgpolicy.ClusterPolicyReportList{}, &client.ListOptions{
+	return deleteReportsNotInSet(ctx, s.client, s.logger, &wgpolicy.ClusterPolicyReport{}, &client.ListOptions{
 		LabelSelector: labelSelector,
 	}, keptReports)
 }

--- a/internal/audit-scanner/report/policyreports_store_test.go
+++ b/internal/audit-scanner/report/policyreports_store_test.go
@@ -292,3 +292,55 @@ func TestDeleteClusterPolicyReportKeepsReportWrittenThisRunWithStaleLabel(t *tes
 	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "stale-report"}, &wgpolicy.ClusterPolicyReport{})
 	require.True(t, apierrors.IsNotFound(err))
 }
+
+// TestDeleteAllPolicyReports covers the bulk-delete fast path, used when the
+// scan wrote no reports in a namespace (e.g. no auditable policies target it):
+// all kubewarden-managed reports in that namespace are deleted
+// unconditionally, while unmanaged reports and reports in other namespaces are
+// preserved.
+func TestDeleteAllPolicyReports(t *testing.T) {
+	managedDefault := testutils.NewPolicyReportFactory().
+		Name("managed-default").Namespace("default").WithAppLabel().Build()
+	unmanagedDefault := testutils.NewPolicyReportFactory().
+		Name("unmanaged-default").Namespace("default").Build()
+	managedOther := testutils.NewPolicyReportFactory().
+		Name("managed-other").Namespace("other").WithAppLabel().Build()
+
+	fakeClient, err := testutils.NewFakeClient(managedDefault, unmanagedDefault, managedOther)
+	require.NoError(t, err)
+	store := NewPolicyReportStore(fakeClient, slog.Default())
+
+	err = store.DeleteAllReports(t.Context(), "default")
+	require.NoError(t, err)
+
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "managed-default", Namespace: "default"}, &wgpolicy.PolicyReport{})
+	require.True(t, apierrors.IsNotFound(err))
+
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "unmanaged-default", Namespace: "default"}, &wgpolicy.PolicyReport{})
+	require.NoError(t, err)
+
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "managed-other", Namespace: "other"}, &wgpolicy.PolicyReport{})
+	require.NoError(t, err)
+}
+
+// TestDeleteAllClusterPolicyReports is the cluster-scoped counterpart of
+// TestDeleteAllPolicyReports.
+func TestDeleteAllClusterPolicyReports(t *testing.T) {
+	managed := testutils.NewClusterPolicyReportFactory().
+		Name("managed").WithAppLabel().Build()
+	unmanaged := testutils.NewClusterPolicyReportFactory().
+		Name("unmanaged").Build()
+
+	fakeClient, err := testutils.NewFakeClient(managed, unmanaged)
+	require.NoError(t, err)
+	store := NewPolicyReportStore(fakeClient, slog.Default())
+
+	err = store.DeleteAllClusterReports(t.Context())
+	require.NoError(t, err)
+
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "managed"}, &wgpolicy.ClusterPolicyReport{})
+	require.True(t, apierrors.IsNotFound(err))
+
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "unmanaged"}, &wgpolicy.ClusterPolicyReport{})
+	require.NoError(t, err)
+}

--- a/internal/audit-scanner/report/policyreports_store_test.go
+++ b/internal/audit-scanner/report/policyreports_store_test.go
@@ -10,10 +10,12 @@ import (
 	testutils "github.com/kubewarden/adm-controller/internal/audit-scanner/testutils"
 	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admission/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	wgpolicy "sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
 )
@@ -190,7 +192,7 @@ func TestDeletePolicyReport(t *testing.T) {
 	logger := slog.Default()
 	store := NewPolicyReportStore(fakeClient, logger)
 
-	err = store.DeleteOldReports(t.Context(), "new-uid", "default")
+	err = store.DeleteOldReports(t.Context(), sets.New("new-report"), "default")
 	require.NoError(t, err)
 
 	storedPolicyReportList := &wgpolicy.PolicyReportList{}
@@ -225,7 +227,7 @@ func TestDeleteClusterPolicyReport(t *testing.T) {
 	logger := slog.Default()
 	store := NewPolicyReportStore(fakeClient, logger)
 
-	err = store.DeleteOldClusterReports(t.Context(), "new-uid")
+	err = store.DeleteOldClusterReports(t.Context(), sets.New("new-report"))
 	require.NoError(t, err)
 
 	storedPolicyReportList := &wgpolicy.ClusterPolicyReportList{}
@@ -244,4 +246,49 @@ func TestDeleteClusterPolicyReport(t *testing.T) {
 	err = fakeClient.List(t.Context(), storedPolicyReportList, &client.ListOptions{LabelSelector: labelSelector})
 	require.NoError(t, err)
 	require.Len(t, storedPolicyReportList.Items, 1)
+}
+
+// TestDeletePolicyReportKeepsReportWrittenThisRunWithStaleLabel is the regression
+// test for the read-after-write race, for the deprecated wgpolicy PolicyReport
+// store. See the equivalent test in openreports_store_test.go for details.
+func TestDeletePolicyReportKeepsReportWrittenThisRunWithStaleLabel(t *testing.T) {
+	keptWithStaleLabel := testutils.NewPolicyReportFactory().
+		Name("kept-report").Namespace("default").RunUID("stale-uid").WithAppLabel().Build()
+	staleReport := testutils.NewPolicyReportFactory().
+		Name("stale-report").Namespace("default").RunUID("stale-uid").WithAppLabel().Build()
+
+	fakeClient, err := testutils.NewFakeClient(keptWithStaleLabel, staleReport)
+	require.NoError(t, err)
+	store := NewPolicyReportStore(fakeClient, slog.Default())
+
+	err = store.DeleteOldReports(t.Context(), sets.New("kept-report"), "default")
+	require.NoError(t, err)
+
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "kept-report", Namespace: "default"}, &wgpolicy.PolicyReport{})
+	require.NoError(t, err)
+
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "stale-report", Namespace: "default"}, &wgpolicy.PolicyReport{})
+	require.True(t, apierrors.IsNotFound(err))
+}
+
+// TestDeleteClusterPolicyReportKeepsReportWrittenThisRunWithStaleLabel is the
+// cluster-scoped counterpart of the regression test above.
+func TestDeleteClusterPolicyReportKeepsReportWrittenThisRunWithStaleLabel(t *testing.T) {
+	keptWithStaleLabel := testutils.NewClusterPolicyReportFactory().
+		Name("kept-report").RunUID("stale-uid").WithAppLabel().Build()
+	staleReport := testutils.NewClusterPolicyReportFactory().
+		Name("stale-report").RunUID("stale-uid").WithAppLabel().Build()
+
+	fakeClient, err := testutils.NewFakeClient(keptWithStaleLabel, staleReport)
+	require.NoError(t, err)
+	store := NewPolicyReportStore(fakeClient, slog.Default())
+
+	err = store.DeleteOldClusterReports(t.Context(), sets.New("kept-report"))
+	require.NoError(t, err)
+
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "kept-report"}, &wgpolicy.ClusterPolicyReport{})
+	require.NoError(t, err)
+
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Name: "stale-report"}, &wgpolicy.ClusterPolicyReport{})
+	require.True(t, apierrors.IsNotFound(err))
 }

--- a/internal/audit-scanner/report/store.go
+++ b/internal/audit-scanner/report/store.go
@@ -7,11 +7,12 @@ import (
 	"log/slog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
 // Store is an interface to abstract the storage of reports. It's agnostic to the
@@ -52,10 +53,15 @@ func managedByKubewardenSelector() (labels.Selector, error) {
 	return selector, nil
 }
 
-// deleteReportsNotInSet lists the kubewarden-managed reports of the kind held by
-// list (matching listOpts) and deletes those whose name is not present in
-// keptReports, which holds the names of the reports created or patched during
-// the current scan run.
+// deleteReportsNotInSet lists the kubewarden-managed reports of the kind
+// represented by sample (matching listOpts) and deletes those whose name is
+// not present in keptReports, which holds the names of the reports created or
+// patched during the current scan run.
+//
+// The list only fetches object metadata (a PartialObjectMetadataList), not the
+// full report body (labels, scope and results): GC only needs name, UID,
+// ResourceVersion and namespace, so this avoids transferring and decoding the
+// full report payload for every managed report on every scan.
 //
 // Each report is deleted with UID and ResourceVersion preconditions (optimistic
 // concurrency), so a report that was concurrently re-created or updated (for
@@ -65,26 +71,31 @@ func deleteReportsNotInSet(
 	ctx context.Context,
 	c client.Client,
 	logger *slog.Logger,
-	list client.ObjectList,
+	sample client.Object,
 	listOpts *client.ListOptions,
 	keptReports sets.Set[string],
 ) error {
-	if err := c.List(ctx, list, listOpts); err != nil {
-		return fmt.Errorf("failed to list reports: %w", err)
-	}
-
-	items, err := apimeta.ExtractList(list)
+	gvk, err := apiutil.GVKForObject(sample, c.Scheme())
 	if err != nil {
-		return fmt.Errorf("failed to extract report list: %w", err)
+		return fmt.Errorf("failed to get GroupVersionKind for %T: %w", sample, err)
+	}
+	listGVK := gvk
+	listGVK.Kind += "List"
+
+	list := &metav1.PartialObjectMetadataList{}
+	list.SetGroupVersionKind(listGVK)
+
+	if listErr := c.List(ctx, list, listOpts); listErr != nil {
+		return fmt.Errorf("failed to list reports: %w", listErr)
 	}
 
 	var errs []error
-	for _, item := range items {
-		report, ok := item.(client.Object)
-		if !ok {
-			errs = append(errs, fmt.Errorf("expected client.Object, got %T", item))
-			continue
-		}
+	for i := range list.Items {
+		report := &list.Items[i]
+		// The API server sets Kind/APIVersion on each returned item, but set it
+		// explicitly too so Delete knows which resource to target regardless.
+		report.SetGroupVersionKind(gvk)
+
 		if keptReports.Has(report.GetName()) {
 			continue
 		}

--- a/internal/audit-scanner/report/store.go
+++ b/internal/audit-scanner/report/store.go
@@ -29,11 +29,24 @@ type Store interface {
 	// can wrongly match — and therefore delete — reports that were just patched
 	// with the current run UID.
 	DeleteOldReports(ctx context.Context, keptReports sets.Set[string], namespace string) error
+	// DeleteAllReports deletes, in a single deletecollection call, all the
+	// kubewarden-managed Reports in the given namespace.
+	//
+	// This must only be called when the current scan run wrote no reports in
+	// this namespace (e.g. no policy targets any resource in scope): in that
+	// case every kubewarden-managed report found is necessarily stale, so there
+	// is no read-after-write race to guard against and no need for the
+	// per-item, precondition-guarded delete used by DeleteOldReports.
+	DeleteAllReports(ctx context.Context, namespace string) error
 	CreateOrPatchClusterReport(ctx context.Context, report any) error
 	// DeleteOldClusterReports deletes all the kubewarden-managed ClusterReports
 	// whose name is not present in keptReports. See DeleteOldReports for the
 	// rationale behind deleting by name instead of by label selector.
 	DeleteOldClusterReports(ctx context.Context, keptReports sets.Set[string]) error
+	// DeleteAllClusterReports deletes, in a single deletecollection call, all
+	// the kubewarden-managed ClusterReports. See DeleteAllReports for when it
+	// is safe to call this instead of DeleteOldClusterReports.
+	DeleteAllClusterReports(ctx context.Context) error
 }
 
 func NewReportStoreOfKind(kind CrdKind, client client.Client, logger *slog.Logger) Store {
@@ -51,6 +64,29 @@ func managedByKubewardenSelector() (labels.Selector, error) {
 		return nil, fmt.Errorf("failed to parse label selector: %w", err)
 	}
 	return selector, nil
+}
+
+// deleteAllManagedReports deletes, in a single deletecollection call, all the
+// kubewarden-managed reports of the kind represented by sample, in the given
+// namespace (ignored for cluster-scoped kinds).
+//
+// Callers must only use this when the current scan run wrote no reports in
+// scope, so every managed report returned by the label selector is
+// necessarily stale: there is no write to race against, unlike
+// deleteReportsNotInSet.
+func deleteAllManagedReports(ctx context.Context, c client.Client, sample client.Object, namespace string) error {
+	labelSelector, err := managedByKubewardenSelector()
+	if err != nil {
+		return err
+	}
+
+	if deleteErr := c.DeleteAllOf(ctx, sample, &client.DeleteAllOfOptions{ListOptions: client.ListOptions{
+		LabelSelector: labelSelector,
+		Namespace:     namespace,
+	}}); deleteErr != nil {
+		return fmt.Errorf("failed to delete reports: %w", deleteErr)
+	}
+	return nil
 }
 
 // deleteReportsNotInSet lists the kubewarden-managed reports of the kind

--- a/internal/audit-scanner/report/store.go
+++ b/internal/audit-scanner/report/store.go
@@ -2,8 +2,15 @@ package report
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -11,9 +18,21 @@ import (
 // kind of report used (PolicyReport or OpenReport).
 type Store interface {
 	CreateOrPatchReport(ctx context.Context, report any) error
-	DeleteOldReports(ctx context.Context, scanRunID, namespace string) error
+	// DeleteOldReports deletes all the kubewarden-managed Reports in the given
+	// namespace whose name is not present in keptReports. keptReports holds the
+	// names of the reports created or patched during the current scan run.
+	//
+	// Deleting by an explicit set of names (instead of a "run-uid != current"
+	// label selector) avoids a read-after-write race: a collection delete
+	// evaluates its selector against a possibly stale API server cache, which
+	// can wrongly match — and therefore delete — reports that were just patched
+	// with the current run UID.
+	DeleteOldReports(ctx context.Context, keptReports sets.Set[string], namespace string) error
 	CreateOrPatchClusterReport(ctx context.Context, report any) error
-	DeleteOldClusterReports(ctx context.Context, scanRunID string) error
+	// DeleteOldClusterReports deletes all the kubewarden-managed ClusterReports
+	// whose name is not present in keptReports. See DeleteOldReports for the
+	// rationale behind deleting by name instead of by label selector.
+	DeleteOldClusterReports(ctx context.Context, keptReports sets.Set[string]) error
 }
 
 func NewReportStoreOfKind(kind CrdKind, client client.Client, logger *slog.Logger) Store {
@@ -21,4 +40,78 @@ func NewReportStoreOfKind(kind CrdKind, client client.Client, logger *slog.Logge
 		return NewPolicyReportStore(client, logger)
 	}
 	return NewOpenReportStore(client, logger)
+}
+
+// managedByKubewardenSelector returns a label selector matching all the reports
+// managed by the audit scanner.
+func managedByKubewardenSelector() (labels.Selector, error) {
+	selector, err := labels.Parse(fmt.Sprintf("%s=%s", labelAppManagedBy, labelApp))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse label selector: %w", err)
+	}
+	return selector, nil
+}
+
+// deleteReportsNotInSet lists the kubewarden-managed reports of the kind held by
+// list (matching listOpts) and deletes those whose name is not present in
+// keptReports, which holds the names of the reports created or patched during
+// the current scan run.
+//
+// Each report is deleted with UID and ResourceVersion preconditions (optimistic
+// concurrency), so a report that was concurrently re-created or updated (for
+// example by an overlapping scan) is left untouched: such conflicts, as well as
+// not-found errors, are expected and ignored.
+func deleteReportsNotInSet(
+	ctx context.Context,
+	c client.Client,
+	logger *slog.Logger,
+	list client.ObjectList,
+	listOpts *client.ListOptions,
+	keptReports sets.Set[string],
+) error {
+	if err := c.List(ctx, list, listOpts); err != nil {
+		return fmt.Errorf("failed to list reports: %w", err)
+	}
+
+	items, err := apimeta.ExtractList(list)
+	if err != nil {
+		return fmt.Errorf("failed to extract report list: %w", err)
+	}
+
+	var errs []error
+	for _, item := range items {
+		report, ok := item.(client.Object)
+		if !ok {
+			errs = append(errs, fmt.Errorf("expected client.Object, got %T", item))
+			continue
+		}
+		if keptReports.Has(report.GetName()) {
+			continue
+		}
+		if derr := deleteReport(ctx, c, logger, report); derr != nil {
+			errs = append(errs, derr)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// deleteReport deletes a single report guarding the operation with UID and
+// ResourceVersion preconditions. Not-found and conflict errors are treated as
+// success: they mean the report is already gone or was modified concurrently.
+func deleteReport(ctx context.Context, c client.Client, logger *slog.Logger, report client.Object) error {
+	err := c.Delete(ctx, report, client.Preconditions{
+		UID:             ptr.To(report.GetUID()),
+		ResourceVersion: ptr.To(report.GetResourceVersion()),
+	})
+	switch {
+	case apierrors.IsNotFound(err), apierrors.IsConflict(err):
+		logger.DebugContext(ctx, "skipping deletion of report modified concurrently",
+			slog.String("name", report.GetName()),
+			slog.String("namespace", report.GetNamespace()))
+		return nil
+	case err != nil:
+		return fmt.Errorf("failed to delete report %s: %w", report.GetName(), err)
+	default:
+		return nil
+	}
 }

--- a/internal/audit-scanner/scanner/scanner.go
+++ b/internal/audit-scanner/scanner/scanner.go
@@ -164,9 +164,6 @@ func (s *Scanner) ScanNamespace(ctx context.Context, nsName, runUID string) erro
 		slog.String("namespace", nsName),
 		slog.String("RunUID", runUID),
 		slog.Int("parallel-resources-audits", s.parallelResourcesAudits))
-	semaphore := semaphore.NewWeighted(int64(s.parallelResourcesAudits))
-	var workers sync.WaitGroup
-	keptReports := newReportNameSet()
 
 	namespace, err := s.k8sClient.GetNamespace(ctx, nsName)
 	if err != nil {
@@ -182,6 +179,26 @@ func (s *Scanner) ScanNamespace(ctx context.Context, nsName, runUID string) erro
 		slog.Int("policies-to-evaluate", policies.PolicyNum),
 		slog.Int("policies-skipped", policies.SkippedNum),
 		slog.Int("policies-errored", policies.ErroredNum))
+
+	if len(policies.PoliciesByGVR) == 0 {
+		// No policy targets any resource in this namespace, so no report can
+		// have been written during this run: every kubewarden-managed report
+		// found is necessarily stale and can be deleted in a single call,
+		// instead of listing and comparing against an (empty) write-set.
+		s.logger.InfoContext(ctx, "no auditable policies for namespace, deleting all managed reports",
+			slog.String("namespace", nsName))
+		if deleteErr := s.reportStore.DeleteAllReports(ctx, nsName); deleteErr != nil {
+			s.logger.ErrorContext(ctx, "error deleting old reports",
+				slog.String("error", deleteErr.Error()),
+				slog.String("RunUID", runUID))
+		}
+		s.logger.InfoContext(ctx, "Namespaced resources scan finished")
+		return nil
+	}
+
+	semaphore := semaphore.NewWeighted(int64(s.parallelResourcesAudits))
+	var workers sync.WaitGroup
+	keptReports := newReportNameSet()
 
 	for gvr, pols := range policies.PoliciesByGVR {
 		pager := s.k8sClient.GetResources(gvr, nsName)
@@ -283,10 +300,6 @@ func (s *Scanner) ScanAllNamespaces(ctx context.Context, runUID string) error {
 func (s *Scanner) ScanClusterWideResources(ctx context.Context, runUID string) error {
 	s.logger.InfoContext(ctx, "clusterwide resources scan started", slog.String("RunUID", runUID))
 
-	semaphore := semaphore.NewWeighted(int64(s.parallelResourcesAudits))
-	var workers sync.WaitGroup
-	keptReports := newReportNameSet()
-
 	policies, err := s.policiesClient.GetClusterWidePolicies(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to obtain cluster auditable policies: %w", err)
@@ -297,6 +310,26 @@ func (s *Scanner) ScanClusterWideResources(ctx context.Context, runUID string) e
 		slog.Int("policies-skipped", policies.SkippedNum),
 		slog.Int("policies-errored", policies.ErroredNum),
 		slog.Int("parallel-resources-audits", s.parallelResourcesAudits))
+
+	if len(policies.PoliciesByGVR) == 0 {
+		// No cluster-wide policy targets any resource, so no cluster report can
+		// have been written during this run: every kubewarden-managed
+		// ClusterReport found is necessarily stale and can be deleted in a
+		// single call, instead of listing and comparing against an (empty)
+		// write-set.
+		s.logger.InfoContext(ctx, "no cluster-wide auditable policies, deleting all managed ClusterReports")
+		if deleteErr := s.reportStore.DeleteAllClusterReports(ctx); deleteErr != nil {
+			s.logger.ErrorContext(ctx, "error deleting old ClusterReports",
+				slog.String("error", deleteErr.Error()),
+				slog.String("RunUID", runUID))
+		}
+		s.logger.InfoContext(ctx, "Cluster-wide resources scan finished")
+		return nil
+	}
+
+	semaphore := semaphore.NewWeighted(int64(s.parallelResourcesAudits))
+	var workers sync.WaitGroup
+	keptReports := newReportNameSet()
 
 	for gvr, pols := range policies.PoliciesByGVR {
 		pager := s.k8sClient.GetResources(gvr, "")

--- a/internal/audit-scanner/scanner/scanner.go
+++ b/internal/audit-scanner/scanner/scanner.go
@@ -26,9 +26,37 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const httpClientTimeout = 10 * time.Second
+
+// reportNameSet is a concurrency-safe set of report names (resource UIDs)
+// collected while auditing resources in parallel. It records the reports that
+// were created or patched during the current scan run, so that the garbage
+// collection step can delete only the reports that are NOT part of this run.
+type reportNameSet struct {
+	mu    sync.Mutex
+	names sets.Set[string]
+}
+
+func newReportNameSet() *reportNameSet {
+	return &reportNameSet{names: sets.New[string]()}
+}
+
+func (r *reportNameSet) insert(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.names.Insert(name)
+}
+
+// snapshot returns a copy of the collected names, safe to use after the audit
+// goroutines have finished.
+func (r *reportNameSet) snapshot() sets.Set[string] {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.names.Clone()
+}
 
 // Scanner verifies that existing resources don't violate any of the policies.
 type Scanner struct {
@@ -138,6 +166,7 @@ func (s *Scanner) ScanNamespace(ctx context.Context, nsName, runUID string) erro
 		slog.Int("parallel-resources-audits", s.parallelResourcesAudits))
 	semaphore := semaphore.NewWeighted(int64(s.parallelResourcesAudits))
 	var workers sync.WaitGroup
+	keptReports := newReportNameSet()
 
 	namespace, err := s.k8sClient.GetNamespace(ctx, nsName)
 	if err != nil {
@@ -174,7 +203,7 @@ func (s *Scanner) ScanNamespace(ctx context.Context, nsName, runUID string) erro
 				defer semaphore.Release(1)
 				defer workers.Done()
 
-				if auditErr := s.auditResource(ctx, policiesToAudit, *resource, runUID, policies.SkippedNum, policies.ErroredNum); auditErr != nil {
+				if auditErr := s.auditResource(ctx, policiesToAudit, *resource, runUID, policies.SkippedNum, policies.ErroredNum, keptReports); auditErr != nil {
 					s.logger.ErrorContext(ctx, "error auditing resource",
 						slog.String("error", auditErr.Error()),
 						slog.String("RunUID", runUID))
@@ -195,7 +224,7 @@ func (s *Scanner) ScanNamespace(ctx context.Context, nsName, runUID string) erro
 	}
 	workers.Wait()
 
-	if deleteErr := s.reportStore.DeleteOldReports(ctx, runUID, nsName); deleteErr != nil {
+	if deleteErr := s.reportStore.DeleteOldReports(ctx, keptReports.snapshot(), nsName); deleteErr != nil {
 		s.logger.ErrorContext(ctx, "error deleting old reports",
 			slog.String("error", deleteErr.Error()),
 			slog.String("RunUID", runUID))
@@ -256,6 +285,7 @@ func (s *Scanner) ScanClusterWideResources(ctx context.Context, runUID string) e
 
 	semaphore := semaphore.NewWeighted(int64(s.parallelResourcesAudits))
 	var workers sync.WaitGroup
+	keptReports := newReportNameSet()
 
 	policies, err := s.policiesClient.GetClusterWidePolicies(ctx)
 	if err != nil {
@@ -287,7 +317,7 @@ func (s *Scanner) ScanClusterWideResources(ctx context.Context, runUID string) e
 				defer semaphore.Release(1)
 				defer workers.Done()
 
-				s.auditClusterResource(ctx, policiesToAudit, *resource, runUID, policies.SkippedNum, policies.ErroredNum)
+				s.auditClusterResource(ctx, policiesToAudit, *resource, runUID, policies.SkippedNum, policies.ErroredNum, keptReports)
 			}()
 
 			return nil
@@ -305,7 +335,7 @@ func (s *Scanner) ScanClusterWideResources(ctx context.Context, runUID string) e
 
 	workers.Wait()
 
-	if deleteErr := s.reportStore.DeleteOldClusterReports(ctx, runUID); deleteErr != nil {
+	if deleteErr := s.reportStore.DeleteOldClusterReports(ctx, keptReports.snapshot()); deleteErr != nil {
 		s.logger.ErrorContext(ctx, "error deleting old ClusterReports",
 			slog.String("error", deleteErr.Error()),
 			slog.String("RunUID", runUID))
@@ -321,7 +351,7 @@ type policyAuditResult struct {
 }
 
 //gocognit:ignore
-func (s *Scanner) auditResource(ctx context.Context, policies []*policies.Policy, resource unstructured.Unstructured, runUID string, skippedPoliciesNum, erroredPoliciesNum int) error {
+func (s *Scanner) auditResource(ctx context.Context, policies []*policies.Policy, resource unstructured.Unstructured, runUID string, skippedPoliciesNum, erroredPoliciesNum int, keptReports *reportNameSet) error {
 	s.logger.InfoContext(ctx, "audit resource",
 		slog.String("resource", resource.GetName()),
 		slog.Int("policies-to-evaluate", len(policies)),
@@ -417,12 +447,16 @@ func (s *Scanner) auditResource(ctx context.Context, policies []*policies.Policy
 		err := s.reportStore.CreateOrPatchReport(ctx, policyReport)
 		if err != nil {
 			s.logger.ErrorContext(ctx, "error adding PolicyReport to store.", slog.String("error", err.Error()))
+		} else {
+			// Record the report as part of this run so the garbage collection
+			// step does not delete it. The report name is the resource UID.
+			keptReports.insert(string(resource.GetUID()))
 		}
 	}
 	return nil
 }
 
-func (s *Scanner) auditClusterResource(ctx context.Context, policies []*policies.Policy, resource unstructured.Unstructured, runUID string, skippedPoliciesNum, erroredPoliciesNum int) {
+func (s *Scanner) auditClusterResource(ctx context.Context, policies []*policies.Policy, resource unstructured.Unstructured, runUID string, skippedPoliciesNum, erroredPoliciesNum int, keptReports *reportNameSet) {
 	s.logger.InfoContext(ctx, "audit clusterwide resource",
 		slog.String("resource", resource.GetName()),
 		slog.Int("policies-to-evaluate", len(policies)))
@@ -491,6 +525,10 @@ func (s *Scanner) auditClusterResource(ctx context.Context, policies []*policies
 		err := s.reportStore.CreateOrPatchClusterReport(ctx, clusterReport)
 		if err != nil {
 			s.logger.ErrorContext(ctx, "error adding ClusterPolicyReport to store", slog.String("error", err.Error()))
+		} else {
+			// Record the report as part of this run so the garbage collection
+			// step does not delete it. The report name is the resource UID.
+			keptReports.insert(string(resource.GetUID()))
 		}
 	}
 }

--- a/internal/audit-scanner/scanner/scanner_test.go
+++ b/internal/audit-scanner/scanner/scanner_test.go
@@ -1787,3 +1787,72 @@ func TestScanClusterWideResourcesWithOpenReport(t *testing.T) {
 	assert.Len(t, clusterPolicyReport.Results, 3)
 	assert.Equal(t, runUID, clusterPolicyReport.GetLabels()[auditConstants.AuditScannerRunUIDLabel])
 }
+
+// TestScanNamespaceWithNoAuditablePoliciesDeletesAllManagedReports covers the
+// bulk-delete fast path: when no policy targets any resource in a namespace,
+// no report can have been written during the scan, so every kubewarden-managed
+// report found for that namespace must be deleted regardless of its
+// run-uid label.
+func TestScanNamespaceWithNoAuditablePoliciesDeletesAllManagedReports(t *testing.T) {
+	namespace1 := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "namespace1",
+			UID:  "namespace1-uid",
+		},
+	}
+
+	// A managed report left over from a previous scan, when a policy still
+	// targeted this namespace.
+	staleReport := testutils.NewPolicyReportFactory().
+		Name("stale-report").Namespace("namespace1").WithAppLabel().Build()
+
+	dynamicClient := dynamicFake.NewSimpleDynamicClient(scheme.Scheme, namespace1)
+	clientset := fake.NewClientset(namespace1)
+	client, err := testutils.NewFakeClient(namespace1, staleReport)
+	require.NoError(t, err)
+
+	logger := slog.Default()
+	k8sClient := k8s.NewClient(dynamicClient, clientset, "kubewarden", nil, pageSize, logger)
+	policiesClient := policies.NewClient(client, "kubewarden", "", logger)
+	policyReportStore := report.NewPolicyReportStore(client, logger)
+
+	config := newTestConfig(policiesClient, k8sClient, policyReportStore)
+	scanner, err := NewScanner(config)
+	require.NoError(t, err)
+
+	runUID := uuid.New().String()
+	err = scanner.ScanNamespace(t.Context(), "namespace1", runUID)
+	require.NoError(t, err)
+
+	err = client.Get(t.Context(), types.NamespacedName{Name: "stale-report", Namespace: "namespace1"}, &wgpolicy.PolicyReport{})
+	require.True(t, apimachineryErrors.IsNotFound(err))
+}
+
+// TestScanClusterWideResourcesWithNoAuditablePoliciesDeletesAllManagedReports
+// is the cluster-scoped counterpart of
+// TestScanNamespaceWithNoAuditablePoliciesDeletesAllManagedReports.
+func TestScanClusterWideResourcesWithNoAuditablePoliciesDeletesAllManagedReports(t *testing.T) {
+	staleClusterReport := testutils.NewClusterPolicyReportFactory().
+		Name("stale-cluster-report").WithAppLabel().Build()
+
+	dynamicClient := dynamicFake.NewSimpleDynamicClient(scheme.Scheme)
+	clientset := fake.NewClientset()
+	client, err := testutils.NewFakeClient(staleClusterReport)
+	require.NoError(t, err)
+
+	logger := slog.Default()
+	k8sClient := k8s.NewClient(dynamicClient, clientset, "kubewarden", nil, pageSize, logger)
+	policiesClient := policies.NewClient(client, "kubewarden", "", logger)
+	policyReportStore := report.NewPolicyReportStore(client, logger)
+
+	config := newTestConfig(policiesClient, k8sClient, policyReportStore)
+	scanner, err := NewScanner(config)
+	require.NoError(t, err)
+
+	runUID := uuid.New().String()
+	err = scanner.ScanClusterWideResources(t.Context(), runUID)
+	require.NoError(t, err)
+
+	err = client.Get(t.Context(), types.NamespacedName{Name: "stale-cluster-report"}, &wgpolicy.ClusterPolicyReport{})
+	require.True(t, apimachineryErrors.IsNotFound(err))
+}


### PR DESCRIPTION
The GC step deleted reports with a DeleteAllOf call using a "run-uid != current" label selector. That selector is evaluated against the API server's watch cache, which can lag behind patches committed in the same scan run. As a result, reports that were just updated with the current run UID could still appear stale to the delete, causing them to be wrongly removed.

This commit changes how the deletion of the stale reports happens.

Each auditResource/auditClusterResource goroutine records the report name in a concurrency-safe set after a successful CreateOrPatch. DeleteOldReports/DeleteOldClusterReports then list managed reports and delete only those whose name is absent from that set, using per-item Delete with UID+ResourceVersion preconditions for optimistic concurrency.

I've tested the fix by running the broken e2e test locally, everything seems to be fine now.

Fixes: https://github.com/kubewarden/adm-controller/issues/1838
