### PR TITLE
feat(controller): Add tracking labels to ConfigMaps of PolicyServers

### DIFF
--- a/internal/controller/policyserver_controller_configmap.go
+++ b/internal/controller/policyserver_controller_configmap.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -165,9 +166,15 @@ func (r *PolicyServerReconciler) updateConfigMapData(cfg *corev1.ConfigMap, poli
 	}
 
 	cfg.Data = data
-	cfg.ObjectMeta.Labels = map[string]string{
-		constants.PolicyServerLabelKey: policyServer.ObjectMeta.Name,
+	labels := map[string]string{
+		// PolicyServerLabelKey is used to map ConfigMap events to policy reconcile
+		// requests
+		constants.PolicyServerLabelKey: policyServer.Name,
 	}
+	// Use the same labels as other resources backing the PolicyServer, to track
+	// for deletion later on
+	maps.Copy(labels, policyServer.CommonLabels())
+	cfg.Labels = labels
 	if err = controllerutil.SetOwnerReference(policyServer, cfg, r.Client.Scheme()); err != nil {
 		return errors.Join(errors.New("failed to set policy server configmap owner reference"), err)
 	}

--- a/internal/controller/policyserver_controller_test.go
+++ b/internal/controller/policyserver_controller_test.go
@@ -269,6 +269,19 @@ var _ = Describe("PolicyServer controller", func() {
 			})))
 		})
 
+		It("should create the policy server configmap with the same labels as the other policy server resources", func() {
+			policyServer := policiesv1.NewPolicyServerFactory().WithName(policyServerName).Build()
+			createPolicyServerAndWaitForItsService(ctx, policyServer)
+
+			configmap, err := getTestPolicyServerConfigMap(ctx, policyServerName)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(configmap.Labels).To(HaveKeyWithValue(constants.PolicyServerLabelKey, policyServerName))
+			for k, v := range policyServer.CommonLabels() {
+				Expect(configmap.Labels).To(HaveKeyWithValue(k, v))
+			}
+		})
+
 		It("should create the policy server configmap with the assigned policies", func() {
 			timeoutEvalSeconds := int32(5)
 


### PR DESCRIPTION
## Description


Add common ownership labels to the ConfigMaps associated with PolicyServers.
This is needed to easily delete the ConfigMaps in the Helm pre-delete-hook.

On new install, this new label is no problem.

On upgrade, this relabel bumps the ConfigMap resourceVersion, which bumps the kubewarden/config-version label on the pod of the PolicyServer, triggering a rollout of the PolicyServer.

<!-- Please provide the link to the GitHub issue you are addressing -->

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

Added unit test.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
