### PR TITLE
fix(chart): Delete all CRs on helm uninstall

### DIFF
--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -334,7 +334,8 @@ to `false` removes all managed resources.
 CRDs are installed with the `helm.sh/resource-policy: keep` annotation:
 
 - `helm upgrade` updates CRDs normally
-- `helm uninstall` does not delete CRDs, which prevents cascade-deletion of all PolicyServers and policies in the cluster
+- `helm uninstall` does not delete CRDs, but deletes all deployed
+  Kubewarden custom resources (see [Uninstall](#uninstall))
 
 #### Reinstalling under a different release name or namespace
 
@@ -369,14 +370,15 @@ helm uninstall kubewarden-controller -n kubewarden
 
 This removes:
 
+- All Kubewarden custom resources (PolicyServers, ClusterAdmissionPolicies,
+  AdmissionPolicies, ClusterAdmissionPolicyGroups, AdmissionPolicyGroups),
+  including user-managed ones, in every namespace.
 - The controller Deployment
-- Managed defaults (resources labeled `kubewarden.io/managed-by=kubewarden-controller-defaults`)
 - ConfigMaps, Secrets, Services
 
 It does not remove:
 
 - CRDs (kept by `helm.sh/resource-policy: keep`)
-- User-managed PolicyServers and policies
 
 To remove CRDs after uninstall:
 

--- a/charts/admission-controller/templates/controller/pre-delete-hook.yaml
+++ b/charts/admission-controller/templates/controller/pre-delete-hook.yaml
@@ -32,7 +32,7 @@ spec:
       containers:
         - name: pre-delete-job
           image: '{{ template "system_default_registry" . }}{{ .Values.preDeleteJob.image.repository }}:{{ .Values.preDeleteJob.image.tag }}'
-          command: ["kubectl", "delete", "--wait", "policyservers,clusteradmissionpolicies,admissionpolicies,clusteradmissionpolicygroups,admissionpolicygroups", "-n", "{{ .Release.Namespace }}", "-l", "kubewarden.io/managed-by=kubewarden-controller-defaults", "--ignore-not-found"]
+          command: ["kubectl", "delete", "--wait", "policyservers,clusteradmissionpolicies,admissionpolicies,clusteradmissionpolicygroups,admissionpolicygroups", "--all", "--all-namespaces", "--ignore-not-found"]
           env:
             - name: KUBERLR_ALLOWDOWNLOAD
               value: "1"

--- a/internal/controller/policyserver_controller_configmap.go
+++ b/internal/controller/policyserver_controller_configmap.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -165,9 +166,15 @@ func (r *PolicyServerReconciler) updateConfigMapData(cfg *corev1.ConfigMap, poli
 	}
 
 	cfg.Data = data
-	cfg.ObjectMeta.Labels = map[string]string{
-		constants.PolicyServerLabelKey: policyServer.ObjectMeta.Name,
+	labels := map[string]string{
+		// PolicyServerLabelKey is used to map ConfigMap events to policy reconcile
+		// requests
+		constants.PolicyServerLabelKey: policyServer.Name,
 	}
+	// Use the same labels as other resources backing the PolicyServer, to track
+	// for deletion later on
+	maps.Copy(labels, policyServer.CommonLabels())
+	cfg.Labels = labels
 	if err = controllerutil.SetOwnerReference(policyServer, cfg, r.Client.Scheme()); err != nil {
 		return errors.Join(errors.New("failed to set policy server configmap owner reference"), err)
 	}

--- a/internal/controller/policyserver_controller_test.go
+++ b/internal/controller/policyserver_controller_test.go
@@ -269,6 +269,19 @@ var _ = Describe("PolicyServer controller", func() {
 			})))
 		})
 
+		It("should create the policy server configmap with the same labels as the other policy server resources", func() {
+			policyServer := policiesv1.NewPolicyServerFactory().WithName(policyServerName).Build()
+			createPolicyServerAndWaitForItsService(ctx, policyServer)
+
+			configmap, err := getTestPolicyServerConfigMap(ctx, policyServerName)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(configmap.Labels).To(HaveKeyWithValue(constants.PolicyServerLabelKey, policyServerName))
+			for k, v := range policyServer.CommonLabels() {
+				Expect(configmap.Labels).To(HaveKeyWithValue(k, v))
+			}
+		})
+
 		It("should create the policy server configmap with the assigned policies", func() {
 			timeoutEvalSeconds := int32(5)
 


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix https://github.com/kubewarden/adm-controller/issues/1849 (solution C)

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

Expand the existing helm pre-delete-hook to delete all CRs across all
namespaces.

This matches the behavior of 1.36.



## Test

<!-- Please provides a short description about how to test your pullrequest -->

chart e2e tests.
<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
