### PR TITLE
test(helm): Parametrize asserts to not depend on chart name

### DIFF
--- a/charts/admission-controller/tests/pre_delete_hook_test.yaml
+++ b/charts/admission-controller/tests/pre_delete_hook_test.yaml
@@ -6,6 +6,8 @@ release:
   namespace: kubewarden
 tests:
   - it: "should render a pre-delete Job that can be retried on failure"
+    set:
+      fullnameOverride: kubewarden-admission-controller
     asserts:
       - hasDocuments:
           count: 1
@@ -29,6 +31,7 @@ tests:
 
   - it: "should run the controller image in cleanup mode"
     set:
+      fullnameOverride: kubewarden-admission-controller
       image:
         repository: "kubewarden/kubewarden-controller"
         tag: v99.0.0
@@ -56,10 +59,13 @@ tests:
       global:
         cattle:
           systemDefaultRegistry: "registry.example.com"
+      image:
+        repository: "kubewarden/kubewarden-controller"
+        tag: v99.0.0
     asserts:
-      - matchRegex:
+      - equal:
           path: spec.template.spec.containers[0].image
-          pattern: ^registry.example.com/
+          value: registry.example.com/kubewarden/kubewarden-controller:v99.0.0
 
   - it: "should apply the configured security contexts and resources"
     asserts:


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Set `fullnameOverride`, `image.repository`, `image.tag` on test cases instead of relying on the chart's default values which may differ in downstream charts.


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [x] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
