### PR TITLE
feat!(controller,helm): Implement `controller --cleanup` and consume it in `pre-delete-hook`

### DIFF
--- a/api/policies/v1/policyserver_webhook.go
+++ b/api/policies/v1/policyserver_webhook.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/go-logr/logr"
@@ -83,9 +82,6 @@ func (ps *PolicyServer) SetupWebhookWithManager(mgr ctrl.Manager, deploymentsNam
 	logger := mgr.GetLogger().WithName("policyserver-webhook")
 
 	err := ctrl.NewWebhookManagedBy(mgr, ps).
-		WithDefaulter(&policyServerDefaulter{
-			logger: logger,
-		}).
 		WithValidator(&policyServerValidator{
 			deploymentsNamespace: deploymentsNamespace,
 			k8sClient:            mgr.GetClient(),
@@ -94,24 +90,6 @@ func (ps *PolicyServer) SetupWebhookWithManager(mgr ctrl.Manager, deploymentsNam
 		Complete()
 	if err != nil {
 		return fmt.Errorf("failed enrolling webhook with manager: %w", err)
-	}
-
-	return nil
-}
-
-// +kubebuilder:webhook:path=/mutate-policies-kubewarden-io-v1-policyserver,mutating=true,failurePolicy=fail,sideEffects=None,groups=policies.kubewarden.io,resources=policyservers,verbs=create;update,versions=v1,name=mpolicyserver.kb.io,admissionReviewVersions={v1,v1beta1}
-
-// policyServerDefaulter sets defaults of PolicyServer objects when they are created or updated.
-type policyServerDefaulter struct {
-	logger logr.Logger
-}
-
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the type.
-func (d *policyServerDefaulter) Default(_ context.Context, policyServer *PolicyServer) error {
-	d.logger.Info("Defaulting PolicyServer", "name", policyServer.GetName())
-
-	if policyServer.ObjectMeta.DeletionTimestamp == nil {
-		controllerutil.AddFinalizer(policyServer, constants.KubewardenFinalizer)
 	}
 
 	return nil

--- a/api/policies/v1/policyserver_webhook_test.go
+++ b/api/policies/v1/policyserver_webhook_test.go
@@ -27,21 +27,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
-
-	"github.com/kubewarden/adm-controller/internal/constants"
 )
 
 const fakeSigstoreTrustConfig = `{"trusted_root": {"version": "test"}}`
-
-func TestPolicyServerDefault(t *testing.T) {
-	defaulter := policyServerDefaulter{}
-	policyServer := &PolicyServer{}
-
-	err := defaulter.Default(t.Context(), policyServer)
-	require.NoError(t, err)
-
-	assert.Contains(t, policyServer.Finalizers, constants.KubewardenFinalizer)
-}
 
 func TestPolicyServerValidateCreate(t *testing.T) {
 	validator := policyServerValidator{logger: logr.Discard()}

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -367,18 +367,19 @@ helm install <release> <chart> -n <namespace> --take-ownership
 helm uninstall kubewarden-controller -n kubewarden
 ```
 
-This removes:
-
-- The controller Deployment
-- Managed defaults (resources labeled `kubewarden.io/managed-by=kubewarden-controller-defaults`)
-- ConfigMaps, Secrets, Services
+This removes the controller Deployment, default PolicyServer, recommended
+policies, and everything that makes the policies run, including the regular
+chart resources (RBAC, Secrets, Services, ConfigMaps, and so on).
 
 It does not remove:
 
-- CRDs (kept by `helm.sh/resource-policy: keep`)
-- User-managed PolicyServers and policies
+- CRDs (kept by `helm.sh/resource-policy: keep`).
+- User-managed PolicyServer and policy custom resources.
 
-To remove CRDs after uninstall:
+The user-managed custom resources are kept on purpose. Re-installing the chart
+deploys the controller, which reconciles them, and activates them back.
+
+To remove all user-managed custom resources and the CRDs do:
 
 ```sh
 kubectl delete crd policyservers.policies.kubewarden.io

--- a/charts/admission-controller/templates/controller/pre-delete-hook.yaml
+++ b/charts/admission-controller/templates/controller/pre-delete-hook.yaml
@@ -24,7 +24,10 @@ The Job runs the controller image in cleanup mode, which:
      PolicyServer and the recommended policies). The user-defined custom
      resources are kept: the controller reconciles them again (and re-adds
      their finalizers) on re-installation.
-  5. Deletes the resources backing the remaining PolicyServers.
+  5. Deletes the resources backing the remaining PolicyServers. Only the
+     resources labeled as policy-server components are swept: the chart-managed
+     resources (e.g. the controller Secrets and Services) are left for Helm to
+     delete right after this hook.
 */}}
 apiVersion: batch/v1
 kind: Job

--- a/charts/admission-controller/templates/controller/pre-delete-hook.yaml
+++ b/charts/admission-controller/templates/controller/pre-delete-hook.yaml
@@ -1,3 +1,31 @@
+{{- /*
+The uninstall must leave behind ONLY the Kubewarden CRDs (kept via the
+"helm.sh/resource-policy": keep annotation) and the user-defined
+PolicyServer/policy CRs, so that a future re-installation of the chart can
+adopt and reconcile them again. Everything that makes the policies run
+(policy-server Deployments, Services, certificate Secrets, ConfigMaps,
+PodDisruptionBudgets and the policies' webhook configurations) must be removed,
+otherwise orphaned policy-servers would keep evaluating admission requests
+without any controller reconciling them, or worse, webhook configurations would
+still be around without policy-server Deployments, causing a DoS on the
+cluster.
+
+The Job runs the controller image in cleanup mode, which:
+  1. Deletes the controller Deployment and waits for its pods to be gone, so
+     nothing recreates the resources removed by the following steps.
+  2. Deletes every Kubewarden webhook configuration, so no orphaned webhook
+     keeps intercepting admission requests and the following writes to the
+     Kubewarden custom resources are not rejected by webhooks pointing to the
+     deleted controller.
+  3. Strips the Kubewarden finalizers from the Kubewarden CRs, so they can be
+     deleted with plain kubectl commands without a running controller honoring
+     their finalizers.
+  4. Deletes the custom resources managed by this chart (the default
+     PolicyServer and the recommended policies). The user-defined custom
+     resources are kept: the controller reconciles them again (and re-adds
+     their finalizers) on re-installation.
+  5. Deletes the resources backing the remaining PolicyServers.
+*/}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -30,16 +58,18 @@ spec:
       {{- include "imagePullSecrets" .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
       containers:
-        - name: pre-delete-job
-          image: '{{ template "system_default_registry" . }}{{ .Values.preDeleteJob.image.repository }}:{{ .Values.preDeleteJob.image.tag }}'
-          command: ["kubectl", "delete", "--wait", "policyservers,clusteradmissionpolicies,admissionpolicies,clusteradmissionpolicygroups,admissionpolicygroups", "-n", "{{ .Release.Namespace }}", "-l", "kubewarden.io/managed-by=kubewarden-controller-defaults", "--ignore-not-found"]
-          env:
-            - name: KUBERLR_ALLOWDOWNLOAD
-              value: "1"
+        - name: kubewarden-cleanup
+          image: '{{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}'
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /controller
+          args:
+            - --cleanup
+            - --deployments-namespace={{ .Release.Namespace }}
+            - --controller-deployment-name={{ include "admission-controller.fullname" . }}
+            - --zap-log-level={{ .Values.logLevel }}
           {{- if .Values.preDeleteHook.containerSecurityContext }}
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
 {{ toYaml .Values.preDeleteHook.containerSecurityContext | indent 12 }}
           {{- end }}
           {{- if and .Values.resources .Values.resources.preDeleteJob }}

--- a/charts/admission-controller/templates/controller/webhooks.yaml
+++ b/charts/admission-controller/templates/controller/webhooks.yaml
@@ -148,28 +148,6 @@ webhooks:
     service:
       name: {{ include "admission-controller.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
-      path: /mutate-policies-kubewarden-io-v1-policyserver
-  failurePolicy: Fail
-  name: mpolicyserver.kb.io
-  rules:
-    - apiGroups:
-        - policies.kubewarden.io
-      apiVersions:
-        - v1
-      operations:
-        - CREATE
-        - UPDATE
-      resources:
-        - policyservers
-  sideEffects: None
-- admissionReviewVersions:
-    - v1
-    - v1beta1
-  clientConfig:
-    caBundle: {{ $caBundle }}
-    service:
-      name: {{ include "admission-controller.webhookServiceName" . }}
-      namespace: {{ .Release.Namespace }}
       path: /mutate-policies-kubewarden-io-v1-admissionpolicy
   failurePolicy: Fail
   name: madmissionpolicy.kb.io

--- a/charts/admission-controller/tests/pre_delete_hook_test.yaml
+++ b/charts/admission-controller/tests/pre_delete_hook_test.yaml
@@ -1,0 +1,75 @@
+suite: pre-delete hook rendering
+templates:
+  - controller/pre-delete-hook.yaml
+release:
+  name: kubewarden
+  namespace: kubewarden
+tests:
+  - it: "should render a pre-delete Job that can be retried on failure"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-delete
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "1"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: hook-succeeded
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: kubewarden-admission-controller
+      - equal:
+          path: spec.template.spec.restartPolicy
+          value: OnFailure
+
+  - it: "should run the controller image in cleanup mode"
+    set:
+      image:
+        repository: "kubewarden/kubewarden-controller"
+        tag: v99.0.0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: kubewarden-cleanup
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: kubewarden/kubewarden-controller:v99.0.0$
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /controller
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - --cleanup
+            - --deployments-namespace=kubewarden
+            - --controller-deployment-name=kubewarden-admission-controller
+            - --zap-log-level=info
+
+  - it: "should prefix the image with the system default registry"
+    set:
+      global:
+        cattle:
+          systemDefaultRegistry: "registry.example.com"
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^registry.example.com/
+
+  - it: "should apply the configured security contexts and resources"
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+      - isNotNullOrEmpty:
+          path: spec.template.spec.containers[0].resources

--- a/charts/admission-controller/tests/webhooks_coverage_test.yaml
+++ b/charts/admission-controller/tests/webhooks_coverage_test.yaml
@@ -64,8 +64,6 @@ tests:
           path: webhooks[2].clientConfig.caBundle
       - isNotNullOrEmpty:
           path: webhooks[3].clientConfig.caBundle
-      - isNotNullOrEmpty:
-          path: webhooks[4].clientConfig.caBundle
 
   - it: "all validating webhooks should have caBundle injected"
     documentSelector:
@@ -166,14 +164,14 @@ tests:
 
   # ── Group 7: webhook count must match what controller-gen produces ──
 
-  - it: "MutatingWebhookConfiguration should have exactly 5 webhooks"
+  - it: "MutatingWebhookConfiguration should have exactly 4 webhooks"
     documentSelector:
       path: kind
       value: MutatingWebhookConfiguration
     asserts:
       - lengthEqual:
           path: webhooks
-          count: 5
+          count: 4
 
   - it: "ValidatingWebhookConfiguration should have exactly 5 webhooks"
     documentSelector:
@@ -213,11 +211,6 @@ tests:
           any: true
           content:
             name: mclusteradmissionpolicygroup.kb.io
-      - contains:
-          path: webhooks
-          any: true
-          content:
-            name: mpolicyserver.kb.io
 
   - it: "MutatingWebhookConfiguration should have correct service paths for all webhooks"
     documentSelector:
@@ -225,7 +218,7 @@ tests:
       value: MutatingWebhookConfiguration
     asserts:
       # Order matches webhooks.yaml: clusteradmissionpolicy, clusteradmissionpolicygroup,
-      # policyserver, admissionpolicy, admissionpolicygroup
+      # admissionpolicy, admissionpolicygroup
       - equal:
           path: webhooks[0].clientConfig.service.path
           value: /mutate-policies-kubewarden-io-v1-clusteradmissionpolicy
@@ -234,12 +227,9 @@ tests:
           value: /mutate-policies-kubewarden-io-v1-clusteradmissionpolicygroup
       - equal:
           path: webhooks[2].clientConfig.service.path
-          value: /mutate-policies-kubewarden-io-v1-policyserver
-      - equal:
-          path: webhooks[3].clientConfig.service.path
           value: /mutate-policies-kubewarden-io-v1-admissionpolicy
       - equal:
-          path: webhooks[4].clientConfig.service.path
+          path: webhooks[3].clientConfig.service.path
           value: /mutate-policies-kubewarden-io-v1-admissionpolicygroup
 
   # ── Group 8 (cont.): each validating webhook must be present with correct name and service path ──

--- a/charts/generated-webhooks-manifests.yaml
+++ b/charts/generated-webhooks-manifests.yaml
@@ -89,27 +89,6 @@ webhooks:
     resources:
     - clusteradmissionpolicygroups
   sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /mutate-policies-kubewarden-io-v1-policyserver
-  failurePolicy: Fail
-  name: mpolicyserver.kb.io
-  rules:
-  - apiGroups:
-    - policies.kubewarden.io
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - policyservers
-  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -48,6 +48,7 @@ import (
 
 	policiesv1 "github.com/kubewarden/adm-controller/api/policies/v1"
 	"github.com/kubewarden/adm-controller/api/policies/v1alpha2"
+	"github.com/kubewarden/adm-controller/internal/cleanup"
 	"github.com/kubewarden/adm-controller/internal/constants"
 	"github.com/kubewarden/adm-controller/internal/controller"
 	"github.com/kubewarden/adm-controller/internal/featuregates"
@@ -117,6 +118,8 @@ func main() {
 	var openTelemetryClientCertificateSecret string
 	var openTelemetryCertificateSecret string
 	var imagePullSecretsFlag string
+	var cleanupMode bool
+	var controllerDeploymentName string
 
 	flag.StringVar(&mgrOpts.MetricsAddr, "metrics-bind-address", ":8088", "The address the controller-runtime metric endpoint binds to.")
 	flag.StringVar(&mgrOpts.ProbeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -160,6 +163,18 @@ func main() {
 			"WARNING: enabling this increases the attack surface by exposing webhook endpoints "+
 			"on the host network and giving pods visibility of all node network interfaces. "+
 			"Use only when the Kubernetes API server cannot reach pod-network webhook endpoints.")
+	flag.BoolVar(&cleanupMode,
+		"cleanup",
+		false,
+		"Run in cleanup mode instead of starting the controller manager. "+
+			"Used by the Helm chart pre-delete hook: deletes the controller Deployment, "+
+			"the Kubewarden webhook configurations, the chart-managed default resources and "+
+			"the resources backing the policy servers, and strips the Kubewarden finalizers "+
+			"from the kept Kubewarden custom resources.")
+	flag.StringVar(&controllerDeploymentName,
+		"controller-deployment-name",
+		"",
+		"The name of the controller Deployment to delete in cleanup mode.")
 
 	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
@@ -167,6 +182,14 @@ func main() {
 	mgrOpts.EnableMutualTLS = config.ClientCAConfigMapName != ""
 	config.ImagePullSecrets = parseImagePullSecrets(imagePullSecretsFlag)
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	if cleanupMode {
+		if err := runCleanup(mgrOpts.DeploymentsNamespace, controllerDeploymentName); err != nil {
+			setupLog.Error(err, "cleanup failed")
+			retcode = 1
+		}
+		return
+	}
 
 	// Validate --webhook-server-port range.
 	if int64(mgrOpts.WebhookServerPort) < minAllowedPort || int64(mgrOpts.WebhookServerPort) > maxAllowedPort {
@@ -299,6 +322,32 @@ func main() {
 		retcode = 1
 		return
 	}
+}
+
+// runCleanup runs the uninstall cleanup performed by the Helm chart
+// pre-delete hook, using a plain client instead of a manager: no leader
+// election, no webhook server, no metrics.
+func runCleanup(deploymentsNamespace, controllerDeploymentName string) error {
+	if deploymentsNamespace == "" {
+		return errors.New("--deployments-namespace must be provided in cleanup mode")
+	}
+	if controllerDeploymentName == "" {
+		return errors.New("--controller-deployment-name must be provided in cleanup mode")
+	}
+
+	k8sClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("failed to create the client: %w", err)
+	}
+
+	err = cleanup.Run(ctrl.SetupSignalHandler(), k8sClient, ctrl.Log.WithName("cleanup"), cleanup.Options{
+		DeploymentsNamespace:     deploymentsNamespace,
+		ControllerDeploymentName: controllerDeploymentName,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to run the cleanup: %w", err)
+	}
+	return nil
 }
 
 func setupManager(mgrOpts ManagerOptions) (ctrl.Manager, error) {

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -1,0 +1,309 @@
+// Package cleanup implements the cleanup logic run by the Helm chart
+// pre-delete hook when the Kubewarden stack is uninstalled.
+//
+// The uninstall must leave behind ONLY the Kubewarden CRDs and the
+// user-defined PolicyServer/policy CRs, without their Kubewarden
+// finalizers, so that:
+//   - nothing keeps evaluating admission requests without a controller
+//     reconciling it,
+//   - a future re-installation of the chart can adopt and reconcile the kept
+//     custom resources again,
+//   - the kept custom resources (and their CRDs) can be deleted with plain
+//     kubectl commands, without a running controller honoring finalizers.
+package cleanup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	policiesv1 "github.com/kubewarden/adm-controller/api/policies/v1"
+	"github.com/kubewarden/adm-controller/internal/constants"
+)
+
+// The wait tuning is defined as variables so the tests can shorten it.
+//
+//nolint:gochecknoglobals // overridden by the tests
+var (
+	// controllerPodsGoneTimeout is the maximum time to wait for the
+	// controller pods to be fully terminated after their Deployment is
+	// deleted.
+	controllerPodsGoneTimeout = 3 * time.Minute
+	// controllerPodsGonePollInterval is the poll interval used while waiting
+	// for the controller pods to be gone.
+	controllerPodsGonePollInterval = 1 * time.Second
+)
+
+// Options configures the cleanup run.
+type Options struct {
+	// DeploymentsNamespace is the namespace where the Kubewarden stack (the
+	// controller, policyservers, etc) is deployed.
+	DeploymentsNamespace string
+	// ControllerDeploymentName is the name of the controller Deployment to
+	// delete before cleaning up the resources it manages.
+	ControllerDeploymentName string
+}
+
+func Run(ctx context.Context, c client.Client, log logr.Logger, opts Options) error {
+	if opts.DeploymentsNamespace == "" {
+		return errors.New("the deployments namespace must be provided")
+	}
+	if opts.ControllerDeploymentName == "" {
+		return errors.New("the controller deployment name must be provided")
+	}
+
+	// Delete the controller Deployment and wait for its pods to be gone, so
+	// nothing recreates the resources removed by the following steps and
+	// nothing re-adds the finalizers stripped below.
+	log.Info("deleting the controller deployment", "namespace", opts.DeploymentsNamespace, "name", opts.ControllerDeploymentName)
+	if err := deleteControllerDeployment(ctx, c, opts); err != nil {
+		return fmt.Errorf("failed to delete the controller deployment: %w", err)
+	}
+
+	// Delete every Kubewarden webhook configuration: the policies webhook
+	// configurations, so no orphaned webhook keeps intercepting admission
+	// requests, and the controller's own webhook configurations, so the
+	// following writes to the Kubewarden custom resources are not rejected
+	// by webhooks pointing to the deleted controller.
+	log.Info("deleting the Kubewarden webhook configurations")
+	if err := deleteWebhookConfigurations(ctx, c); err != nil {
+		return fmt.Errorf("failed to delete the Kubewarden webhook configurations: %w", err)
+	}
+
+	// Strip the Kubewarden finalizers from all the Kubewarden custom
+	// resources. The controller is gone, so nothing else would honor them.
+	log.Info("stripping the Kubewarden finalizers from the Kubewarden custom resources")
+	if err := stripKubewardenFinalizers(ctx, c); err != nil {
+		return fmt.Errorf("failed to strip the Kubewarden finalizers: %w", err)
+	}
+
+	// Delete the custom resources managed by the chart (the default
+	// PolicyServer and the recommended policies). The user-defined custom
+	// resources are kept: the controller reconciles them again on
+	// re-installation.
+	log.Info("deleting the default Kubewarden custom resources managed by the chart")
+	if err := deleteDefaultsResources(ctx, c); err != nil {
+		return fmt.Errorf("failed to delete the default Kubewarden custom resources: %w", err)
+	}
+
+	// Delete the resources backing the policy servers (Deployments,
+	// Services, Secrets, ConfigMaps and PodDisruptionBudgets).
+	log.Info("deleting the resources backing the policy servers", "namespace", opts.DeploymentsNamespace)
+	if err := deletePolicyServerResources(ctx, c, opts.DeploymentsNamespace); err != nil {
+		return fmt.Errorf("failed to delete the resources backing the policy servers: %w", err)
+	}
+
+	log.Info("cleanup completed")
+	return nil
+}
+
+// deleteControllerDeployment deletes the controller Deployment and waits
+// until no controller pod is left in the namespace.
+func deleteControllerDeployment(ctx context.Context, c client.Client, opts Options) error {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      opts.ControllerDeploymentName,
+			Namespace: opts.DeploymentsNamespace,
+		},
+	}
+	if err := c.Delete(ctx, deployment); client.IgnoreNotFound(err) != nil {
+		return fmt.Errorf("failed to delete deployment %q: %w", opts.ControllerDeploymentName, err)
+	}
+
+	// Waiting on the pods (instead of relying on a delete foreground cascade)
+	// guarantees that no controller process can interfere with the next steps.
+	err := wait.PollUntilContextTimeout(ctx, controllerPodsGonePollInterval, controllerPodsGoneTimeout, true, func(ctx context.Context) (bool, error) {
+		podList := &corev1.PodList{}
+		if err := c.List(ctx, podList,
+			client.InNamespace(opts.DeploymentsNamespace),
+			client.MatchingLabels{constants.ComponentLabelKey: constants.ComponentControllerLabelValue},
+		); err != nil {
+			return false, fmt.Errorf("failed to list the controller pods: %w", err)
+		}
+		return len(podList.Items) == 0, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to wait for the controller pods to be gone: %w", err)
+	}
+	return nil
+}
+
+// deleteWebhookConfigurations deletes all the ValidatingWebhookConfigurations
+// and MutatingWebhookConfigurations labeled as part of Kubewarden.
+func deleteWebhookConfigurations(ctx context.Context, c client.Client) error {
+	partOfKubewarden := client.MatchingLabels{constants.PartOfLabelKey: constants.PartOfLabelValue}
+
+	for _, list := range []client.ObjectList{
+		&admissionregistrationv1.ValidatingWebhookConfigurationList{},
+		&admissionregistrationv1.MutatingWebhookConfigurationList{},
+	} {
+		if err := deleteEachListItem(ctx, c, list, partOfKubewarden); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// kubewardenResourceLists returns fresh list objects for all the Kubewarden
+// custom resource types.
+func kubewardenResourceLists() []client.ObjectList {
+	return []client.ObjectList{
+		&policiesv1.PolicyServerList{},
+		&policiesv1.ClusterAdmissionPolicyList{},
+		&policiesv1.AdmissionPolicyList{},
+		&policiesv1.ClusterAdmissionPolicyGroupList{},
+		&policiesv1.AdmissionPolicyGroupList{},
+	}
+}
+
+// stripKubewardenFinalizers removes the Kubewarden finalizers from all the
+// Kubewarden custom resources, in every namespace. Only the Kubewarden
+// finalizers are removed: finalizers set by other tooling are left untouched.
+func stripKubewardenFinalizers(ctx context.Context, c client.Client) error {
+	for _, list := range kubewardenResourceLists() {
+		if err := c.List(ctx, list); err != nil {
+			return fmt.Errorf("failed to list %T: %w", list, err)
+		}
+
+		if err := forEachListItem(list, func(obj client.Object) error {
+			return stripObjectKubewardenFinalizers(ctx, c, obj)
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// stripObjectKubewardenFinalizers removes the Kubewarden finalizers from the
+// given object, retrying on conflicts against the latest version.
+func stripObjectKubewardenFinalizers(ctx context.Context, c client.Client, obj client.Object) error {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("failed to get the object: %w", err)
+		}
+
+		changed := controllerutil.RemoveFinalizer(obj, constants.KubewardenFinalizer)
+		if controllerutil.RemoveFinalizer(obj, constants.KubewardenFinalizerPre114) {
+			changed = true
+		}
+		if !changed {
+			return nil
+		}
+
+		if err := c.Update(ctx, obj); err != nil {
+			// The object can legitimately disappear while being updated: once
+			// its finalizers are cleared, a pending deletion completes.
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("failed to update the object: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to strip the Kubewarden finalizers from %T %q: %w",
+			obj, client.ObjectKeyFromObject(obj), err)
+	}
+	return nil
+}
+
+// deleteDefaultsResources deletes the Kubewarden custom resources managed by
+// the chart (labeled by the defaults applier). Their Kubewarden finalizers
+// have already been stripped, so the deletion completes without the
+// controller.
+func deleteDefaultsResources(ctx context.Context, c client.Client) error {
+	managedByDefaults := client.MatchingLabels{constants.DefaultsManagedByLabelKey: constants.DefaultsManagedByLabelValue}
+	for _, list := range kubewardenResourceLists() {
+		if err := deleteEachListItem(ctx, c, list, managedByDefaults); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// deletePolicyServerResources deletes the resources backing the policy
+// servers in the deployments namespace. Everything is selected by the labels
+// set by the controller.
+func deletePolicyServerResources(ctx context.Context, c client.Client, namespace string) error {
+	inNamespace := client.InNamespace(namespace)
+	partOfKubewarden := client.MatchingLabels{constants.PartOfLabelKey: constants.PartOfLabelValue}
+
+	for _, list := range []client.ObjectList{
+		&appsv1.DeploymentList{},
+		&corev1.ServiceList{},
+		&corev1.SecretList{},
+		&corev1.ConfigMapList{},
+		&policyv1.PodDisruptionBudgetList{},
+	} {
+		if err := deleteEachListItem(ctx, c, list, inNamespace, partOfKubewarden); err != nil {
+			return err
+		}
+	}
+
+	// TODO: remove in the future
+	// ConfigMaps are additionally selected by the  "kubewarden/policy-server"
+	// label, which is the only label set on the ConfigMaps created by
+	// controllers v1.36: those ConfigMaps are relabeled on the first
+	// reconciliation after an upgrade, but the uninstall must also work when the
+	// controller never reconciled after the upgrade (e.g. it is crashlooping).
+	// The extra selector can be removed once upgrades from chart versions
+	// without the ConfigMap tracking labels are no longer supported
+	return deleteEachListItem(ctx, c, &corev1.ConfigMapList{}, inNamespace, client.HasLabels{constants.PolicyServerLabelKey})
+}
+
+// deleteEachListItem lists the objects matching the given options and deletes
+// them one by one.
+// We aren't using a collection deletion because:
+//   - The ServiceAccount running the cleanup is not granted the
+//     deletecollection verb for security reasons
+//   - Errors pinpoint exactly which object fails to delete
+//   - Number of objects is small enough
+func deleteEachListItem(ctx context.Context, c client.Client, list client.ObjectList, opts ...client.ListOption) error {
+	if err := c.List(ctx, list, opts...); err != nil {
+		return fmt.Errorf("failed to list %T: %w", list, err)
+	}
+
+	return forEachListItem(list, func(obj client.Object) error {
+		if err := c.Delete(ctx, obj); client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("failed to delete %T %q: %w",
+				obj, client.ObjectKeyFromObject(obj), err)
+		}
+		return nil
+	})
+}
+
+// forEachListItem runs the given function on every item of the list.
+func forEachListItem(list client.ObjectList, run func(obj client.Object) error) error {
+	items, err := apimeta.ExtractList(list)
+	if err != nil {
+		return fmt.Errorf("failed to extract the items of %T: %w", list, err)
+	}
+
+	for _, item := range items {
+		obj, ok := item.(client.Object)
+		if !ok {
+			return fmt.Errorf("unexpected list item type %T", item)
+		}
+		if runErr := run(obj); runErr != nil {
+			return runErr
+		}
+	}
+	return nil
+}

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -143,7 +143,12 @@ func deleteControllerDeployment(ctx context.Context, c client.Client, opts Optio
 }
 
 // deleteWebhookConfigurations deletes all the ValidatingWebhookConfigurations
-// and MutatingWebhookConfigurations labeled as part of Kubewarden.
+// and MutatingWebhookConfigurations labeled as part of Kubewarden. The broad
+// "app.kubernetes.io/part-of=kubewarden" selector is intentional: the
+// policies webhook configurations carry no other label, and the controller's
+// own webhook configurations must be deleted here as well, so the following
+// writes to the Kubewarden custom resources are not rejected by fail-closed
+// webhooks pointing to the deleted controller.
 func deleteWebhookConfigurations(ctx context.Context, c client.Client) error {
 	partOfKubewarden := client.MatchingLabels{constants.PartOfLabelKey: constants.PartOfLabelValue}
 
@@ -239,11 +244,18 @@ func deleteDefaultsResources(ctx context.Context, c client.Client) error {
 }
 
 // deletePolicyServerResources deletes the resources backing the policy
-// servers in the deployments namespace. Everything is selected by the labels
-// set by the controller.
+// servers in the deployments namespace. Everything is selected by the
+// "app.kubernetes.io/part-of=kubewarden" and
+// "app.kubernetes.io/component=policy-server" labels set by the controller
+// (the same selection used by the certificate rotation), so the chart-managed
+// resources carrying only the part-of label (e.g. the controller Secrets and
+// Services) are left for Helm to delete right after this hook.
 func deletePolicyServerResources(ctx context.Context, c client.Client, namespace string) error {
 	inNamespace := client.InNamespace(namespace)
-	partOfKubewarden := client.MatchingLabels{constants.PartOfLabelKey: constants.PartOfLabelValue}
+	policyServerLabels := client.MatchingLabels{
+		constants.PartOfLabelKey:    constants.PartOfLabelValue,
+		constants.ComponentLabelKey: constants.ComponentPolicyServerLabelValue,
+	}
 
 	for _, list := range []client.ObjectList{
 		&appsv1.DeploymentList{},
@@ -252,7 +264,7 @@ func deletePolicyServerResources(ctx context.Context, c client.Client, namespace
 		&corev1.ConfigMapList{},
 		&policyv1.PodDisruptionBudgetList{},
 	} {
-		if err := deleteEachListItem(ctx, c, list, inNamespace, partOfKubewarden); err != nil {
+		if err := deleteEachListItem(ctx, c, list, inNamespace, policyServerLabels); err != nil {
 			return err
 		}
 	}

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -1,0 +1,532 @@
+package cleanup
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	policiesv1 "github.com/kubewarden/adm-controller/api/policies/v1"
+	"github.com/kubewarden/adm-controller/internal/constants"
+)
+
+// k8sClient is the client for the envtest environment shared by all the
+// tests. The tests are isolated from each other by using dedicated
+// namespaces and unique names for the cluster-scoped resources.
+var k8sClient client.Client
+
+// thirdPartyFinalizer simulates a finalizer set by other tooling on a
+// Kubewarden custom resource. The cleanup must not remove it.
+const thirdPartyFinalizer = "example.com/third-party-finalizer"
+
+func TestMain(m *testing.M) {
+	crdsDir := filepath.Join("..", "..", "charts", "admission-controller", "templates", "crds")
+	testEnv := &envtest.Environment{
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join(crdsDir, "policies.kubewarden.io_admissionpolicies.yaml"),
+				filepath.Join(crdsDir, "policies.kubewarden.io_admissionpolicygroups.yaml"),
+				filepath.Join(crdsDir, "policies.kubewarden.io_clusteradmissionpolicies.yaml"),
+				filepath.Join(crdsDir, "policies.kubewarden.io_clusteradmissionpolicygroups.yaml"),
+				filepath.Join(crdsDir, "policies.kubewarden.io_policyservers.yaml"),
+			},
+		},
+	}
+
+	restConfig, err := testEnv.Start()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start the test environment: %v\n", err)
+		os.Exit(1)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to add the client-go types to the scheme: %v\n", err)
+		os.Exit(1)
+	}
+	if err := policiesv1.AddToScheme(scheme); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to add the Kubewarden types to the scheme: %v\n", err)
+		os.Exit(1)
+	}
+
+	k8sClient, err = client.New(restConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create the client: %v\n", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	if err := testEnv.Stop(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to stop the test environment: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(code)
+}
+
+func TestRunOptionsValidation(t *testing.T) {
+	err := Run(t.Context(), nil, logr.Discard(), Options{
+		ControllerDeploymentName: "kubewarden-controller",
+	})
+	require.ErrorContains(t, err, "deployments namespace")
+
+	err = Run(t.Context(), nil, logr.Discard(), Options{
+		DeploymentsNamespace: "kubewarden",
+	})
+	require.ErrorContains(t, err, "controller deployment name")
+}
+
+func TestDeleteControllerDeployment(t *testing.T) {
+	ctx := t.Context()
+	namespace := "cleanup-test-controller-deployment"
+	deploymentName := "kubewarden-controller"
+	createNamespace(ctx, t, namespace)
+	shortenPodsGoneWait(t)
+
+	createDeployment(ctx, t, namespace, deploymentName, map[string]string{
+		constants.ComponentLabelKey: constants.ComponentControllerLabelValue,
+	})
+
+	// A controller pod that never terminates: envtest has no kubelet, so the
+	// pod object stays around until it is forcefully deleted.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "controller-pod",
+			Namespace: namespace,
+			Labels: map[string]string{
+				constants.ComponentLabelKey: constants.ComponentControllerLabelValue,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "controller", Image: "controller:test"},
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, pod))
+
+	opts := Options{DeploymentsNamespace: namespace, ControllerDeploymentName: deploymentName}
+
+	// While a controller pod is still around, the wait must time out: the
+	// following cleanup steps are only safe once no controller process can
+	// recreate resources or re-add finalizers.
+	err := deleteControllerDeployment(ctx, k8sClient, opts)
+	require.ErrorContains(t, err, "failed to wait for the controller pods to be gone")
+
+	// The Deployment deletion itself must have been issued regardless.
+	assertNotFound(ctx, t, &appsv1.Deployment{}, namespace, deploymentName)
+
+	require.NoError(t, k8sClient.Delete(ctx, pod, client.GracePeriodSeconds(0)))
+	require.NoError(t, deleteControllerDeployment(ctx, k8sClient, opts))
+
+	// Must be idempotent
+	require.NoError(t, deleteControllerDeployment(ctx, k8sClient, opts))
+}
+
+func TestDeleteWebhookConfigurations(t *testing.T) {
+	ctx := t.Context()
+
+	partOfKubewardenLabels := map[string]string{
+		constants.PartOfLabelKey: constants.PartOfLabelValue,
+	}
+	require.NoError(t, k8sClient.Create(ctx, &admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "cleanup-test-webhook-validating",
+			Labels: partOfKubewardenLabels,
+		},
+	}))
+	require.NoError(t, k8sClient.Create(ctx, &admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "cleanup-test-webhook-mutating",
+			Labels: partOfKubewardenLabels,
+		},
+	}))
+	// A webhook configuration not related to Kubewarden must be kept.
+	require.NoError(t, k8sClient.Create(ctx, &admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cleanup-test-webhook-unrelated",
+		},
+	}))
+
+	require.NoError(t, deleteWebhookConfigurations(ctx, k8sClient))
+
+	assertNotFound(ctx, t, &admissionregistrationv1.ValidatingWebhookConfiguration{}, "", "cleanup-test-webhook-validating")
+	assertNotFound(ctx, t, &admissionregistrationv1.MutatingWebhookConfiguration{}, "", "cleanup-test-webhook-mutating")
+	assertFound(ctx, t, &admissionregistrationv1.ValidatingWebhookConfiguration{}, "", "cleanup-test-webhook-unrelated")
+
+	// Must be idempotent
+	require.NoError(t, deleteWebhookConfigurations(ctx, k8sClient))
+}
+
+func TestStripKubewardenFinalizers(t *testing.T) {
+	ctx := t.Context()
+	namespace := "cleanup-test-strip"
+	createNamespace(ctx, t, namespace)
+
+	policyServer := policiesv1.NewPolicyServerFactory().
+		WithName("cleanup-test-strip-policy-server").
+		Build()
+	policyServer.SetFinalizers([]string{
+		constants.KubewardenFinalizer,
+		constants.KubewardenFinalizerPre114,
+		thirdPartyFinalizer,
+	})
+	require.NoError(t, k8sClient.Create(ctx, policyServer))
+
+	clusterPolicy := policiesv1.NewClusterAdmissionPolicyFactory().
+		WithName("cleanup-test-strip-cluster-policy").
+		Build()
+	clusterPolicy.SetFinalizers([]string{constants.KubewardenFinalizer})
+	require.NoError(t, k8sClient.Create(ctx, clusterPolicy))
+
+	namespacedPolicy := policiesv1.NewAdmissionPolicyFactory().
+		WithName("cleanup-test-strip-policy").
+		WithNamespace(namespace).
+		Build()
+	namespacedPolicy.SetFinalizers([]string{constants.KubewardenFinalizer})
+	require.NoError(t, k8sClient.Create(ctx, namespacedPolicy))
+
+	clusterGroup := policiesv1.NewClusterAdmissionPolicyGroupFactory().
+		WithName("cleanup-test-strip-cluster-group").
+		Build()
+	clusterGroup.SetFinalizers([]string{constants.KubewardenFinalizerPre114})
+	require.NoError(t, k8sClient.Create(ctx, clusterGroup))
+
+	namespacedGroup := policiesv1.NewAdmissionPolicyGroupFactory().
+		WithName("cleanup-test-strip-group").
+		WithNamespace(namespace).
+		Build()
+	namespacedGroup.SetFinalizers([]string{
+		constants.KubewardenFinalizer,
+		constants.KubewardenFinalizerPre114,
+	})
+	require.NoError(t, k8sClient.Create(ctx, namespacedGroup))
+
+	// A resource with only third-party finalizers must be left untouched.
+	untouchedPolicy := policiesv1.NewClusterAdmissionPolicyFactory().
+		WithName("cleanup-test-strip-untouched-policy").
+		Build()
+	untouchedPolicy.SetFinalizers([]string{thirdPartyFinalizer})
+	require.NoError(t, k8sClient.Create(ctx, untouchedPolicy))
+
+	require.NoError(t, stripKubewardenFinalizers(ctx, k8sClient))
+
+	assertFinalizers(ctx, t, &policiesv1.PolicyServer{}, "", policyServer.GetName(), []string{thirdPartyFinalizer})
+	assertFinalizers(ctx, t, &policiesv1.ClusterAdmissionPolicy{}, "", clusterPolicy.GetName(), nil)
+	assertFinalizers(ctx, t, &policiesv1.AdmissionPolicy{}, namespace, namespacedPolicy.GetName(), nil)
+	assertFinalizers(ctx, t, &policiesv1.ClusterAdmissionPolicyGroup{}, "", clusterGroup.GetName(), nil)
+	assertFinalizers(ctx, t, &policiesv1.AdmissionPolicyGroup{}, namespace, namespacedGroup.GetName(), nil)
+	assertFinalizers(ctx, t, &policiesv1.ClusterAdmissionPolicy{}, "", untouchedPolicy.GetName(), []string{thirdPartyFinalizer})
+
+	// Must be idempotent
+	require.NoError(t, stripKubewardenFinalizers(ctx, k8sClient))
+}
+
+func TestDeleteDefaultsResources(t *testing.T) {
+	ctx := t.Context()
+
+	defaultsLabels := map[string]string{
+		constants.DefaultsManagedByLabelKey: constants.DefaultsManagedByLabelValue,
+	}
+
+	// A defaults resource without finalizers: it must be deleted right away.
+	defaultPolicyServer := policiesv1.NewPolicyServerFactory().
+		WithName("cleanup-test-defaults-policy-server").
+		WithoutFinalizers().
+		Build()
+	defaultPolicyServer.SetLabels(defaultsLabels)
+	require.NoError(t, k8sClient.Create(ctx, defaultPolicyServer))
+
+	// A defaults resource with the Kubewarden finalizer still set: the
+	// deletion is issued but does not complete. This documents why Run
+	// must strip the Kubewarden finalizers before deleting the defaults.
+	defaultPolicy := policiesv1.NewClusterAdmissionPolicyFactory().
+		WithName("cleanup-test-defaults-policy").
+		Build()
+	defaultPolicy.SetLabels(defaultsLabels)
+	defaultPolicy.SetFinalizers([]string{constants.KubewardenFinalizer})
+	require.NoError(t, k8sClient.Create(ctx, defaultPolicy))
+
+	// A user resource, not labeled as managed defaults: it must be kept.
+	userPolicyServer := policiesv1.NewPolicyServerFactory().
+		WithName("cleanup-test-defaults-user-policy-server").
+		WithoutFinalizers().
+		Build()
+	require.NoError(t, k8sClient.Create(ctx, userPolicyServer))
+
+	require.NoError(t, deleteDefaultsResources(ctx, k8sClient))
+
+	assertNotFound(ctx, t, &policiesv1.PolicyServer{}, "", defaultPolicyServer.GetName())
+
+	terminatingPolicy := &policiesv1.ClusterAdmissionPolicy{}
+	assertFound(ctx, t, terminatingPolicy, "", defaultPolicy.GetName())
+	require.NotNil(t, terminatingPolicy.GetDeletionTimestamp(),
+		"the deletion of a defaults resource with finalizers should be issued but not complete")
+
+	keptPolicyServer := &policiesv1.PolicyServer{}
+	assertFound(ctx, t, keptPolicyServer, "", userPolicyServer.GetName())
+	require.Nil(t, keptPolicyServer.GetDeletionTimestamp(), "user resources should be kept")
+
+	// Must be idempotent
+	require.NoError(t, deleteDefaultsResources(ctx, k8sClient))
+}
+
+func TestDeletePolicyServerResources(t *testing.T) {
+	ctx := t.Context()
+	namespace := "cleanup-test-policy-server-resources"
+	resourcesName := "policy-server-cleanup-test"
+	createNamespace(ctx, t, namespace)
+
+	policyServerLabels := map[string]string{
+		constants.PartOfLabelKey:       constants.PartOfLabelValue,
+		constants.ComponentLabelKey:    constants.ComponentPolicyServerLabelValue,
+		constants.PolicyServerLabelKey: "cleanup-test",
+	}
+
+	createDeployment(ctx, t, namespace, resourcesName, policyServerLabels)
+
+	require.NoError(t, k8sClient.Create(ctx, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resourcesName,
+			Namespace: namespace,
+			Labels:    policyServerLabels,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Port: 443}},
+		},
+	}))
+
+	require.NoError(t, k8sClient.Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resourcesName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				constants.PartOfLabelKey:    constants.PartOfLabelValue,
+				constants.ComponentLabelKey: constants.ComponentPolicyServerLabelValue,
+			},
+		},
+	}))
+
+	require.NoError(t, k8sClient.Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resourcesName,
+			Namespace: namespace,
+			Labels:    policyServerLabels,
+		},
+	}))
+
+	// A ConfigMap created by an older version of the controller, carrying
+	// only the "kubewarden/policy-server" label.
+	require.NoError(t, k8sClient.Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "policy-server-old-labels",
+			Namespace: namespace,
+			Labels: map[string]string{
+				constants.PolicyServerLabelKey: "cleanup-test",
+			},
+		},
+	}))
+
+	minAvailable := intstr.FromInt32(1)
+	require.NoError(t, k8sClient.Create(ctx, &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resourcesName,
+			Namespace: namespace,
+			Labels:    policyServerLabels,
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			MinAvailable: &minAvailable,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "policy-server"},
+			},
+		},
+	}))
+
+	// Resources not related to Kubewarden must be kept.
+	require.NoError(t, k8sClient.Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "unrelated-configmap", Namespace: namespace},
+	}))
+	require.NoError(t, k8sClient.Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "unrelated-secret", Namespace: namespace},
+	}))
+
+	// A policy server resource with a third-party finalizer: the deletion is
+	// issued and the cleanup moves on without waiting or failing. Completing
+	// the deletion is the responsibility of whoever owns the finalizer.
+	require.NoError(t, k8sClient.Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "policy-server-third-party-finalizer",
+			Namespace:  namespace,
+			Labels:     policyServerLabels,
+			Finalizers: []string{thirdPartyFinalizer},
+		},
+	}))
+
+	require.NoError(t, deletePolicyServerResources(ctx, k8sClient, namespace))
+
+	assertNotFound(ctx, t, &appsv1.Deployment{}, namespace, resourcesName)
+	assertNotFound(ctx, t, &corev1.Service{}, namespace, resourcesName)
+	assertNotFound(ctx, t, &corev1.Secret{}, namespace, resourcesName)
+	assertNotFound(ctx, t, &corev1.ConfigMap{}, namespace, resourcesName)
+	assertNotFound(ctx, t, &corev1.ConfigMap{}, namespace, "policy-server-old-labels")
+	assertNotFound(ctx, t, &policyv1.PodDisruptionBudget{}, namespace, resourcesName)
+	assertFound(ctx, t, &corev1.ConfigMap{}, namespace, "unrelated-configmap")
+	assertFound(ctx, t, &corev1.Secret{}, namespace, "unrelated-secret")
+
+	terminatingConfigMap := &corev1.ConfigMap{}
+	assertFound(ctx, t, terminatingConfigMap, namespace, "policy-server-third-party-finalizer")
+	require.NotNil(t, terminatingConfigMap.GetDeletionTimestamp(),
+		"the deletion of a resource with a third-party finalizer should be issued but not complete")
+
+	// Must be idempotent
+	require.NoError(t, deletePolicyServerResources(ctx, k8sClient, namespace))
+}
+
+// TestRun verifies the composition of the cleanup steps, with one resource
+// per category. The behavior of every step is covered by the per-step tests.
+func TestRun(t *testing.T) {
+	ctx := t.Context()
+	namespace := "cleanup-test-run"
+	deploymentName := "kubewarden-controller"
+	createNamespace(ctx, t, namespace)
+	shortenPodsGoneWait(t)
+
+	createDeployment(ctx, t, namespace, deploymentName, map[string]string{
+		constants.ComponentLabelKey: constants.ComponentControllerLabelValue,
+	})
+
+	require.NoError(t, k8sClient.Create(ctx, &admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cleanup-test-run-webhook",
+			Labels: map[string]string{
+				constants.PartOfLabelKey: constants.PartOfLabelValue,
+			},
+		},
+	}))
+
+	// A defaults resource with the Kubewarden finalizer: its full removal
+	// proves that Run strips the finalizers before deleting the defaults.
+	defaultPolicyServer := policiesv1.NewPolicyServerFactory().
+		WithName("cleanup-test-run-default-policy-server").
+		Build()
+	defaultPolicyServer.SetLabels(map[string]string{
+		constants.DefaultsManagedByLabelKey: constants.DefaultsManagedByLabelValue,
+	})
+	defaultPolicyServer.SetFinalizers([]string{constants.KubewardenFinalizer})
+	require.NoError(t, k8sClient.Create(ctx, defaultPolicyServer))
+
+	userPolicyServer := policiesv1.NewPolicyServerFactory().
+		WithName("cleanup-test-run-user-policy-server").
+		Build()
+	userPolicyServer.SetFinalizers([]string{constants.KubewardenFinalizer, thirdPartyFinalizer})
+	require.NoError(t, k8sClient.Create(ctx, userPolicyServer))
+
+	createDeployment(ctx, t, namespace, "policy-server-cleanup-test-run", map[string]string{
+		constants.PartOfLabelKey:    constants.PartOfLabelValue,
+		constants.ComponentLabelKey: constants.ComponentPolicyServerLabelValue,
+	})
+
+	opts := Options{DeploymentsNamespace: namespace, ControllerDeploymentName: deploymentName}
+	require.NoError(t, Run(ctx, k8sClient, logr.Discard(), opts))
+
+	assertNotFound(ctx, t, &appsv1.Deployment{}, namespace, deploymentName)
+	assertNotFound(ctx, t, &admissionregistrationv1.ValidatingWebhookConfiguration{}, "", "cleanup-test-run-webhook")
+	assertNotFound(ctx, t, &policiesv1.PolicyServer{}, "", defaultPolicyServer.GetName())
+	assertFinalizers(ctx, t, &policiesv1.PolicyServer{}, "", userPolicyServer.GetName(), []string{thirdPartyFinalizer})
+	assertNotFound(ctx, t, &appsv1.Deployment{}, namespace, "policy-server-cleanup-test-run")
+
+	// The cleanup must be idempotent.
+	require.NoError(t, Run(ctx, k8sClient, logr.Discard(), opts))
+}
+
+// createNamespace creates the given namespace. Namespaces are never deleted:
+// envtest cannot garbage collect them, so every test uses a dedicated one.
+func createNamespace(ctx context.Context, t *testing.T, name string) {
+	t.Helper()
+
+	require.NoError(t, k8sClient.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}))
+}
+
+// createDeployment creates a minimal valid Deployment with the given labels.
+func createDeployment(ctx context.Context, t *testing.T, namespace, name string, labels map[string]string) {
+	t.Helper()
+
+	require.NoError(t, k8sClient.Create(ctx, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": name},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": name},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "container", Image: "image:test"},
+					},
+				},
+			},
+		},
+	}))
+}
+
+// shortenPodsGoneWait shrinks the controller pods wait tuning for the
+// duration of the test, restoring it afterwards.
+func shortenPodsGoneWait(t *testing.T) {
+	t.Helper()
+
+	originalTimeout := controllerPodsGoneTimeout
+	originalPollInterval := controllerPodsGonePollInterval
+	controllerPodsGoneTimeout = 2 * time.Second
+	controllerPodsGonePollInterval = 50 * time.Millisecond
+	t.Cleanup(func() {
+		controllerPodsGoneTimeout = originalTimeout
+		controllerPodsGonePollInterval = originalPollInterval
+	})
+}
+
+func assertNotFound(ctx context.Context, t *testing.T, obj client.Object, namespace, name string) {
+	t.Helper()
+
+	err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, obj)
+	require.Truef(t, apierrors.IsNotFound(err), "%T %s/%s should be deleted, got: %v", obj, namespace, name, err)
+}
+
+func assertFound(ctx context.Context, t *testing.T, obj client.Object, namespace, name string) {
+	t.Helper()
+
+	err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, obj)
+	require.NoErrorf(t, err, "%T %s/%s should be kept", obj, namespace, name)
+}
+
+// assertFinalizers asserts that the object exists and carries exactly the
+// given finalizers.
+func assertFinalizers(ctx context.Context, t *testing.T, obj client.Object, namespace, name string, finalizers []string) {
+	t.Helper()
+
+	assertFound(ctx, t, obj, namespace, name)
+	require.Equalf(t, finalizers, obj.GetFinalizers(), "unexpected finalizers on %T %s/%s", obj, namespace, name)
+}

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -366,6 +366,28 @@ func TestDeletePolicyServerResources(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "unrelated-secret", Namespace: namespace},
 	}))
 
