### PR TITLE
feat(ci): Check questions.yaml is in sync with values.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,8 +176,12 @@ manifests: ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefin
 generate-chart: ## Generate Helm chart values schema.
 	$(HELM_SCHEMA) --values charts/admission-controller/values.yaml --output charts/admission-controller/values.schema.json
 
+.PHONY: check-questions
+check-questions: ## Check that questions.yaml is in sync with values.yaml.
+	go run ./hack/check-questions
+
 .PHONY: check-generate
-check-generate: generate
+check-generate: generate check-questions
 	@./hack/check-for-auto-generated-changes.sh
 
 ##@ Dependencies

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ check-questions: ## Check that questions.yaml is in sync with values.yaml.
 	go run ./hack/check-questions
 
 .PHONY: check-generate
-check-generate: generate check-questions
+check-generate: check-questions generate
 	@./hack/check-for-auto-generated-changes.sh
 
 ##@ Dependencies

--- a/charts/admission-controller/questions.yaml
+++ b/charts/admission-controller/questions.yaml
@@ -249,7 +249,7 @@ questions:
     group: "Default PolicyServer"
   - variable: "policyServer.image.tag"
     type: string
-    default: "v1.36.0"
+    default: "v1.37.0"
     show_if: policyServer.enabled=true
     label: PolicyServer image tag
     description: |

--- a/charts/admission-controller/questions.yaml
+++ b/charts/admission-controller/questions.yaml
@@ -4,7 +4,7 @@ questions:
   # Audit checks:
   - variable: "auditScanner.enable"
     type: boolean
-    default: false
+    default: true
     required: true
     label: Enable Background Audit check
     description: |
@@ -52,7 +52,7 @@ questions:
       Audit checks
     group: "Audit checks"
   - variable: "auditScanner.skipAdditionalNamespaces"
