### PR TITLE
ci(helm): Fix helm install for Helm 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,6 +421,9 @@ jobs:
           persist-credentials: false
       - name: Install helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          # helm --verify=false flag only exists on Helm >= 4
+          version: v4.2.3
       # Disable plugin verification until the following issue is addressed https://github.com/helm-unittest/helm-unittest/issues/777
       - name: Install Helm-unittest
         run: helm plugin install https://github.com/helm-unittest/helm-unittest --verify=false

--- a/.github/workflows/open-release-pr.yml
+++ b/.github/workflows/open-release-pr.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Install helm
         # Helm and helm plugins installation required by the updatecli release action
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          # helm --verify=false flag only exists on Helm >= 4
+          version: v4.2.3
 
       - name: Install helm values schema json plugin
         # Disable plugin verification until helm v4 is supported


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Helm 3 doesn't support `--verify=false`, and depending on the GHA, they download either Helm 3 or 4.

Add a fallback until each GHA goes with Helm 4.
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

Using `with.version: 4.13.4` or similar, and add a lot of annotations and specific renovatebot for renovatebot to bump that. Felt too much, this is good for now.

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
