### PR TITLE
ci(sigstore): Revert sigstore/scaffolding to v0.7.33

### DIFF
--- a/.github/actions/setup-sigstore-env/action.yaml
+++ b/.github/actions/setup-sigstore-env/action.yaml
@@ -7,7 +7,13 @@ runs:
   using: "composite"
   steps:
     - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-    - uses: sigstore/scaffolding/actions/setup@5444af42e303f5ceb37e077637f953133a4eba7c # v0.7.37
+    - uses: sigstore/scaffolding/actions/setup@8bd68672d418e5bd1b0ee1f2e2981874c3a30967 # v0.7.33
+      with:
+        # Pin the release installed by the action. Without this it defaults to
+        # "latest-release" (currently v0.7.37), which dropped release-rekor.yaml
+        # in favor of release-rekor-tiles.yaml and breaks the setup script
+        # ("Secret ... illegal base64 data").
+        version: "v0.7.33"
     - name: Initialize cosign to use local Sigstore instance
       shell: bash
       run: |


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Explorative commit, 0.7.37 seems to break the job. See: https://github.com/kubewarden/adm-controller/pull/1886

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

Ci. Ensure that label `ci-rust` is set, after each push!

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
