### PR TITLE
fix: recommended policies should always have the "backgroundAudit" set to true

### DIFF
--- a/charts/admission-controller/templates/defaults/policies/_allow-privilege-escalation.tpl
+++ b/charts/admission-controller/templates/defaults/policies/_allow-privilege-escalation.tpl
@@ -14,6 +14,7 @@ spec:
   failurePolicy: {{ include "policy_failure_policy" . | trim }}
   module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.allowPrivilegeEscalationPolicy.module.repository }}:{{ .Values.recommendedPolicies.allowPrivilegeEscalationPolicy.module.tag }}
   mutating: true
+  backgroundAudit: true
   rules:
     - apiGroups: [""]
       apiVersions: ["v1"]

--- a/charts/admission-controller/templates/defaults/policies/_capabilities.tpl
+++ b/charts/admission-controller/templates/defaults/policies/_capabilities.tpl
@@ -14,6 +14,7 @@ spec:
   failurePolicy: {{ include "policy_failure_policy" . | trim }}
   module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.capabilitiesPolicy.module.repository }}:{{ .Values.recommendedPolicies.capabilitiesPolicy.module.tag }}
   mutating: true
+  backgroundAudit: true
   rules:
     - apiGroups: [""]
       apiVersions: ["v1"]

--- a/charts/admission-controller/templates/defaults/policies/_host-namespace.tpl
+++ b/charts/admission-controller/templates/defaults/policies/_host-namespace.tpl
@@ -14,6 +14,7 @@ spec:
   failurePolicy: {{ include "policy_failure_policy" . | trim }}
   module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.hostNamespacePolicy.module.repository }}:{{ .Values.recommendedPolicies.hostNamespacePolicy.module.tag }}
   mutating: false
+  backgroundAudit: true
   rules:
     - apiGroups: [""]
       apiVersions: ["v1"]

--- a/charts/admission-controller/templates/defaults/policies/_host-paths.tpl
+++ b/charts/admission-controller/templates/defaults/policies/_host-paths.tpl
@@ -14,6 +14,7 @@ spec:
   failurePolicy: {{ include "policy_failure_policy" . | trim }}
   module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.hostPathsPolicy.module.repository }}:{{ .Values.recommendedPolicies.hostPathsPolicy.module.tag }}
   mutating: false
+  backgroundAudit: true
   rules:
     - apiGroups: [""]
       apiVersions: ["v1"]

--- a/charts/admission-controller/templates/defaults/policies/_pod-privileged.tpl
+++ b/charts/admission-controller/templates/defaults/policies/_pod-privileged.tpl
@@ -14,6 +14,7 @@ spec:
   failurePolicy: {{ include "policy_failure_policy" . | trim }}
   module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.podPrivilegedPolicy.module.repository }}:{{ .Values.recommendedPolicies.podPrivilegedPolicy.module.tag }}
   mutating: false
+  backgroundAudit: true
   rules:
     - apiGroups: [""]
       apiVersions: ["v1"]

--- a/charts/admission-controller/templates/defaults/policies/_user-group.tpl
+++ b/charts/admission-controller/templates/defaults/policies/_user-group.tpl
@@ -14,6 +14,7 @@ spec:
   failurePolicy: {{ include "policy_failure_policy" . | trim }}
   module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.userGroupPolicy.module.repository }}:{{ .Values.recommendedPolicies.userGroupPolicy.module.tag }}
   mutating: true
+  backgroundAudit: true
   rules:
     - apiGroups: [""]
       apiVersions: ["v1"]

--- a/charts/admission-controller/tests/defaults_configmap_test.yaml
+++ b/charts/admission-controller/tests/defaults_configmap_test.yaml
@@ -198,6 +198,29 @@ tests:
           path: data["allow-privilege-escalation.yaml"]
           pattern: "UPDATE"
 