-    type: array[
+    type: array[string]
     show_if: auditScanner.enable=true
     label: Additional namespaces to skip from audit
     description: |
@@ -305,7 +305,7 @@ questions:
       allowed, but not from "protect" to "monitor".
     group: "Recommended Policies"
   - variable: "recommendedPolicies.skipAdditionalNamespaces"
-    type: array[
+    type: array[string]
     show_if: recommendedPolicies.enabled=true
     label: Additional namespaces to skip from evaluation
     description: |
@@ -331,14 +331,14 @@ questions:
     group: "drop-capabilities policy settings"
     label: Allowed capabilities
     required: false
-    type: array[
+    type: array[string]
   - variable: recommendedPolicies.capabilitiesPolicy.settings.required_drop_capabilities
     description: The capabilities which must be dropped from containers.
     tooltip: Specified as the capability name in ALL_CAPS. (e.g. `NET_ADMIN`)
     group: "drop-capabilities policy settings"
     label: Required drop capabilities
     required: false
-    type: array[
+    type: array[string]
   - variable: recommendedPolicies.capabilitiesPolicy.settings.default_add_capabilities
     description: >-
       The capabilities which are added to containers by default, in addition to
@@ -347,7 +347,7 @@ questions:
     group: "drop-capabilities policy settings"
     label: Default add capabilities
     required: false
-    type: array[
+    type: array[string]
   # host namespace policy settings
   - variable: recommendedPolicies.hostNamespacePolicy.settings.allow_host_ipc
     tooltip: Allows the pod to set .spec.HostIPC to true.

--- a/hack/check-questions/main.go
+++ b/hack/check-questions/main.go
@@ -1,0 +1,201 @@
+// check-questions validates that charts/admission-controller/questions.yaml
+// is in sync with charts/admission-controller/values.yaml.
+//
+// It checks that:
+//   - every question (and subquestion) variable path exists in values.yaml
+//   - every question default matches the value in values.yaml
+//   - every question type is a valid Rancher questions type
+//   - every variable referenced in a show_if expression exists in
+//     values.yaml or is defined as another question's variable
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	questionsFile = "charts/admission-controller/questions.yaml"
+	valuesFile    = "charts/admission-controller/values.yaml"
+)
+
+type question struct {
+	Variable     string     `yaml:"variable"`
+	Type         string     `yaml:"type"`
+	Default      any        `yaml:"default"`
+	ShowIf       string     `yaml:"show_if"`
+	Subquestions []question `yaml:"subquestions"`
+}
+
+type questionsDoc struct {
+	Questions []question `yaml:"questions"`
+}
+
+func validType(t string) bool {
+	if t == "" {
+		// Rancher defaults to string
+		return true
+	}
+	switch t {
+	case "string", "multiline", "boolean", "int", "integer", "float",
+		"password", "enum", "questions", "secret", "storageclass",
+		"hostname", "pvc", "cert", "date":
+		return true
+	}
+	containerTypeRe := regexp.MustCompile(`^(array|map)\[[a-z]*\]$`)
+	return containerTypeRe.MatchString(t)
+}
+
+// allowedMissingKey reports whether a variable path is allowed to be
+// absent from values.yaml: such keys are commented out there (optional
+// settings), and the question's default only serves as a Rancher UI
+// prefill.
+func allowedMissingKey(variable string) bool {
+	switch variable {
+	case "global.priorityClassName",
+		"telemetry.sidecar.tracing.jaeger.endpoint",
+		"telemetry.sidecar.tracing.jaeger.tls.insecure":
+		return true
+	}
+	return false
+}
+
+// lookup resolves a dotted path in a decoded YAML tree.
+func lookup(values map[string]any, path string) (any, bool) {
+	var current any = values
+	for _, part := range strings.Split(path, ".") {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = m[part]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+// normalize renders a scalar value in a canonical string form so that
+// defaults from questions.yaml can be compared with values.yaml values.
+func normalize(v any) (string, bool) {
+	switch x := v.(type) {
+	case nil:
+		return "", true
+	case string:
+		return x, true
+	case bool:
+		return strconv.FormatBool(x), true
+	case int:
+		return strconv.FormatFloat(float64(x), 'f', -1, 64), true
+	case int64:
+		return strconv.FormatFloat(float64(x), 'f', -1, 64), true
+	case float64:
+		return strconv.FormatFloat(x, 'f', -1, 64), true
+	default:
+		return "", false // maps, arrays: not compared
+	}
+}
+
+// flatten returns all questions and subquestions as a single list, plus
+// the set of variable names defined by them.
+func flatten(qs []question) ([]question, map[string]bool) {
+	knownVariables := map[string]bool{}
+	var all []question
+	var collect func([]question)
+	collect = func(qs []question) {
+		for _, q := range qs {
+			knownVariables[q.Variable] = true
+			all = append(all, q)
+			collect(q.Subquestions)
+		}
+	}
+	collect(qs)
+	return all, knownVariables
+}
+
+// checkQuestion validates a single question against values.yaml and
+// returns the list of problems found.
+func checkQuestion(q question, values map[string]any, knownVariables map[string]bool) []string {
+	var errs []string
+
+	val, found := lookup(values, q.Variable)
+	if !found && !allowedMissingKey(q.Variable) {
+		errs = append(errs, fmt.Sprintf("%s: variable not found in %s", q.Variable, valuesFile))
+	}
+
+	if !validType(q.Type) {
+		errs = append(errs, fmt.Sprintf("%s: invalid Rancher question type %q", q.Variable, q.Type))
+	}
+
+	if q.Default != nil && found {
+		defStr, defOK := normalize(q.Default)
+		valStr, valOK := normalize(val)
+		if defOK && valOK && defStr != valStr {
+			errs = append(errs, fmt.Sprintf("%s: default %q does not match values.yaml value %q",
+				q.Variable, defStr, valStr))
+		}
+	}
+
+	showIfVarRe := regexp.MustCompile(`([A-Za-z0-9_.]+)\s*(=|!=)`)
+	for _, m := range showIfVarRe.FindAllStringSubmatch(q.ShowIf, -1) {
+		ref := m[1]
+		if knownVariables[ref] {
+			continue
+		}
+		if _, ok := lookup(values, ref); !ok {
+			errs = append(errs, fmt.Sprintf("%s: show_if references unknown variable %q", q.Variable, ref))
+		}
+	}
+
+	return errs
+}
+
+func run() error {
+	values := map[string]any{}
+	if err := unmarshalFile(valuesFile, &values); err != nil {
+		return err
+	}
+	var doc questionsDoc
+	if err := unmarshalFile(questionsFile, &doc); err != nil {
+		return err
+	}
+
+	all, knownVariables := flatten(doc.Questions)
+
+	var errs []string
+	for _, q := range all {
+		errs = append(errs, checkQuestion(q, values, knownVariables)...)
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%s is out of sync with %s:\n  - %s",
+			questionsFile, valuesFile, strings.Join(errs, "\n  - "))
+	}
+	fmt.Fprintf(os.Stdout, "%s is in sync with %s (%d questions checked)\n",
+		questionsFile, valuesFile, len(all))
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func unmarshalFile(path string, out any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+	if err = yaml.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/adm-controller/issues/1923

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

Add new `check-questions` target to `make check-generate`.
This new target calls `hack/check-questions/main.go`, which compares the
questions.yaml and the values.yaml for:
- every question (and subquestion) variable path exists in values.yaml
- every question default matches the value in values.yaml
- every question type is a valid Rancher questions type
- every variable referenced in a show_if expression exists in
  values.yaml or is defined as another question's variable

Assisted-by: Claude Fable 5


## Test

<!-- Please provides a short description about how to test your pullrequest -->

CI
<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

This approach works for feature branches or downstream forks.


### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
