### PR TITLE
chore(crates): missing version update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3675,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.37.0-alpha"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4935,7 +4935,7 @@ dependencies = [
 
 [[package]]
 name = "policy-server"
-version = "1.37.0-alpha"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/kwctl/Cargo.toml
+++ b/crates/kwctl/Cargo.toml
@@ -3,7 +3,7 @@ authors     = ["Kubewarden Developers <cncf-kubewarden-maintainers@lists.cncf.io
 description = "Tool to manage Kubewarden policies"
 edition     = "2024"
 name        = "kwctl"
-version     = "1.37.0-alpha"
+version     = "1.37.0-rc.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/policy-server/Cargo.toml
+++ b/crates/policy-server/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 edition = "2024"
 name = "policy-server"
-version = "1.37.0-alpha"
+version = "1.37.0-rc.1"
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
## Description

The Cargo.toml files has the out of date version. To allow the release the versions must be update to v1.37.0-rc.1.