+  - it: "recommended policies should set backgroundAudit to true"
+    set:
+      recommendedPolicies.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["allow-privilege-escalation.yaml"]
+          pattern: "backgroundAudit: true"
+      - matchRegex:
+          path: data["capabilities.yaml"]
+          pattern: "backgroundAudit: true"
+      - matchRegex:
+          path: data["host-namespace.yaml"]
+          pattern: "backgroundAudit: true"
+      - matchRegex:
+          path: data["host-paths.yaml"]
+          pattern: "backgroundAudit: true"
+      - matchRegex:
+          path: data["pod-privileged.yaml"]
+          pattern: "backgroundAudit: true"
+      - matchRegex:
+          path: data["user-group.yaml"]
+          pattern: "backgroundAudit: true"
+
   - it: "should not render policy entries when recommendedPolicies.enabled is false"
     set:
       policyServer.enabled: true

--- a/internal/controller/defaults_applier.go
+++ b/internal/controller/defaults_applier.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -11,14 +10,13 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/sets"
+	sigsyaml "sigs.k8s.io/yaml"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	policiesv1 "github.com/kubewarden/adm-controller/api/policies/v1"
 	"github.com/kubewarden/adm-controller/internal/constants"
 )
 
@@ -35,7 +33,6 @@ type DefaultsApplierReconciler struct {
 	Log                  logr.Logger
 	DeploymentsNamespace string
 	ConfigMapName        string
-	decoder              runtime.Decoder
 }
 
 // Reconcile watches the defaults ConfigMap and applies the resources it contains.