+	// Chart-managed resources are part of Kubewarden but do not back a
+	// policy server: they must be left for Helm to delete, not swept here.
+	require.NoError(t, k8sClient.Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubewarden-ca",
+			Namespace: namespace,
+			Labels: map[string]string{
+				constants.PartOfLabelKey:    constants.PartOfLabelValue,
+				constants.ComponentLabelKey: constants.ComponentControllerLabelValue,
+			},
+		},
+	}))
+	require.NoError(t, k8sClient.Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubewarden-defaults",
+			Namespace: namespace,
+			Labels: map[string]string{
+				constants.PartOfLabelKey: constants.PartOfLabelValue,
+			},
+		},
+	}))
+
 	// A policy server resource with a third-party finalizer: the deletion is
 	// issued and the cleanup moves on without waiting or failing. Completing
 	// the deletion is the responsibility of whoever owns the finalizer.
@@ -388,6 +410,8 @@ func TestDeletePolicyServerResources(t *testing.T) {
 	assertNotFound(ctx, t, &policyv1.PodDisruptionBudget{}, namespace, resourcesName)
 	assertFound(ctx, t, &corev1.ConfigMap{}, namespace, "unrelated-configmap")
 	assertFound(ctx, t, &corev1.Secret{}, namespace, "unrelated-secret")
+	assertFound(ctx, t, &corev1.Secret{}, namespace, "kubewarden-ca")
+	assertFound(ctx, t, &corev1.ConfigMap{}, namespace, "kubewarden-defaults")
 
 	terminatingConfigMap := &corev1.ConfigMap{}
 	assertFound(ctx, t, terminatingConfigMap, namespace, "policy-server-third-party-finalizer")

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -45,6 +45,9 @@ const (
 	PartOfLabelKey                  = "app.kubernetes.io/part-of"
 	PartOfLabelValue                = "kubewarden"
 
+	// ComponentControllerLabelValue is set via Helm chart templates.
+	ComponentControllerLabelValue = "controller"
+
 	ManagedByKey = "app.kubernetes.io/managed-by"
 	// ManagedByKeyLabelValue is set via Helm chart templates.
 	ManagedByKeyLabelValue = "kubewarden-controller"

--- a/internal/controller/policyserver_controller.go
+++ b/internal/controller/policyserver_controller.go
@@ -110,6 +110,18 @@ func (r *PolicyServerReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return r.reconcileDeletion(ctx, &policyServer)
 	}
 
+	// Ensure the kubewarden finalizer is present before any resource backing
+	// the PolicyServer is created and once we know it's not being deleted.
+	// This also covers PolicyServers kept across a Helm uninstall/reinstall
+	// cycle, whose finalizers are stripped by the uninstall cleanup and regained
+	// here.
+	if !controllerutil.ContainsFinalizer(&policyServer, constants.KubewardenFinalizer) {
+		controllerutil.AddFinalizer(&policyServer, constants.KubewardenFinalizer)
+		if err := r.Update(ctx, &policyServer); err != nil {
+			return ctrl.Result{}, fmt.Errorf("cannot add finalizer to policy server: %w", err)
+		}
+	}
+
 	err := r.reconcilePolicyServerCertSecret(ctx, &policyServer)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/internal/controller/policyserver_controller_test.go
+++ b/internal/controller/policyserver_controller_test.go
@@ -282,6 +282,20 @@ var _ = Describe("PolicyServer controller", func() {
 			}
 		})
 
+		It("should add the Kubewarden finalizer during reconciliation when it is missing", func() {
+			// PolicyServers kept across a Helm uninstall/reinstall cycle have
+			// their finalizers stripped by the uninstall cleanup, and the reconciler
+			// must add them back.
+			policyServer := policiesv1.NewPolicyServerFactory().WithName(policyServerName).WithoutFinalizers().Build()
+			createPolicyServerAndWaitForItsService(ctx, policyServer)
+
+			Eventually(func() (*policiesv1.PolicyServer, error) {
+				return getTestPolicyServer(ctx, policyServerName)
+			}, timeout, pollInterval).Should(
+				HaveField("Finalizers", ContainElement(constants.KubewardenFinalizer)),
+			)
+		})
+
 		It("should create the policy server configmap with the assigned policies", func() {
 			timeoutEvalSeconds := int32(5)
 


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix https://github.com/kubewarden/adm-controller/issues/1849 (via solution B)

Breaking change new in v1.37: Kubewarden CRs will be left around after `helm uninstall`. CRDs were already left around prior to this PR.

- Add a new `controller --cleanup --deployments-namespace=<release ns> --controller-deployment-name=<controller deployment name>`
  Implement the cleanup logic run by the Helm chart `pre-delete-hook` when the Kubewarden stack is uninstalled.

  The uninstall leaves behind ONLY the Kubewarden CRDs and the user-defined PolicyServer/policy CRs, without their Kubewarden finalizers, so that:
  - nothing keeps evaluating admission requests without a controller reconciling it,
  - a future re-installation of the chart can adopt and reconcile the kept custom resources again,
  - the kept custom resources (and their CRDs) can be deleted with plain kubectl commands, without a running controller honoring finalizers.


- Fix corner case with new behavior: 
  Historically, we had a MutatingWebhookConfiguration that used a Defaulter to add a Finalizer to the PolicyServers. This is not enough if users exercise this PR feature, or they are migrating, as  PolicyServers aren't CREATEd/UPDATEd by the controller but exist prior to the installation of the controller (so the MutatingWebhook doesn't trigger). Therefore, set their Finalizer in the PolicyServer Reconciler.
  - The PolicyServer Defaulter and MutatingWebhookConfiguration was only used for adding that Finalizer. Drop it entirely now.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

Added unit tests and helm tests.
Tried some Go e2e tests, but discarded them as they were heavy:
- They take 9-11min, which runs over the default timeout of 10mins
- I needed to increase inotify max_user_instances and max_user_watches, to run the e2e tests + 1 unrelated cluster in my machine

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