@@ -57,34 +54,29 @@ func (r *DefaultsApplierReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	desired := sets.New[resourceKey]()
 
 	for key, yamlData := range cm.Data {
-		obj, gvk, err := r.decoder.Decode([]byte(yamlData), nil, nil)
-		if err != nil {
+		obj := &unstructured.Unstructured{}
+		if err := sigsyaml.Unmarshal([]byte(yamlData), obj); err != nil {
 			log.Error(err, "failed to decode resource from ConfigMap", "key", key)
 			// Don't fail the whole reconciliation for one bad entry
 			continue
 		}
 
-		clientObj, ok := obj.(client.Object)
-		if !ok {
-			log.Error(errors.New("decoded object is not a client.Object"), "skipping resource", "key", key, "gvk", gvk)
-			continue
-		}
-
-		if !isSupportedType(clientObj) {
-			log.Info("Unsupported resource type, skipping", "key", key, "type", fmt.Sprintf("%T", clientObj))
+		gvk := obj.GroupVersionKind()
+		if !isSupportedGVK(gvk) {
+			log.Info("Unsupported resource type, skipping", "key", key, "gvk", gvk.String())
 			continue
 		}
 
 		// Track this resource as desired
 		rk := resourceKey{
 			gvk:       gvk.String(),
-			name:      clientObj.GetName(),
-			namespace: clientObj.GetNamespace(),
+			name:      obj.GetName(),
+			namespace: obj.GetNamespace(),
 		}
 		desired.Insert(rk)
 
 		// Apply the resource with ownership label injected
-		if applyErr := r.applyResource(ctx, clientObj); applyErr != nil {
+		if applyErr := r.applyResource(ctx, obj); applyErr != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to apply resource %s: %w", rk, applyErr)
 		}
 	}
@@ -99,8 +91,6 @@ func (r *DefaultsApplierReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 // SetupWithManager registers the reconciler with the manager.
 func (r *DefaultsApplierReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	r.decoder = serializer.NewCodecFactory(r.Scheme).UniversalDeserializer()
-
 	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.ConfigMap{}).
 		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
@@ -113,94 +103,51 @@ func (r *DefaultsApplierReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return nil
 }
 
-// applyResource creates or updates the resource, managing user-defined metadata from ConfigMap.
-func (r *DefaultsApplierReconciler) applyResource(ctx context.Context, desired client.Object) error {
-	log := r.Log.WithValues("resource", client.ObjectKeyFromObject(desired), "kind", desired.GetObjectKind().GroupVersionKind().Kind)
+// applyResource applies the desired resource using Server-Side Apply. Only the fields present
+// in the ConfigMap YAML are sent, so the API server applies CRD schema defaults (e.g.
+// spec.backgroundAudit=true) for any field the template omits. SSA also manages field ownership:
+// keys removed from the YAML are pruned, and re-applying identical content is a no-op.
+func (r *DefaultsApplierReconciler) applyResource(ctx context.Context, desired *unstructured.Unstructured) error {
+	log := r.Log.WithValues("resource", client.ObjectKeyFromObject(desired), "kind", desired.GetKind())
 
-	// CreateOrPatch GETs the existing object into desired, overwriting the
-	// decoded state. Save a copy so the mutate function can restore everything.
-	desiredCopy, ok := desired.DeepCopyObject().(client.Object)
-	if !ok {
-		return errors.New("failed to cast deep copied object to client.Object")
+	// The status subresource cannot be set via an apply to the main resource; drop it so it
+	// does not end up in our managed field set.
+	unstructured.RemoveNestedField(desired.Object, "status")
+
+	// Stamp the ownership label used by cleanupStale to identify managed resources.
+	labels := desired.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
 	}
+	labels[constants.DefaultsManagedByLabelKey] = constants.DefaultsManagedByLabelValue
+	desired.SetLabels(labels)
 
-	_, err := controllerutil.CreateOrPatch(ctx, r.Client, desired, func() error {
-		copySpec(desiredCopy, desired)
-		applyManagedMetadata(desiredCopy, desired)
-
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create or patch resource: %w", err)
+	if err := r.Apply(ctx, client.ApplyConfigurationFromUnstructured(desired),
+		client.FieldOwner(constants.DefaultsManagedByLabelValue),
+		client.ForceOwnership,
+	); err != nil {
+		return fmt.Errorf("failed to server-side apply resource: %w", err)
 	}
 
 	log.V(1).Info("Resource applied successfully")
 	return nil
 }
 
-// isSupportedType returns true if the object is a known Kubewarden resource type.
-func isSupportedType(obj client.Object) bool {
-	switch obj.(type) {
-	case *policiesv1.PolicyServer,
-		*policiesv1.ClusterAdmissionPolicy,
-		*policiesv1.AdmissionPolicy,
-		*policiesv1.ClusterAdmissionPolicyGroup,
-		*policiesv1.AdmissionPolicyGroup:
+// isSupportedGVK returns true if the GroupVersionKind is a known Kubewarden resource type.
+func isSupportedGVK(gvk schema.GroupVersionKind) bool {
+	if gvk.Group != constants.KubewardenPoliciesGroup {
+		return false
+	}
+	switch gvk.Kind {
+	case "PolicyServer",
+		"ClusterAdmissionPolicy",
+		"AdmissionPolicy",
+		"ClusterAdmissionPolicyGroup",
+		"AdmissionPolicyGroup":
 		return true
 	default:
 		return false
 	}
-}
-
-// copySpec copies the Spec field from src to dst for all supported resource types.
-func copySpec(src, dst client.Object) {
-	switch d := dst.(type) {
-	case *policiesv1.PolicyServer:
-		if s, ok := src.(*policiesv1.PolicyServer); ok {
-			d.Spec = s.Spec
-		}
-	case *policiesv1.ClusterAdmissionPolicy:
-		if s, ok := src.(*policiesv1.ClusterAdmissionPolicy); ok {
-			d.Spec = s.Spec
-		}
-	case *policiesv1.AdmissionPolicy:
-		if s, ok := src.(*policiesv1.AdmissionPolicy); ok {
-			d.Spec = s.Spec
-		}
-	case *policiesv1.ClusterAdmissionPolicyGroup:
-		if s, ok := src.(*policiesv1.ClusterAdmissionPolicyGroup); ok {
-			d.Spec = s.Spec
-		}
-	case *policiesv1.AdmissionPolicyGroup:
-		if s, ok := src.(*policiesv1.AdmissionPolicyGroup); ok {
-			d.Spec = s.Spec
-		}
-	}
-}
-
-// applyManagedMetadata merges labels and annotations from the ConfigMap YAML into the live
-// object, preserving keys set by other controllers or tools. Previously managed keys that are
-// no longer present in the desired object are removed. The ownership label is always injected.
-func applyManagedMetadata(desired, live client.Object) {
-	// Ensure annotation map exists on live (needed to store label-key tracking).
-	annotations := live.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-
-	// Labels: merge desired keys, remove stale managed keys, then stamp the ownership label.
-	labels := live.GetLabels()
-	if labels == nil {
-		labels = make(map[string]string)
-	}
-	applyManagedKeys(labels, desired.GetLabels(), annotations, constants.ManagedLabelKeysAnnotation)
-	labels[constants.DefaultsManagedByLabelKey] = constants.DefaultsManagedByLabelValue
-
-	// Annotations: merge desired keys, remove stale managed keys.
-	applyManagedKeys(annotations, desired.GetAnnotations(), annotations, constants.ManagedAnnotationKeysAnnotation)
-
-	live.SetLabels(labels)
-	live.SetAnnotations(annotations)
 }
 
 // cleanupStale removes managed resources that are not in the desired set.

--- a/internal/controller/defaults_applier_test.go
+++ b/internal/controller/defaults_applier_test.go
@@ -8,6 +8,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	sigsyaml "sigs.k8s.io/yaml"
@@ -26,6 +28,21 @@ func marshalPolicyServer(ps *policiesv1.PolicyServer) string {
 func marshalClusterAdmissionPolicy(policy *policiesv1.ClusterAdmissionPolicy) string {
 	policy.SetGroupVersionKind(policiesv1.GroupVersion.WithKind("ClusterAdmissionPolicy"))
 	data, err := sigsyaml.Marshal(policy)
+	Expect(err).ToNot(HaveOccurred())
+	return string(data)
+}
+
+// marshalClusterAdmissionPolicyWithoutBackgroundAudit renders a ClusterAdmissionPolicy to YAML
+// with the spec.backgroundAudit field removed entirely, mimicking a chart template that omits it.
+// This lets us assert that the applier lets the API server apply the CRD default (true) instead of
+// clobbering it with the Go zero value (false).
+func marshalClusterAdmissionPolicyWithoutBackgroundAudit(policy *policiesv1.ClusterAdmissionPolicy) string {
+	policy.SetGroupVersionKind(policiesv1.GroupVersion.WithKind("ClusterAdmissionPolicy"))
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(policy)
+	Expect(err).ToNot(HaveOccurred())
+	unstructured.RemoveNestedField(obj, "spec", "backgroundAudit")
+	unstructured.RemoveNestedField(obj, "status")
+	data, err := sigsyaml.Marshal(obj)
 	Expect(err).ToNot(HaveOccurred())
 	return string(data)
 }
@@ -122,6 +139,36 @@ var _ = Describe("DefaultsApplierReconciler", func() {
 
 			Expect(createdPS.Labels).To(HaveKeyWithValue(constants.DefaultsManagedByLabelKey, constants.DefaultsManagedByLabelValue))
 			Expect(createdPS.Spec.Image).To(Equal(ps.Spec.Image))
+		})
+	})
+
+	Context("when a policy omits backgroundAudit", func() {
+		It("should apply the CRD default of true instead of the Go zero value", func() {
+			policy := policiesv1.NewClusterAdmissionPolicyFactory().WithName(policyName).WithoutFinalizers().Build()
+			policyYAML := marshalClusterAdmissionPolicyWithoutBackgroundAudit(policy)
+
+			// Guard: the ConfigMap entry must not carry a backgroundAudit field at all,
+			// otherwise this test would not exercise server-side defaulting.
+			Expect(policyYAML).ToNot(ContainSubstring("backgroundAudit"))
+
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: deploymentsNamespace,
+				},
+				Data: map[string]string{
+					"policy": policyYAML,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+
+			createdPolicy := &policiesv1.ClusterAdmissionPolicy{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: policyName}, createdPolicy)
+			}, timeout, pollInterval).Should(Succeed())
+
+			Expect(createdPolicy.Spec.BackgroundAudit).To(BeTrue(),
+				"server-side defaulting should set backgroundAudit=true when the field is omitted")
 		})
 	})
 


### PR DESCRIPTION
## Description

The recommended policies are rendered from the defaults ConfigMap and applied by the controller. When the template left `backgroundAudit` unset, the value reaching the API server was false instead of the CRD default of true, so the audit scanner skipped those policies. This was a regression from 1.36, where the policies were audited by default.

This PR fixes that in two ways: first, we add the missing flag in the Helm chart. This ensures that the field will always be present and set to `true`. The second fix is in the controller where it now uses server-side apply to update the resources. This way, we ensure that default values defined in the CRDs will be applied when the field is not defined. This will work not only for the `backgroundAudit` flag but for any field that we can add in the future with no need to change the code. 

Fix #1851 
